### PR TITLE
Allow banning of EoS on koboldcpp

### DIFF
--- a/mikupad.html
+++ b/mikupad.html
@@ -1758,9 +1758,8 @@ export function App() {
 						</div>
 					`}
 				`}
-				${html`
-					<${Checkbox} label="Ignore <eos>"
-						disabled=${!!cancel} value=${ignoreEos} onValueChange=${setIgnoreEos}/>`}
+				<${Checkbox} label="Ignore <eos>"
+					disabled=${!!cancel} value=${ignoreEos} onValueChange=${setIgnoreEos}/>
 			</${CollapsibleGroup}>
 			${!!tokens && html`
 				<${InputBox} label="Tokens" value=${tokens} readOnly/>`}

--- a/mikupad.html
+++ b/mikupad.html
@@ -1758,7 +1758,7 @@ export function App() {
 						</div>
 					`}
 				`}
-				${endpointAPI != 2 && html`
+				${html`
 					<${Checkbox} label="Ignore <eos>"
 						disabled=${!!cancel} value=${ignoreEos} onValueChange=${setIgnoreEos}/>`}
 			</${CollapsibleGroup}>

--- a/mikupad.html
+++ b/mikupad.html
@@ -1333,7 +1333,7 @@ export function App() {
 					typical_p: typicalP,
 					tfs_z: tfsZ,
 				}),
-				ignore_eos: ignoreEos,
+    				...(endpointAPI == 2 ? { use_default_badwordsids: ignoreEos } : { ignore_eos: ignoreEos }),
 				n_predict: maxPredictTokens,
 				n_probs: 10,
 				signal: ac.signal,


### PR DESCRIPTION
Quick fix for koboldcpp EoS ban. Just swapped ignore_eos for the koboldcpp equivalent if koboldcpp is selected.