### PR TITLE
Feature/persistent context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 package-lock.json
 project/mikupad.html
 mikupad_compiled.html
-koboldcpp.exe
-.gitignore
-.mikupadorig.html
 
 # Logs
 logs

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ package-lock.json
 project/mikupad.html
 mikupad_compiled.html
 koboldcpp.exe
+.gitignore
+.mikupadorig.html
 
 # Logs
 logs

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 package-lock.json
 project/mikupad.html
 mikupad_compiled.html
+koboldcpp.exe
 
 # Logs
 logs

--- a/mikupad.html
+++ b/mikupad.html
@@ -125,9 +125,23 @@ body {
 	scrollbar-gutter: stable;
 	font: inherit;
 }
-html.monospace-dark #prompt-area {
-	background: var(--color-bg);
-	color: var(--color-text);
+#memory-area, #an-area {
+	flex: 1;
+	border: none;
+	outline: none;
+	resize: none;
+	background: var(--color-base-100);
+	color: var(--color-base-10);
+	padding: 0.5em;
+	scrollbar-gutter: stable;
+	font: initial;
+}
+#memory-area {
+	min-height:9.5em;
+}
+#an-area {
+	min-height:3.5em;
+                          
 }
 
 #prompt-overlay {
@@ -232,13 +246,14 @@ html.monospace-dark #sidebar {
 	gap: 4px;
 }
 
-.InputBox, .SelectBox {
+.InputBox, .SelectBox, .TextArea {
 	display: flex;
+  position: relative;
 	flex-direction: column;
 	font-size: 0.75rem;
 	padding: 0 8px;
 }
-.InputBox > input, .SelectBox > select {
+.InputBox > input, .SelectBox > select, .TextArea > textarea {
 	appearance: none;
 	border: none;
 	outline: none;
@@ -328,6 +343,13 @@ button {
 	color: inherit;
 	background: var(--color-base-30);
 	border-radius: 2px;
+}
+button.textAreaSettings {
+  all: unset;
+  width:1.25em;
+  position:absolute;
+  top:calc(1.25em + 1px);
+  right:1px;
 }
 button:hover {
 	background: var(--color-base-40);
@@ -1394,6 +1416,10 @@ const defaultPresets = {
 	mirostatEta: 0.1,
 	ignoreEos: false,
 	openaiPresets: false,
+	contextLength: 4096,
+	memoryTokens: '',
+  anTokens: '',
+  anDepth: 3
 };
 
 function joinPrompt(prompt) {
@@ -1508,13 +1534,54 @@ export function App() {
 	const [tokens, setTokens] = useState(0);
 	const [predictStartTokens, setPredictStartTokens] = useState(0);
 	const [lastError, setLastError] = useState(undefined);
+	const [contextLength, setContextLength] = useSessionState('contextLength', defaultPresets.contextLength);
+	const [memoryTokens, setMemoryTokens] = useSessionState('memoryTokens', defaultPresets.memoryTokens);
+  const [anTokens, setAnTokens] = useSessionState('anTokens', defaultPresets.anTokens);
+  const [anDepth, setAnDepth] = useSessionState('anDepth', defaultPresets.anDepth);
 
 	const promptText = useMemo(() => joinPrompt(promptChunks), [promptChunks]);
 
 	// Update theme on the first render.
 	useMemo(() => !theme || switchTheme(theme, true), []);
 
-	async function predict(prompt = promptText, chunkCount = promptChunks.length) {
+  const modifiedPrompt = useMemo(() => {
+    // define used variables
+    const tokenRatio = 3.3;
+    const additionalContext = (memoryTokens + anTokens).length; // TODO add active WI
+    const estimatedPromptLength = Math.round(
+      promptText.length - contextLength * tokenRatio + additionalContext / tokenRatio) + 1;
+    
+    // truncate prompt
+    const truncPrompt = promptText.substring(estimatedPromptLength);
+    // assemble context in order
+    const permContextPrompt = memoryTokens.concat(promptText.substring(estimatedPromptLength));
+  
+    // Find the index of the newline character three lines up from the end
+    const newlineIndex = permContextPrompt
+      .split('\n')
+      .reverse()
+      .findIndex((line, index) => index < 3 && line.trim() === '');
+
+    // Insert author's note X newlines up from the bottom
+    if (newlineIndex !== -1) {
+      const lines = permContextPrompt.split('\n');
+      lines.splice(lines.length - newlineIndex - anDepth-1, 0, anTokens);
+      return lines.join('\n');
+    }
+
+    // If no newline is found, return the original string
+    return permContextPrompt;
+  }, [contextLength, promptText, memoryTokens, anTokens, anDepth]);
+
+	// Update dark mode on the first render.
+	useMemo(() => !darkMode || switchDarkMode(darkMode, true), []);
+  
+  function viewContext(context = modifiedPrompt) {
+    console.log(context)
+    console.log(anDepth)
+  };
+  
+	async function predict(prompt = modifiedPrompt, chunkCount = promptChunks.length) {
 		if (cancel) {
 			cancel?.();
 
@@ -2095,6 +2162,46 @@ export function App() {
 				${(!openaiPresets || endpointAPI != 3) && html`
 					<${Checkbox} label="Ignore <eos>"
 						disabled=${!!cancel} value=${ignoreEos} onValueChange=${setIgnoreEos}/>`}
+			</${CollapsibleGroup}>
+      <${CollapsibleGroup} label="Persistent Context">
+        <label className="TextArea">
+          Memory
+          <textarea
+          readOnly=${!!cancel}
+          placeholder="Anything written here will be injected at the head of the prompt. Tokens here DO count towards the Context Limit."
+          defaultValue=${memoryTokens}
+          value=${memoryTokens}
+          onInput=${(e) => setMemoryTokens(e.target.value)}			
+          id="memory-area"/>
+          <button
+					className="textAreaSettings"
+					disabled=${!!cancel}
+					onClick=${() => predict()}>
+					<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="-1 -6 8 7" xmlns="http://www.w3.org/2000/svg"><path d="M0 0 3-3C3-4 3-5 5-5L4-4 5-3 6-4C6-2 5-2 4-2L1 1C0 2-1 1 0 0"></path></svg>
+          </button>
+        </label>
+        <label className="TextArea">
+          Author's Note
+          <textarea
+          readOnly=${!!cancel}
+          placeholder="Author's note"
+          defaultValue=${anTokens}
+          value=${anTokens}
+          onInput=${(e) => setAnTokens(e.target.value)}			
+          id="an-area"/>
+          <button
+					className="textAreaSettings"
+					disabled=${!!cancel}
+					onClick=${() => predict()}>
+					<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="-1 -6 8 7" xmlns="http://www.w3.org/2000/svg"><path d="M0 0 3-3C3-4 3-5 5-5L4-4 5-3 6-4C6-2 5-2 4-2L1 1C0 2-1 1 0 0"></path></svg>
+          </button>
+        </label>
+        <button
+					id="viewContext"
+					disabled=${!!cancel}
+					onClick=${() => viewContext()}>
+					Current Context
+				</button>
 			</${CollapsibleGroup}>
 			${!!tokens && html`
 				<${InputBox} label="Tokens" value=${tokens} readOnly/>`}

--- a/mikupad.html
+++ b/mikupad.html
@@ -141,7 +141,7 @@ body {
 	min-height:9.5em;
 }
 #an-area {
-	min-height:3.5em;                  
+	min-height:3.5em;
 }
 .expanded-text-area-settings {
 	margins: auto;
@@ -1474,8 +1474,8 @@ const defaultPresets = {
 	ignoreEos: false,
 	openaiPresets: false,
 	contextLength: 4096,
-	memoryTokens: '',
-	anTokens: '',
+	memoryTokens: ({ "prefix":"", "text":"", "suffix":""}),
+	anTokens: ({ "prefix":"", "text":"", "suffix":""}),
 	anDepth: 3
 };
 
@@ -1593,7 +1593,7 @@ export function App() {
 	const [lastError, setLastError] = useState(undefined);
 	const [contextLength, setContextLength] = useSessionState('contextLength', defaultPresets.contextLength);
 	const [memoryTokens, setMemoryTokens] = useSessionState('memoryTokens', defaultPresets.memoryTokens);
-	
+
 	const [anTokens, setAnTokens] = useSessionState('anTokens', defaultPresets.anTokens);
 	const [anDepth, setAnDepth] = useSessionState('anDepth', defaultPresets.anDepth);
 	const handleAnDepthChange = (value) => {
@@ -1605,7 +1605,16 @@ export function App() {
 				setAnDepth(0);
 		}
 	};
-	
+
+	function handleAnTokensChange(key,value) {
+		setAnTokens((prevAnTokens) => ({ ...prevAnTokens, [key]: value }));
+	}
+	function handleMemoryTokensChange(key,value) {
+		setMemoryTokens((prevMemoryTokens) => ({ ...prevMemoryTokens, [key]: value }));
+	}
+
+
+
 	const [modalState, setModalState] = useState({});
 	const toggleModal = (modalKey) => {
 		setModalState((prevState) => ({
@@ -1614,30 +1623,40 @@ export function App() {
 		}));
 	};
 	const closeModal = (modalKey) => {
-	setModalState((prevState) => ({
-		...prevState,
-		[modalKey]: false,
-	}));
-};
-	
+		setModalState((prevState) => ({
+			...prevState,
+			[modalKey]: false,
+		}));
+	};
+
 	const promptText = useMemo(() => joinPrompt(promptChunks), [promptChunks]);
 
 	// Update theme on the first render.
 	useMemo(() => !theme || switchTheme(theme, true), []);
-	
+
 
 	const modifiedPrompt = useMemo(() => {
-		// define used variables
+		// assemble individual contexts if text not empty
+		const order = ["prefix","text","suffix"]
+		const assMemory = memoryTokens.text && memoryTokens.text !== ""
+	    ? order.map(key => memoryTokens[key]).join("").replace(/\\n/g,'\n')
+	    : "";
+		const assAn = anTokens.text && anTokens.text !== ""
+	    ? order.map(key => anTokens[key]).join("").replace(/\\n/g,'\n')
+	    : "";
+
+		// prompt length estimation
 		const tokenRatio = 3.3;
-		const additionalContext = (memoryTokens + anTokens).length; // TODO add active WI
+		const additionalContext = (assMemory + assAn).length; // TODO add active WI
 		const estimatedPromptLength = Math.round(
 			promptText.length - contextLength * tokenRatio + additionalContext / tokenRatio) + 1;
-		
+
 		// truncate prompt
 		const truncPrompt = promptText.substring(estimatedPromptLength);
+
 		// assemble context in order
-		const permContextPrompt = memoryTokens.concat(promptText.substring(estimatedPromptLength));
-	
+		const permContextPrompt = assMemory.concat(promptText.substring(estimatedPromptLength));
+
 		// make injection depth valid
 		const truncPromptLen = truncPrompt.split('\n').length;
 		const injDepth = truncPromptLen >= anDepth ? anDepth : truncPromptLen
@@ -1646,7 +1665,7 @@ export function App() {
 		if (anTokens !== '') {
 			const lines = permContextPrompt.match(/.*\n?/g);
 			const injIndex = lines.length-injDepth-1
-			lines.splice(injIndex,0,anTokens)
+			lines.splice(injIndex,0,assAn)
 			return lines.join('');
 		}
 
@@ -1656,12 +1675,9 @@ export function App() {
 
 	// Update dark mode on the first render.
 	useMemo(() => !darkMode || switchDarkMode(darkMode, true), []);
-	
-	function viewContext(context = modifiedPrompt) {
-		console.log(context)
-	};
-	
-	
+
+
+
 	async function predict(prompt = modifiedPrompt, chunkCount = promptChunks.length) {
 		if (cancel) {
 			cancel?.();
@@ -2252,15 +2268,15 @@ export function App() {
 					<textarea
 					readOnly=${!!cancel}
 					placeholder="Anything written here will be injected at the head of the prompt. Tokens here DO count towards the Context Limit."
-					defaultValue=${memoryTokens}
-					value=${memoryTokens}
-					onInput=${(e) => setMemoryTokens(e.target.value)}			
+					defaultValue=${memoryTokens.text}
+					value=${memoryTokens.text}
+					onInput=${(e) => handleMemoryTokensChange("text", e.target.value) }
 					id="memory-area"/>
 					<button
 					className="textAreaSettings"
 					disabled=${!!cancel}
 					onClick=${() => toggleModal("memory")}>
-					
+
 					<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="-1 -5 8 7" xmlns="http://www.w3.org/2000/svg"><path d="M0 0 3-3C3-4 3-5 5-5L4-4 5-3 6-4C6-2 5-2 4-2L1 1C0 2-1 1 0 0"></path></svg>
 					</button>
 				</label>
@@ -2269,9 +2285,9 @@ export function App() {
 					<textarea
 					readOnly=${!!cancel}
 					placeholder="Anything written here will be injected ${anDepth} newlines into context."
-					defaultValue=${anTokens}
-					value=${anTokens}
-					onInput=${(e) => setAnTokens(e.target.value)}			
+					defaultValue=${anTokens.text}
+					value=${anTokens.text}
+					onInput=${(e) => handleAnTokensChange("text", e.target.value) }
 					id="an-area"/>
 					<button
 					className="textAreaSettings"
@@ -2319,42 +2335,63 @@ export function App() {
 		</div>
 		<${Modal} isOpen=${modalState.memory} onClose=${() => closeModal("memory")}>
 			<h2>Memory</h2>
-			<p>This text will be added at the very top of your context.</p>
+			<p class="modal-description">
+				This text will be added at the very top of your context.<br/>
+				Prefix and suffix will be attached at the beginning or end of your memory respectively. \n for newlines.
+			</p>
+			<div className="hbox">
+				<${InputBox} label="Prefix" type="text" placeholder="[INST]"
+					readOnly=${!!cancel} value=${memoryTokens.prefix} onValueChange=${(value) => handleMemoryTokensChange("prefix", value)}/>
+				<${InputBox} label="Suffix" type="text" placeholder="[/INST]"
+					readOnly=${!!cancel} value=${memoryTokens.suffix} onValueChange=${(value) => handleMemoryTokensChange("suffix", value)}/>
+			</div>
 			<textarea
-			readOnly=${!!cancel}
-			placeholder="Anything written here will be injected at the head of the prompt. Tokens here DO count towards the Context Limit."
-			defaultValue=${memoryTokens}
-			value=${memoryTokens}
-			onInput=${(e) => setMemoryTokens(e.target.value)}
-			class="expanded-text-area-settings"
-			id="memory-area-settings"/>
+				readOnly=${!!cancel}
+				placeholder="Anything written here will be injected at the head of the prompt. Tokens here DO count towards the Context Limit."
+				defaultValue=${memoryTokens.text}
+				value=${memoryTokens.text}
+				onInput=${(e) => handleMemoryTokensChange("text", e.target.value) }
+				class="expanded-text-area-settings"
+				id="memory-area-settings"/>
 		</${Modal}>
 
-			<${Modal} isOpen=${modalState.an} onClose=${() => closeModal("an")}>
-				<h2>Author's Note</h2>
-				<p>This text will be injected N non-empty newlines deep into your recent context.</p>
+		<${Modal} isOpen=${modalState.an} onClose=${() => closeModal("an")}>
+			<h2>Author's Note</h2>
+			<p class="modal-description">
+				This text will be injected N newlines deep into your recent context.<br/>
+				Prefix and suffix will be attached at the beginning or end of your Author's Note respectively. \n for newlines.
+			</p>
+			<div className="hbox">
+				<${InputBox} label="Prefix" type="text" placeholder="[INST]"
+					readOnly=${!!cancel} value=${anTokens.prefix} onValueChange=${(value) => handleAnTokensChange("prefix", value)}/>
+				<${InputBox} label="Suffix" type="text" placeholder="[/INST]"
+					readOnly=${!!cancel} value=${anTokens.suffix} onValueChange=${(value) => handleAnTokensChange("suffix", value)}/>
 				<${InputBox} label="AN Injection Depth (0-N)" type="number" step="1"
 					readOnly=${!!cancel} value=${anDepth} onValueChange=${handleAnDepthChange}/>
-				<textarea
-				readOnly=${!!cancel}
-				placeholder="Anything written here will be injected ${anDepth} newlines into context."
-				defaultValue=${anTokens}
-				value=${anTokens}
-				onInput=${(e) => setAnTokens(e.target.value)}
-				class="expanded-text-area-settings"
-				id="expanded-an-settings"/>
-			</${Modal}>
-			
-			<${Modal} isOpen=${modalState.context} onClose=${() => closeModal("context")}>
-				<h2>Context</h2>
-				<p>This is the prompt being sent to your large language model.</p>
-				<textarea
-				readOnly=${!!cancel}
-				value=${modifiedPrompt}
-				class="expanded-text-area-settings"
-				id="context-area-settings" readOnly/>
-				</${Modal}>
-		`;
+			</div>
+
+			<textarea
+			readOnly=${!!cancel}
+			placeholder="Anything written here will be injected ${anDepth} newlines into context."
+			defaultValue=${anTokens.text}
+			value=${anTokens.text}
+			onInput=${(e) => handleAnTokensChange("text", e.target.value) }
+			class="expanded-text-area-settings"
+			id="expanded-an-settings"/>
+		</${Modal}>
+
+		<${Modal} isOpen=${modalState.context} onClose=${() => closeModal("context")}>
+			<h2>Context</h2>
+			<p class="modal-description">
+				This is the prompt being sent to your large language model.
+			</p>
+			<textarea
+			readOnly=${!!cancel}
+			value=${modifiedPrompt}
+			class="expanded-text-area-settings"
+			id="context-area-settings" readOnly/>
+		</${Modal}>
+	`;
 }
 
 createRoot(document.body).render(html`<${App}/>`);

--- a/mikupad.html
+++ b/mikupad.html
@@ -383,7 +383,7 @@ html.monospace-dark .InputBox > input:read-only {
 	transform: translate(0, -45%);
 }
 .tooltip:hover .tooltiptext {
-		opacity: 1;
+	opacity: 1;
 }
 
 .error-text {

--- a/mikupad.html
+++ b/mikupad.html
@@ -216,6 +216,32 @@ html.monospace-dark #probs {
 	font-size: 0.8rem;
 }
 
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5); /* Dimmed background color */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.modal-container {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal {
+  background: white;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
+}
+
 #sidebar {
 	font-family: inherit;
 	width: 250px;
@@ -1043,6 +1069,22 @@ function CollapsibleGroup({ label, expanded, children }) {
 		</div>`;
 }
 
+  function Modal({ isOpen, onClose, children, ...props }) {
+    if (!isOpen) {
+      return null;
+    }
+
+    return html`
+    <div className="modal-overlay" onClick=${onClose}>
+      <div className="modal-container">
+        <div className="modal" onClick=${(e) => e.stopPropagation()} ...${props}>
+          ${children}
+        </div>
+      </div>
+    </div>
+    `;
+  }
+
 function Sessions({ sessionStorage, onSessionChange, disabled }) {
 	const [version, setVersion] = useState(0);
 	const [newSessionName, setNewSessionName] = useState('');
@@ -1538,11 +1580,27 @@ export function App() {
 	const [memoryTokens, setMemoryTokens] = useSessionState('memoryTokens', defaultPresets.memoryTokens);
   const [anTokens, setAnTokens] = useSessionState('anTokens', defaultPresets.anTokens);
   const [anDepth, setAnDepth] = useSessionState('anDepth', defaultPresets.anDepth);
-
+  
+  const [modalState, setModalState] = useState({});
+  
+  const toggleModal = (modalKey) => {
+    setModalState((prevState) => ({
+      ...prevState,
+      [modalKey]: !prevState[modalKey],
+    }));
+  };
+  const closeModal = (modalKey) => {
+  setModalState((prevState) => ({
+    ...prevState,
+    [modalKey]: false,
+  }));
+};
+  
 	const promptText = useMemo(() => joinPrompt(promptChunks), [promptChunks]);
 
 	// Update theme on the first render.
 	useMemo(() => !theme || switchTheme(theme, true), []);
+  
 
   const modifiedPrompt = useMemo(() => {
     // define used variables
@@ -1578,8 +1636,8 @@ export function App() {
   
   function viewContext(context = modifiedPrompt) {
     console.log(context)
-    console.log(anDepth)
   };
+  
   
 	async function predict(prompt = modifiedPrompt, chunkCount = promptChunks.length) {
 		if (cancel) {
@@ -2176,7 +2234,8 @@ export function App() {
           <button
 					className="textAreaSettings"
 					disabled=${!!cancel}
-					onClick=${() => predict()}>
+					onClick=${() => toggleModal("memory")}>
+          
 					<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="-1 -6 8 7" xmlns="http://www.w3.org/2000/svg"><path d="M0 0 3-3C3-4 3-5 5-5L4-4 5-3 6-4C6-2 5-2 4-2L1 1C0 2-1 1 0 0"></path></svg>
           </button>
         </label>
@@ -2192,7 +2251,7 @@ export function App() {
           <button
 					className="textAreaSettings"
 					disabled=${!!cancel}
-					onClick=${() => predict()}>
+					onClick=${() => toggleModal("an")}>
 					<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="-1 -6 8 7" xmlns="http://www.w3.org/2000/svg"><path d="M0 0 3-3C3-4 3-5 5-5L4-4 5-3 6-4C6-2 5-2 4-2L1 1C0 2-1 1 0 0"></path></svg>
           </button>
         </label>
@@ -2200,7 +2259,7 @@ export function App() {
 					id="viewContext"
 					disabled=${!!cancel}
 					onClick=${() => viewContext()}>
-					Current Context
+					Print Context to Console
 				</button>
 			</${CollapsibleGroup}>
 			${!!tokens && html`
@@ -2232,7 +2291,17 @@ export function App() {
 			</div>
 			${!!lastError && html`
 				<span className="error-text">${lastError}</span>`}
-		</div>`;
+		</div>
+    <${Modal} isOpen=${modalState.memory} onClose=${() => closeModal("memory")}>
+        <p>This is the content of Modal 1!</p>
+        <Button label="Close Modal" onClick=${() => closeModal("memory")} />
+      </${Modal}>
+
+      <${Modal} isOpen=${modalState.an} onClose=${() => closeModal("an")}>
+        <p>This is the content of Modal 2!</p>
+        <Button label="Close Modal" onClick=${() => closeModal("an")} />
+      </${Modal}>
+    `;
 }
 
 createRoot(document.body).render(html`<${App}/>`);

--- a/mikupad.html
+++ b/mikupad.html
@@ -144,7 +144,7 @@ body {
 	min-height:3.5em;
 }
 .expanded-text-area-settings {
-	margins: auto;
+	margin: 8px 0 8px 0;
 	width:100%;
 	box-sizing: border-box;
 	height:25.5em;

--- a/mikupad.html
+++ b/mikupad.html
@@ -1,14 +1,14 @@
 <!doctype html>
 <meta charset="utf-8">
 <!-- mikupad by Anon
-  --
-  -- To the extent possible under law, the person who associated CC0 with
-  -- mikupad has waived all copyright and related or neighboring rights
-  -- to mikupad.
-  --
-  -- You should have received a copy of the CC0 legalcode along with this
-  -- work.  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-  -->
+	--
+	-- To the extent possible under law, the person who associated CC0 with
+	-- mikupad has waived all copyright and related or neighboring rights
+	-- to mikupad.
+	--
+	-- You should have received a copy of the CC0 legalcode along with this
+	-- work.  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+	-->
 <title>mikupad</title>
 <script type="importmap">
 {
@@ -68,8 +68,8 @@ html.serif-dark {
 }
 
 html.monospace-dark {
-    ---color-bg-dark: #282833;
-    --color-bg: #202020;
+		---color-bg-dark: #282833;
+		--color-bg: #202020;
 	--color-text: #bababa;
 	--color-base-0: oklch(77.65% 0.0752 285.22);
 	--color-base-10: color-mix(in oklch, var(--color-base-100) 90%, var(--color-base-0));
@@ -135,7 +135,7 @@ body {
 	padding: 0.5em;
 	scrollbar-gutter: stable;
 	font: initial;
-  border-radius: 2px;
+	border-radius: 2px;
 }
 #memory-area {
 	min-height:9.5em;
@@ -144,10 +144,10 @@ body {
 	min-height:3.5em;                  
 }
 .expanded-text-area-settings {
-  margins: auto;
+	margins: auto;
 	width:100%;
-  box-sizing: border-box;
-  height:25.5em;
+	box-sizing: border-box;
+	height:25.5em;
 }
 
 #prompt-overlay {
@@ -223,33 +223,33 @@ html.monospace-dark #probs {
 }
 
 .modal-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.5);
-  display: flex;
-  align-items: center;
-  justify-content: center;
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	background: rgba(0, 0, 0, 0.5);
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 .modal-container {
-  width: 100%;
-  height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+	width: 100%;
+	height: 100%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
 .modal {
-  background: var(--color-base-50);
-  width:75%;
-  height:fit-content;
-  padding: 1em;
-  border-radius: 2px;
+	background: var(--color-base-50);
+	width:75%;
+	height:fit-content;
+	padding: 1em;
+	border-radius: 2px;
 }
 .button-modal-bottom {
-  float:right;
+	float:right;
 }
 
 #sidebar {
@@ -284,7 +284,7 @@ html.monospace-dark #sidebar {
 
 .InputBox, .SelectBox, .TextArea {
 	display: flex;
-  position: relative;
+	position: relative;
 	flex-direction: column;
 	font-size: 0.75rem;
 	padding: 0 8px;
@@ -356,7 +356,7 @@ html.monospace-dark .InputBox > input:read-only {
 	transform: translate(0, -45%);
 }
 .tooltip:hover .tooltiptext {
-    opacity: 1;
+		opacity: 1;
 }
 
 .error-text {
@@ -381,11 +381,11 @@ button {
 	border-radius: 2px;
 }
 button.textAreaSettings {
-  all: unset;
-  width:1.25em;
-  position:absolute;
-  top:calc(1.25em + 1px);
-  right:1px;
+	all: unset;
+	width:1.25em;
+	position:absolute;
+	top:calc(1.25em + 1px);
+	right:1px;
 }
 button:hover {
 	background: var(--color-base-40);
@@ -1079,26 +1079,26 @@ function CollapsibleGroup({ label, expanded, children }) {
 		</div>`;
 }
 
-  function Modal({ isOpen, onClose, children, ...props }) {
-    if (!isOpen) {
-      return null;
-    }
+	function Modal({ isOpen, onClose, children, ...props }) {
+		if (!isOpen) {
+			return null;
+		}
 
-    return html`
-    <div className="modal-overlay" onClick=${onClose}>
-      <div className="modal-container">
-        <div className="modal" onClick=${(e) => e.stopPropagation()} ...${props}>
-          ${children}
-          <button
-          class="button-modal-bottom"
+		return html`
+		<div className="modal-overlay" onClick=${onClose}>
+			<div className="modal-container">
+				<div className="modal" onClick=${(e) => e.stopPropagation()} ...${props}>
+					${children}
+					<button
+					class="button-modal-bottom"
 					onClick=${onClose}>
-            Close
-          </button>
-        </div>
-      </div>
-    </div>
-    `;
-  }
+						Close
+					</button>
+				</div>
+			</div>
+		</div>
+		`;
+	}
 
 function Sessions({ sessionStorage, onSessionChange, disabled }) {
 	const [version, setVersion] = useState(0);
@@ -1475,8 +1475,8 @@ const defaultPresets = {
 	openaiPresets: false,
 	contextLength: 4096,
 	memoryTokens: '',
-  anTokens: '',
-  anDepth: 3
+	anTokens: '',
+	anDepth: 3
 };
 
 function joinPrompt(prompt) {
@@ -1484,16 +1484,16 @@ function joinPrompt(prompt) {
 }
 
 function replaceUnprintableBytes(inputString) {
-  // Define a regular expression to match unprintable bytes
-  const unprintableBytesRegex = /[\0-\x1F\x7F-\x9F\xAD\u0378\u0379\u037F-\u0383\u038B\u038D\u03A2\u0528-\u0530\u0557\u0558\u0560\u0588\u058B-\u058E\u0590\u05C8-\u05CF\u05EB-\u05EF\u05F5-\u0605\u061C\u061D\u06DD\u070E\u070F\u074B\u074C\u07B2-\u07BF\u07FB-\u07FF\u082E\u082F\u083F\u085C\u085D\u085F-\u089F\u08A1\u08AD-\u08E3\u08FF\u0978\u0980\u0984\u098D\u098E\u0991\u0992\u09A9\u09B1\u09B3-\u09B5\u09BA\u09BB\u09C5\u09C6\u09C9\u09CA\u09CF-\u09D6\u09D8-\u09DB\u09DE\u09E4\u09E5\u09FC-\u0A00\u0A04\u0A0B-\u0A0E\u0A11\u0A12\u0A29\u0A31\u0A34\u0A37\u0A3A\u0A3B\u0A3D\u0A43-\u0A46\u0A49\u0A4A\u0A4E-\u0A50\u0A52-\u0A58\u0A5D\u0A5F-\u0A65\u0A76-\u0A80\u0A84\u0A8E\u0A92\u0AA9\u0AB1\u0AB4\u0ABA\u0ABB\u0AC6\u0ACA\u0ACE\u0ACF\u0AD1-\u0ADF\u0AE4\u0AE5\u0AF2-\u0B00\u0B04\u0B0D\u0B0E\u0B11\u0B12\u0B29\u0B31\u0B34\u0B3A\u0B3B\u0B45\u0B46\u0B49\u0B4A\u0B4E-\u0B55\u0B58-\u0B5B\u0B5E\u0B64\u0B65\u0B78-\u0B81\u0B84\u0B8B-\u0B8D\u0B91\u0B96-\u0B98\u0B9B\u0B9D\u0BA0-\u0BA2\u0BA5-\u0BA7\u0BAB-\u0BAD\u0BBA-\u0BBD\u0BC3-\u0BC5\u0BC9\u0BCE\u0BCF\u0BD1-\u0BD6\u0BD8-\u0BE5\u0BFB-\u0C00\u0C04\u0C0D\u0C11\u0C29\u0C34\u0C3A-\u0C3C\u0C45\u0C49\u0C4E-\u0C54\u0C57\u0C5A-\u0C5F\u0C64\u0C65\u0C70-\u0C77\u0C80\u0C81\u0C84\u0C8D\u0C91\u0CA9\u0CB4\u0CBA\u0CBB\u0CC5\u0CC9\u0CCE-\u0CD4\u0CD7-\u0CDD\u0CDF\u0CE4\u0CE5\u0CF0\u0CF3-\u0D01\u0D04\u0D0D\u0D11\u0D3B\u0D3C\u0D45\u0D49\u0D4F-\u0D56\u0D58-\u0D5F\u0D64\u0D65\u0D76-\u0D78\u0D80\u0D81\u0D84\u0D97-\u0D99\u0DB2\u0DBC\u0DBE\u0DBF\u0DC7-\u0DC9\u0DCB-\u0DCE\u0DD5\u0DD7\u0DE0-\u0DF1\u0DF5-\u0E00\u0E3B-\u0E3E\u0E5C-\u0E80\u0E83\u0E85\u0E86\u0E89\u0E8B\u0E8C\u0E8E-\u0E93\u0E98\u0EA0\u0EA4\u0EA6\u0EA8\u0EA9\u0EAC\u0EBA\u0EBE\u0EBF\u0EC5\u0EC7\u0ECE\u0ECF\u0EDA\u0EDB\u0EE0-\u0EFF\u0F48\u0F6D-\u0F70\u0F98\u0FBD\u0FCD\u0FDB-\u0FFF\u10C6\u10C8-\u10CC\u10CE\u10CF\u1249\u124E\u124F\u1257\u1259\u125E\u125F\u1289\u128E\u128F\u12B1\u12B6\u12B7\u12BF\u12C1\u12C6\u12C7\u12D7\u1311\u1316\u1317\u135B\u135C\u137D-\u137F\u139A-\u139F\u13F5-\u13FF\u169D-\u169F\u16F1-\u16FF\u170D\u1715-\u171F\u1737-\u173F\u1754-\u175F\u176D\u1771\u1774-\u177F\u17DE\u17DF\u17EA-\u17EF\u17FA-\u17FF\u180F\u181A-\u181F\u1878-\u187F\u18AB-\u18AF\u18F6-\u18FF\u191D-\u191F\u192C-\u192F\u193C-\u193F\u1941-\u1943\u196E\u196F\u1975-\u197F\u19AC-\u19AF\u19CA-\u19CF\u19DB-\u19DD\u1A1C\u1A1D\u1A5F\u1A7D\u1A7E\u1A8A-\u1A8F\u1A9A-\u1A9F\u1AAE-\u1AFF\u1B4C-\u1B4F\u1B7D-\u1B7F\u1BF4-\u1BFB\u1C38-\u1C3A\u1C4A-\u1C4C\u1C80-\u1CBF\u1CC8-\u1CCF\u1CF7-\u1CFF\u1DE7-\u1DFB\u1F16\u1F17\u1F1E\u1F1F\u1F46\u1F47\u1F4E\u1F4F\u1F58\u1F5A\u1F5C\u1F5E\u1F7E\u1F7F\u1FB5\u1FC5\u1FD4\u1FD5\u1FDC\u1FF0\u1FF1\u1FF5\u1FFF\u200B-\u200F\u202A-\u202E\u2060-\u206F\u2072\u2073\u208F\u209D-\u209F\u20BB-\u20CF\u20F1-\u20FF\u218A-\u218F\u23F4-\u23FF\u2427-\u243F\u244B-\u245F\u2700\u2B4D-\u2B4F\u2B5A-\u2BFF\u2C2F\u2C5F\u2CF4-\u2CF8\u2D26\u2D28-\u2D2C\u2D2E\u2D2F\u2D68-\u2D6E\u2D71-\u2D7E\u2D97-\u2D9F\u2DA7\u2DAF\u2DB7\u2DBF\u2DC7\u2DCF\u2DD7\u2DDF\u2E3C-\u2E7F\u2E9A\u2EF4-\u2EFF\u2FD6-\u2FEF\u2FFC-\u2FFF\u3040\u3097\u3098\u3100-\u3104\u312E-\u3130\u318F\u31BB-\u31BF\u31E4-\u31EF\u321F\u32FF\u4DB6-\u4DBF\u9FCD-\u9FFF\uA48D-\uA48F\uA4C7-\uA4CF\uA62C-\uA63F\uA698-\uA69E\uA6F8-\uA6FF\uA78F\uA794-\uA79F\uA7AB-\uA7F7\uA82C-\uA82F\uA83A-\uA83F\uA878-\uA87F\uA8C5-\uA8CD\uA8DA-\uA8DF\uA8FC-\uA8FF\uA954-\uA95E\uA97D-\uA97F\uA9CE\uA9DA-\uA9DD\uA9E0-\uA9FF\uAA37-\uAA3F\uAA4E\uAA4F\uAA5A\uAA5B\uAA7C-\uAA7F\uAAC3-\uAADA\uAAF7-\uAB00\uAB07\uAB08\uAB0F\uAB10\uAB17-\uAB1F\uAB27\uAB2F-\uABBF\uABEE\uABEF\uABFA-\uABFF\uD7A4-\uD7AF\uD7C7-\uD7CA\uD7FC-\uF8FF\uFA6E\uFA6F\uFADA-\uFAFF\uFB07-\uFB12\uFB18-\uFB1C\uFB37\uFB3D\uFB3F\uFB42\uFB45\uFBC2-\uFBD2\uFD40-\uFD4F\uFD90\uFD91\uFDC8-\uFDEF\uFDFE\uFDFF\uFE1A-\uFE1F\uFE27-\uFE2F\uFE53\uFE67\uFE6C-\uFE6F\uFE75\uFEFD-\uFF00\uFFBF-\uFFC1\uFFC8\uFFC9\uFFD0\uFFD1\uFFD8\uFFD9\uFFDD-\uFFDF\uFFE7\uFFEF-\uFFFB\uFFFE\uFFFF]/g;
+	// Define a regular expression to match unprintable bytes
+	const unprintableBytesRegex = /[\0-\x1F\x7F-\x9F\xAD\u0378\u0379\u037F-\u0383\u038B\u038D\u03A2\u0528-\u0530\u0557\u0558\u0560\u0588\u058B-\u058E\u0590\u05C8-\u05CF\u05EB-\u05EF\u05F5-\u0605\u061C\u061D\u06DD\u070E\u070F\u074B\u074C\u07B2-\u07BF\u07FB-\u07FF\u082E\u082F\u083F\u085C\u085D\u085F-\u089F\u08A1\u08AD-\u08E3\u08FF\u0978\u0980\u0984\u098D\u098E\u0991\u0992\u09A9\u09B1\u09B3-\u09B5\u09BA\u09BB\u09C5\u09C6\u09C9\u09CA\u09CF-\u09D6\u09D8-\u09DB\u09DE\u09E4\u09E5\u09FC-\u0A00\u0A04\u0A0B-\u0A0E\u0A11\u0A12\u0A29\u0A31\u0A34\u0A37\u0A3A\u0A3B\u0A3D\u0A43-\u0A46\u0A49\u0A4A\u0A4E-\u0A50\u0A52-\u0A58\u0A5D\u0A5F-\u0A65\u0A76-\u0A80\u0A84\u0A8E\u0A92\u0AA9\u0AB1\u0AB4\u0ABA\u0ABB\u0AC6\u0ACA\u0ACE\u0ACF\u0AD1-\u0ADF\u0AE4\u0AE5\u0AF2-\u0B00\u0B04\u0B0D\u0B0E\u0B11\u0B12\u0B29\u0B31\u0B34\u0B3A\u0B3B\u0B45\u0B46\u0B49\u0B4A\u0B4E-\u0B55\u0B58-\u0B5B\u0B5E\u0B64\u0B65\u0B78-\u0B81\u0B84\u0B8B-\u0B8D\u0B91\u0B96-\u0B98\u0B9B\u0B9D\u0BA0-\u0BA2\u0BA5-\u0BA7\u0BAB-\u0BAD\u0BBA-\u0BBD\u0BC3-\u0BC5\u0BC9\u0BCE\u0BCF\u0BD1-\u0BD6\u0BD8-\u0BE5\u0BFB-\u0C00\u0C04\u0C0D\u0C11\u0C29\u0C34\u0C3A-\u0C3C\u0C45\u0C49\u0C4E-\u0C54\u0C57\u0C5A-\u0C5F\u0C64\u0C65\u0C70-\u0C77\u0C80\u0C81\u0C84\u0C8D\u0C91\u0CA9\u0CB4\u0CBA\u0CBB\u0CC5\u0CC9\u0CCE-\u0CD4\u0CD7-\u0CDD\u0CDF\u0CE4\u0CE5\u0CF0\u0CF3-\u0D01\u0D04\u0D0D\u0D11\u0D3B\u0D3C\u0D45\u0D49\u0D4F-\u0D56\u0D58-\u0D5F\u0D64\u0D65\u0D76-\u0D78\u0D80\u0D81\u0D84\u0D97-\u0D99\u0DB2\u0DBC\u0DBE\u0DBF\u0DC7-\u0DC9\u0DCB-\u0DCE\u0DD5\u0DD7\u0DE0-\u0DF1\u0DF5-\u0E00\u0E3B-\u0E3E\u0E5C-\u0E80\u0E83\u0E85\u0E86\u0E89\u0E8B\u0E8C\u0E8E-\u0E93\u0E98\u0EA0\u0EA4\u0EA6\u0EA8\u0EA9\u0EAC\u0EBA\u0EBE\u0EBF\u0EC5\u0EC7\u0ECE\u0ECF\u0EDA\u0EDB\u0EE0-\u0EFF\u0F48\u0F6D-\u0F70\u0F98\u0FBD\u0FCD\u0FDB-\u0FFF\u10C6\u10C8-\u10CC\u10CE\u10CF\u1249\u124E\u124F\u1257\u1259\u125E\u125F\u1289\u128E\u128F\u12B1\u12B6\u12B7\u12BF\u12C1\u12C6\u12C7\u12D7\u1311\u1316\u1317\u135B\u135C\u137D-\u137F\u139A-\u139F\u13F5-\u13FF\u169D-\u169F\u16F1-\u16FF\u170D\u1715-\u171F\u1737-\u173F\u1754-\u175F\u176D\u1771\u1774-\u177F\u17DE\u17DF\u17EA-\u17EF\u17FA-\u17FF\u180F\u181A-\u181F\u1878-\u187F\u18AB-\u18AF\u18F6-\u18FF\u191D-\u191F\u192C-\u192F\u193C-\u193F\u1941-\u1943\u196E\u196F\u1975-\u197F\u19AC-\u19AF\u19CA-\u19CF\u19DB-\u19DD\u1A1C\u1A1D\u1A5F\u1A7D\u1A7E\u1A8A-\u1A8F\u1A9A-\u1A9F\u1AAE-\u1AFF\u1B4C-\u1B4F\u1B7D-\u1B7F\u1BF4-\u1BFB\u1C38-\u1C3A\u1C4A-\u1C4C\u1C80-\u1CBF\u1CC8-\u1CCF\u1CF7-\u1CFF\u1DE7-\u1DFB\u1F16\u1F17\u1F1E\u1F1F\u1F46\u1F47\u1F4E\u1F4F\u1F58\u1F5A\u1F5C\u1F5E\u1F7E\u1F7F\u1FB5\u1FC5\u1FD4\u1FD5\u1FDC\u1FF0\u1FF1\u1FF5\u1FFF\u200B-\u200F\u202A-\u202E\u2060-\u206F\u2072\u2073\u208F\u209D-\u209F\u20BB-\u20CF\u20F1-\u20FF\u218A-\u218F\u23F4-\u23FF\u2427-\u243F\u244B-\u245F\u2700\u2B4D-\u2B4F\u2B5A-\u2BFF\u2C2F\u2C5F\u2CF4-\u2CF8\u2D26\u2D28-\u2D2C\u2D2E\u2D2F\u2D68-\u2D6E\u2D71-\u2D7E\u2D97-\u2D9F\u2DA7\u2DAF\u2DB7\u2DBF\u2DC7\u2DCF\u2DD7\u2DDF\u2E3C-\u2E7F\u2E9A\u2EF4-\u2EFF\u2FD6-\u2FEF\u2FFC-\u2FFF\u3040\u3097\u3098\u3100-\u3104\u312E-\u3130\u318F\u31BB-\u31BF\u31E4-\u31EF\u321F\u32FF\u4DB6-\u4DBF\u9FCD-\u9FFF\uA48D-\uA48F\uA4C7-\uA4CF\uA62C-\uA63F\uA698-\uA69E\uA6F8-\uA6FF\uA78F\uA794-\uA79F\uA7AB-\uA7F7\uA82C-\uA82F\uA83A-\uA83F\uA878-\uA87F\uA8C5-\uA8CD\uA8DA-\uA8DF\uA8FC-\uA8FF\uA954-\uA95E\uA97D-\uA97F\uA9CE\uA9DA-\uA9DD\uA9E0-\uA9FF\uAA37-\uAA3F\uAA4E\uAA4F\uAA5A\uAA5B\uAA7C-\uAA7F\uAAC3-\uAADA\uAAF7-\uAB00\uAB07\uAB08\uAB0F\uAB10\uAB17-\uAB1F\uAB27\uAB2F-\uABBF\uABEE\uABEF\uABFA-\uABFF\uD7A4-\uD7AF\uD7C7-\uD7CA\uD7FC-\uF8FF\uFA6E\uFA6F\uFADA-\uFAFF\uFB07-\uFB12\uFB18-\uFB1C\uFB37\uFB3D\uFB3F\uFB42\uFB45\uFBC2-\uFBD2\uFD40-\uFD4F\uFD90\uFD91\uFDC8-\uFDEF\uFDFE\uFDFF\uFE1A-\uFE1F\uFE27-\uFE2F\uFE53\uFE67\uFE6C-\uFE6F\uFE75\uFEFD-\uFF00\uFFBF-\uFFC1\uFFC8\uFFC9\uFFD0\uFFD1\uFFD8\uFFD9\uFFDD-\uFFDF\uFFE7\uFFEF-\uFFFB\uFFFE\uFFFF]/g;
 
-  // Replace unprintable bytes with their character codes
-  const replacedString = inputString.replace(unprintableBytesRegex, (match) => {
-    const charCode = match.charCodeAt(0);
-    return `<0x${charCode.toString(16).toUpperCase().padStart(2, '0')}>`;
-  });
+	// Replace unprintable bytes with their character codes
+	const replacedString = inputString.replace(unprintableBytesRegex, (match) => {
+		const charCode = match.charCodeAt(0);
+		return `<0x${charCode.toString(16).toUpperCase().padStart(2, '0')}>`;
+	});
 
-  return replacedString;
+	return replacedString;
 }
 
 function useSessionStorage(defaultPresets) {
@@ -1593,79 +1593,79 @@ export function App() {
 	const [lastError, setLastError] = useState(undefined);
 	const [contextLength, setContextLength] = useSessionState('contextLength', defaultPresets.contextLength);
 	const [memoryTokens, setMemoryTokens] = useSessionState('memoryTokens', defaultPresets.memoryTokens);
-  const [anTokens, setAnTokens] = useSessionState('anTokens', defaultPresets.anTokens);
-  const [anDepth, setAnDepth] = useSessionState('anDepth', defaultPresets.anDepth);
-  
-  const [modalState, setModalState] = useState({});
-  
-  const toggleModal = (modalKey) => {
-    setModalState((prevState) => ({
-      ...prevState,
-      [modalKey]: !prevState[modalKey],
-    }));
-  };
-  const closeModal = (modalKey) => {
-  setModalState((prevState) => ({
-    ...prevState,
-    [modalKey]: false,
-  }));
+	const [anTokens, setAnTokens] = useSessionState('anTokens', defaultPresets.anTokens);
+	const [anDepth, setAnDepth] = useSessionState('anDepth', defaultPresets.anDepth);
+	
+	const [modalState, setModalState] = useState({});
+	
+	const toggleModal = (modalKey) => {
+		setModalState((prevState) => ({
+			...prevState,
+			[modalKey]: !prevState[modalKey],
+		}));
+	};
+	const closeModal = (modalKey) => {
+	setModalState((prevState) => ({
+		...prevState,
+		[modalKey]: false,
+	}));
 };
-  
+	
 	const promptText = useMemo(() => joinPrompt(promptChunks), [promptChunks]);
 
 	// Update theme on the first render.
 	useMemo(() => !theme || switchTheme(theme, true), []);
-  
+	
 
-  const modifiedPrompt = useMemo(() => {
-    // define used variables
-    const tokenRatio = 3.3;
-    const additionalContext = (memoryTokens + anTokens).length; // TODO add active WI
-    const estimatedPromptLength = Math.round(
-      promptText.length - contextLength * tokenRatio + additionalContext / tokenRatio) + 1;
-    
-    // truncate prompt
-    const truncPrompt = promptText.substring(estimatedPromptLength);
-    // assemble context in order
-    const permContextPrompt = memoryTokens.concat(promptText.substring(estimatedPromptLength));
-  
-    // make injection depth valid
-    const truncPromptLen = truncPrompt.split('\n').length;
-    const injDepth = truncPromptLen >= anDepth ? anDepth : truncPromptLen
-    console.log(injDepth)
+	const modifiedPrompt = useMemo(() => {
+		// define used variables
+		const tokenRatio = 3.3;
+		const additionalContext = (memoryTokens + anTokens).length; // TODO add active WI
+		const estimatedPromptLength = Math.round(
+			promptText.length - contextLength * tokenRatio + additionalContext / tokenRatio) + 1;
+		
+		// truncate prompt
+		const truncPrompt = promptText.substring(estimatedPromptLength);
+		// assemble context in order
+		const permContextPrompt = memoryTokens.concat(promptText.substring(estimatedPromptLength));
+	
+		// make injection depth valid
+		const truncPromptLen = truncPrompt.split('\n').length;
+		const injDepth = truncPromptLen >= anDepth ? anDepth : truncPromptLen
+		console.log(injDepth)
 
-    // Insert author's note N newlines up from the bottom and return
-    if (anTokens !== '') {
-      const lines = permContextPrompt.split('\n');
-      
-      const injIndex = lines.length-injDepth-1
-      lines.splice(injIndex+1,0,anTokens)
-      //const concatAn = lines.length-1 > injDepth ? lines[injIndex-1] + lines[injIndex] : lines[injIndex+1] + lines[injIndex+2];
-      if (injDepth < 1) {
-        const concatAn = lines[injIndex] + lines[injIndex+1]
-        lines.splice(injIndex,2,concatAn)
-      }
-      else {
-        const concatAn = lines[injIndex+1] + lines[injIndex+2]
-        lines.splice(injIndex+1,2,concatAn)
-      }
-      
-      //console.log(lines[lines.length])
-      return lines.join('\n');
-    }
+		// Insert author's note N newlines up from the bottom and return
+		if (anTokens !== '') {
+			const lines = permContextPrompt.split('\n');
+			
+			const injIndex = lines.length-injDepth-1
+			lines.splice(injIndex+1,0,anTokens)
+			//const concatAn = lines.length-1 > injDepth ? lines[injIndex-1] + lines[injIndex] : lines[injIndex+1] + lines[injIndex+2];
+			if (injDepth < 1) {
+				const concatAn = lines[injIndex] + lines[injIndex+1]
+				lines.splice(injIndex,2,concatAn)
+			}
+			else {
+				const concatAn = lines[injIndex+1] + lines[injIndex+2]
+				lines.splice(injIndex+1,2,concatAn)
+			}
+			
+			//console.log(lines[lines.length])
+			return lines.join('\n');
+		}
 
-    // If no newline is found, return the original string
-    return permContextPrompt;
-  }, [contextLength, promptText, memoryTokens, anTokens, anDepth]);
+		// If no newline is found, return the original string
+		return permContextPrompt;
+	}, [contextLength, promptText, memoryTokens, anTokens, anDepth]);
 
 	// Update dark mode on the first render.
 	useMemo(() => !darkMode || switchDarkMode(darkMode, true), []);
-  
-  function viewContext(context = modifiedPrompt) {
-    console.log(context)
-  };
-  
-  
+	
+	function viewContext(context = modifiedPrompt) {
+		console.log(context)
+	};
+	
+	
 	async function predict(prompt = modifiedPrompt, chunkCount = promptChunks.length) {
 		if (cancel) {
 			cancel?.();
@@ -2250,41 +2250,41 @@ export function App() {
 					<${Checkbox} label="Ignore <eos>"
 						disabled=${!!cancel} value=${ignoreEos} onValueChange=${setIgnoreEos}/>`}
 			</${CollapsibleGroup}>
-      <${CollapsibleGroup} label="Persistent Context">
-        <label className="TextArea">
-          Memory
-          <textarea
-          readOnly=${!!cancel}
-          placeholder="Anything written here will be injected at the head of the prompt. Tokens here DO count towards the Context Limit."
-          defaultValue=${memoryTokens}
-          value=${memoryTokens}
-          onInput=${(e) => setMemoryTokens(e.target.value)}			
-          id="memory-area"/>
-          <button
+			<${CollapsibleGroup} label="Persistent Context">
+				<label className="TextArea">
+					Memory
+					<textarea
+					readOnly=${!!cancel}
+					placeholder="Anything written here will be injected at the head of the prompt. Tokens here DO count towards the Context Limit."
+					defaultValue=${memoryTokens}
+					value=${memoryTokens}
+					onInput=${(e) => setMemoryTokens(e.target.value)}			
+					id="memory-area"/>
+					<button
 					className="textAreaSettings"
 					disabled=${!!cancel}
 					onClick=${() => toggleModal("memory")}>
-          
+					
 					<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="-1 -6 8 7" xmlns="http://www.w3.org/2000/svg"><path d="M0 0 3-3C3-4 3-5 5-5L4-4 5-3 6-4C6-2 5-2 4-2L1 1C0 2-1 1 0 0"></path></svg>
-          </button>
-        </label>
-        <label className="TextArea">
-          Author's Note
-          <textarea
-          readOnly=${!!cancel}
-          placeholder="Anything written here will be injected ${anDepth} newlines into context."
-          defaultValue=${anTokens}
-          value=${anTokens}
-          onInput=${(e) => setAnTokens(e.target.value)}			
-          id="an-area"/>
-          <button
+					</button>
+				</label>
+				<label className="TextArea">
+					Author's Note
+					<textarea
+					readOnly=${!!cancel}
+					placeholder="Anything written here will be injected ${anDepth} newlines into context."
+					defaultValue=${anTokens}
+					value=${anTokens}
+					onInput=${(e) => setAnTokens(e.target.value)}			
+					id="an-area"/>
+					<button
 					className="textAreaSettings"
 					disabled=${!!cancel}
 					onClick=${() => toggleModal("an")}>
 					<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="-1 -6 8 7" xmlns="http://www.w3.org/2000/svg"><path d="M0 0 3-3C3-4 3-5 5-5L4-4 5-3 6-4C6-2 5-2 4-2L1 1C0 2-1 1 0 0"></path></svg>
-          </button>
-        </label>
-        <button
+					</button>
+				</label>
+				<button
 					id="viewContext"
 					disabled=${!!cancel}
 					onClick=${() => toggleModal("context")}>
@@ -2321,44 +2321,44 @@ export function App() {
 			${!!lastError && html`
 				<span className="error-text">${lastError}</span>`}
 		</div>
-    <${Modal} isOpen=${modalState.memory} onClose=${() => closeModal("memory")}>
-      <h2>Memory</h2>
-      <p>This text will be added at the very top of your context.</p>
-      <textarea
-      readOnly=${!!cancel}
-      placeholder="Anything written here will be injected at the head of the prompt. Tokens here DO count towards the Context Limit."
-      defaultValue=${memoryTokens}
-      value=${memoryTokens}
-      onInput=${(e) => setMemoryTokens(e.target.value)}
-      class="expanded-text-area-settings"
-      id="memory-area-settings"/>
-    </${Modal}>
+		<${Modal} isOpen=${modalState.memory} onClose=${() => closeModal("memory")}>
+			<h2>Memory</h2>
+			<p>This text will be added at the very top of your context.</p>
+			<textarea
+			readOnly=${!!cancel}
+			placeholder="Anything written here will be injected at the head of the prompt. Tokens here DO count towards the Context Limit."
+			defaultValue=${memoryTokens}
+			value=${memoryTokens}
+			onInput=${(e) => setMemoryTokens(e.target.value)}
+			class="expanded-text-area-settings"
+			id="memory-area-settings"/>
+		</${Modal}>
 
-      <${Modal} isOpen=${modalState.an} onClose=${() => closeModal("an")}>
-        <h2>Author's Note</h2>
-        <p>This text will be injected N non-empty newlines deep into your recent context.</p>
-        <${InputBox} label="AN Injection Depth (0-N)" type="number" step="1"
+			<${Modal} isOpen=${modalState.an} onClose=${() => closeModal("an")}>
+				<h2>Author's Note</h2>
+				<p>This text will be injected N non-empty newlines deep into your recent context.</p>
+				<${InputBox} label="AN Injection Depth (0-N)" type="number" step="1"
 					readOnly=${!!cancel} value=${anDepth} onValueChange=${setAnDepth}/>
-        <textarea
-        readOnly=${!!cancel}
-        placeholder="Anything written here will be injected ${anDepth} newlines into context."
-        defaultValue=${anTokens}
-        value=${anTokens}
-        onInput=${(e) => setAnTokens(e.target.value)}
-        class="expanded-text-area-settings"
-        id="expanded-an-settings"/>
-      </${Modal}>
-      
-      <${Modal} isOpen=${modalState.context} onClose=${() => closeModal("context")}>
-        <h2>Context</h2>
-        <p>This is the prompt being sent to your large language model.</p>
-        <textarea
-        readOnly=${!!cancel}
-        value=${modifiedPrompt}
-        class="expanded-text-area-settings"
-        id="context-area-settings" readOnly/>
-        </${Modal}>
-    `;
+				<textarea
+				readOnly=${!!cancel}
+				placeholder="Anything written here will be injected ${anDepth} newlines into context."
+				defaultValue=${anTokens}
+				value=${anTokens}
+				onInput=${(e) => setAnTokens(e.target.value)}
+				class="expanded-text-area-settings"
+				id="expanded-an-settings"/>
+			</${Modal}>
+			
+			<${Modal} isOpen=${modalState.context} onClose=${() => closeModal("context")}>
+				<h2>Context</h2>
+				<p>This is the prompt being sent to your large language model.</p>
+				<textarea
+				readOnly=${!!cancel}
+				value=${modifiedPrompt}
+				class="expanded-text-area-settings"
+				id="context-area-settings" readOnly/>
+				</${Modal}>
+		`;
 }
 
 createRoot(document.body).render(html`<${App}/>`);

--- a/mikupad.html
+++ b/mikupad.html
@@ -68,8 +68,8 @@ html.serif-dark {
 }
 
 html.monospace-dark {
-		---color-bg-dark: #282833;
-		--color-bg: #202020;
+	---color-bg-dark: #282833;
+	--color-bg: #202020;
 	--color-text: #bababa;
 	--color-base-0: oklch(77.65% 0.0752 285.22);
 	--color-base-10: color-mix(in oklch, var(--color-base-100) 90%, var(--color-base-0));
@@ -1593,11 +1593,20 @@ export function App() {
 	const [lastError, setLastError] = useState(undefined);
 	const [contextLength, setContextLength] = useSessionState('contextLength', defaultPresets.contextLength);
 	const [memoryTokens, setMemoryTokens] = useSessionState('memoryTokens', defaultPresets.memoryTokens);
+  
 	const [anTokens, setAnTokens] = useSessionState('anTokens', defaultPresets.anTokens);
 	const [anDepth, setAnDepth] = useSessionState('anDepth', defaultPresets.anDepth);
+  const handleAnDepthChange = (value) => {
+    if (!isNaN(value) && value >= 0) {
+        setAnDepth(value);
+    }
+    else {
+        console.warn('A/N depth smaller than 0, setting to 0.');
+        setAnDepth(0);
+    }
+  };
 	
 	const [modalState, setModalState] = useState({});
-	
 	const toggleModal = (modalKey) => {
 		setModalState((prevState) => ({
 			...prevState,
@@ -1632,29 +1641,17 @@ export function App() {
 		// make injection depth valid
 		const truncPromptLen = truncPrompt.split('\n').length;
 		const injDepth = truncPromptLen >= anDepth ? anDepth : truncPromptLen
-		console.log(injDepth)
 
 		// Insert author's note N newlines up from the bottom and return
 		if (anTokens !== '') {
-			const lines = permContextPrompt.split('\n');
+			const lines = permContextPrompt.match(/.*\n?/g);
 			
 			const injIndex = lines.length-injDepth-1
-			lines.splice(injIndex+1,0,anTokens)
-			//const concatAn = lines.length-1 > injDepth ? lines[injIndex-1] + lines[injIndex] : lines[injIndex+1] + lines[injIndex+2];
-			if (injDepth < 1) {
-				const concatAn = lines[injIndex] + lines[injIndex+1]
-				lines.splice(injIndex,2,concatAn)
-			}
-			else {
-				const concatAn = lines[injIndex+1] + lines[injIndex+2]
-				lines.splice(injIndex+1,2,concatAn)
-			}
-			
-			//console.log(lines[lines.length])
-			return lines.join('\n');
+			lines.splice(injIndex,0,anTokens)
+			return lines.join('');
 		}
 
-		// If no newline is found, return the original string
+		// if no author's note, return original memory context
 		return permContextPrompt;
 	}, [contextLength, promptText, memoryTokens, anTokens, anDepth]);
 
@@ -2338,7 +2335,7 @@ export function App() {
 				<h2>Author's Note</h2>
 				<p>This text will be injected N non-empty newlines deep into your recent context.</p>
 				<${InputBox} label="AN Injection Depth (0-N)" type="number" step="1"
-					readOnly=${!!cancel} value=${anDepth} onValueChange=${setAnDepth}/>
+					readOnly=${!!cancel} value=${anDepth} onValueChange=${handleAnDepthChange}/>
 				<textarea
 				readOnly=${!!cancel}
 				placeholder="Anything written here will be injected ${anDepth} newlines into context."

--- a/mikupad.html
+++ b/mikupad.html
@@ -125,6 +125,10 @@ body {
 	scrollbar-gutter: stable;
 	font: inherit;
 }
+html.monospace-dark #prompt-area {
+	background: var(--color-bg);
+	color: var(--color-text);
+}
 #memory-area, #an-area, .expanded-text-area-settings {
 	flex: 1;
 	border: none;
@@ -242,14 +246,33 @@ html.monospace-dark #probs {
 }
 
 .modal {
+	position: relative;
 	background: var(--color-base-50);
 	width:75%;
 	height:fit-content;
 	padding: 1em;
-	border-radius: 2px;
+	border-radius: 5px;
 }
-.button-modal-bottom {
-	float:right;
+
+.button-modal-top {
+	all:unset;
+	position: absolute;
+	top:1em;
+	right:1em;
+	width:1.25em;
+	height:1.25em;
+	border-radius: 3px;
+}
+.modal-title {
+	font-size: 150%;
+	font-weight:bold;
+	margin-bottom: .25em;
+}
+
+hr {
+	border:unset;
+	border-top: 1px solid var(--color-base-40);
+	margin: 0.5em -1em;
 }
 
 #sidebar {
@@ -1079,7 +1102,7 @@ function CollapsibleGroup({ label, expanded, children }) {
 		</div>`;
 }
 
-	function Modal({ isOpen, onClose, children, ...props }) {
+	function Modal({ isOpen, onClose, title, description, children, ...props }) {
 		if (!isOpen) {
 			return null;
 		}
@@ -1088,11 +1111,14 @@ function CollapsibleGroup({ label, expanded, children }) {
 		<div className="modal-overlay" onClick=${onClose}>
 			<div className="modal-container">
 				<div className="modal" onClick=${(e) => e.stopPropagation()} ...${props}>
+					<div class="modal-title">${title}</div>
+					${ description=="" ? false : html`<div style=${{ whiteSpace: 'pre-line' }} class='modal-desc'>${description}</div>` }
+					<hr/>
 					${children}
 					<button
-					class="button-modal-bottom"
+					class="button-modal-top"
 					onClick=${onClose}>
-						Close
+						<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="-1 -1 10 10" xmlns="http://www.w3.org/2000/svg"><path d="M 0 1 L 3 4 L 0 7 L 1 8 L 4 5 L 7 8 L 8 7 L 5 4 L 8 1 L 7 0 L 4 3 L 1 0 L 1 0 Z"></path></svg>
 					</button>
 				</div>
 			</div>
@@ -1672,11 +1698,6 @@ export function App() {
 		// if no author's note, return original memory context
 		return permContextPrompt;
 	}, [contextLength, promptText, memoryTokens, anTokens, anDepth]);
-
-	// Update dark mode on the first render.
-	useMemo(() => !darkMode || switchDarkMode(darkMode, true), []);
-
-
 
 	async function predict(prompt = modifiedPrompt, chunkCount = promptChunks.length) {
 		if (cancel) {
@@ -2284,7 +2305,7 @@ export function App() {
 					Author's Note
 					<textarea
 					readOnly=${!!cancel}
-					placeholder="Anything written here will be injected ${anDepth} newlines into context."
+					placeholder="Anything written here will be injected ${anDepth} newlines from bottom into context."
 					defaultValue=${anTokens.text}
 					value=${anTokens.text}
 					onInput=${(e) => handleAnTokensChange("text", e.target.value) }
@@ -2333,12 +2354,10 @@ export function App() {
 			${!!lastError && html`
 				<span className="error-text">${lastError}</span>`}
 		</div>
-		<${Modal} isOpen=${modalState.memory} onClose=${() => closeModal("memory")}>
-			<h2>Memory</h2>
-			<p class="modal-description">
-				This text will be added at the very top of your context.<br/>
-				Prefix and suffix will be attached at the beginning or end of your memory respectively. \n for newlines.
-			</p>
+		<${Modal} isOpen=${modalState.memory} onClose=${() => closeModal("memory")}
+		title="Memory"
+		description="This text will be added at the very top of your context.
+		Prefix and suffix will be attached at the beginning or end of your memory respectively. \\n for newlines in pre/suffix.">
 			<div className="hbox">
 				<${InputBox} label="Prefix" type="text" placeholder="[INST]"
 					readOnly=${!!cancel} value=${memoryTokens.prefix} onValueChange=${(value) => handleMemoryTokensChange("prefix", value)}/>
@@ -2355,12 +2374,10 @@ export function App() {
 				id="memory-area-settings"/>
 		</${Modal}>
 
-		<${Modal} isOpen=${modalState.an} onClose=${() => closeModal("an")}>
-			<h2>Author's Note</h2>
-			<p class="modal-description">
-				This text will be injected N newlines deep into your recent context.<br/>
-				Prefix and suffix will be attached at the beginning or end of your Author's Note respectively. \n for newlines.
-			</p>
+		<${Modal} isOpen=${modalState.an} onClose=${() => closeModal("an")}
+		title="Author's Note"
+		description="This text will be injected N newlines from the bottom of your prompt.
+		Prefix and suffix will be attached at the beginning or end of your author's note respectively. \\n for newlines in pre/suffix.">
 			<div className="hbox">
 				<${InputBox} label="Prefix" type="text" placeholder="[INST]"
 					readOnly=${!!cancel} value=${anTokens.prefix} onValueChange=${(value) => handleAnTokensChange("prefix", value)}/>
@@ -2369,10 +2386,9 @@ export function App() {
 				<${InputBox} label="AN Injection Depth (0-N)" type="number" step="1"
 					readOnly=${!!cancel} value=${anDepth} onValueChange=${handleAnDepthChange}/>
 			</div>
-
 			<textarea
 			readOnly=${!!cancel}
-			placeholder="Anything written here will be injected ${anDepth} newlines into context."
+			placeholder="Anything written here will be injected ${anDepth} newlines from bottom into context."
 			defaultValue=${anTokens.text}
 			value=${anTokens.text}
 			onInput=${(e) => handleAnTokensChange("text", e.target.value) }
@@ -2380,11 +2396,9 @@ export function App() {
 			id="expanded-an-settings"/>
 		</${Modal}>
 
-		<${Modal} isOpen=${modalState.context} onClose=${() => closeModal("context")}>
-			<h2>Context</h2>
-			<p class="modal-description">
-				This is the prompt being sent to your large language model.
-			</p>
+		<${Modal} isOpen=${modalState.context} onClose=${() => closeModal("context")}
+		title="Context"
+		description="This is the prompt being sent to your large language model.">
 			<textarea
 			readOnly=${!!cancel}
 			value=${modifiedPrompt}

--- a/mikupad.html
+++ b/mikupad.html
@@ -125,7 +125,7 @@ body {
 	scrollbar-gutter: stable;
 	font: inherit;
 }
-#memory-area, #an-area {
+#memory-area, #an-area, .expanded-text-area-settings {
 	flex: 1;
 	border: none;
 	outline: none;
@@ -135,13 +135,19 @@ body {
 	padding: 0.5em;
 	scrollbar-gutter: stable;
 	font: initial;
+  border-radius: 2px;
 }
 #memory-area {
 	min-height:9.5em;
 }
 #an-area {
-	min-height:3.5em;
-                          
+	min-height:3.5em;                  
+}
+.expanded-text-area-settings {
+  margins: auto;
+	width:100%;
+  box-sizing: border-box;
+  height:25.5em;
 }
 
 #prompt-overlay {
@@ -237,10 +243,13 @@ html.monospace-dark #probs {
 
 .modal {
   background: var(--color-base-50);
-  width:50%;
+  width:75%;
   height:fit-content;
   padding: 1em;
   border-radius: 2px;
+}
+.button-modal-bottom {
+  float:right;
 }
 
 #sidebar {
@@ -1080,6 +1089,11 @@ function CollapsibleGroup({ label, expanded, children }) {
       <div className="modal-container">
         <div className="modal" onClick=${(e) => e.stopPropagation()} ...${props}>
           ${children}
+          <button
+          class="button-modal-bottom"
+					onClick=${onClose}>
+            Close
+          </button>
         </div>
       </div>
     </div>
@@ -1615,16 +1629,28 @@ export function App() {
     // assemble context in order
     const permContextPrompt = memoryTokens.concat(promptText.substring(estimatedPromptLength));
   
-    // Find the index of the newline character three lines up from the end
-    const newlineIndex = permContextPrompt
-      .split('\n')
-      .reverse()
-      .findIndex((line, index) => index < 3 && line.trim() === '');
+    // make injection depth valid
+    const truncPromptLen = truncPrompt.split('\n').length;
+    const injDepth = truncPromptLen >= anDepth ? anDepth : truncPromptLen
+    console.log(injDepth)
 
-    // Insert author's note X newlines up from the bottom
-    if (newlineIndex !== -1) {
+    // Insert author's note N newlines up from the bottom and return
+    if (anTokens !== '') {
       const lines = permContextPrompt.split('\n');
-      lines.splice(lines.length - newlineIndex - anDepth-1, 0, anTokens);
+      
+      const injIndex = lines.length-injDepth-1
+      lines.splice(injIndex+1,0,anTokens)
+      //const concatAn = lines.length-1 > injDepth ? lines[injIndex-1] + lines[injIndex] : lines[injIndex+1] + lines[injIndex+2];
+      if (injDepth < 1) {
+        const concatAn = lines[injIndex] + lines[injIndex+1]
+        lines.splice(injIndex,2,concatAn)
+      }
+      else {
+        const concatAn = lines[injIndex+1] + lines[injIndex+2]
+        lines.splice(injIndex+1,2,concatAn)
+      }
+      
+      //console.log(lines[lines.length])
       return lines.join('\n');
     }
 
@@ -2157,6 +2183,8 @@ export function App() {
 						disabled=${!!cancel} value=${openaiPresets} onValueChange=${setOpenaiPresets}/>`}
 				<${InputBox} label="Seed (-1 = random)" type="text" inputmode="numeric"
 					readOnly=${!!cancel} value=${seed} onValueChange=${setSeed}/>
+				<${InputBox} label="Max Context Length (estimate, characters * 3.3)" type="text" inputmode="numeric"
+					readOnly=${!!cancel} value=${contextLength} onValueChange=${setContextLength}/>
 				<${InputBox} label="Max Predict Tokens${endpointAPI != 0 ? ' (-1 = 1024)' : ' (-1 = infinite)'}" type="text" inputmode="numeric"
 					readOnly=${!!cancel} value=${maxPredictTokens} onValueChange=${setMaxPredictTokens}/>
 				<${InputBox} label="Temperature" type="number" step="0.01"
@@ -2244,7 +2272,7 @@ export function App() {
           Author's Note
           <textarea
           readOnly=${!!cancel}
-          placeholder="Author's note"
+          placeholder="Anything written here will be injected ${anDepth} newlines into context."
           defaultValue=${anTokens}
           value=${anTokens}
           onInput=${(e) => setAnTokens(e.target.value)}			
@@ -2259,8 +2287,8 @@ export function App() {
         <button
 					id="viewContext"
 					disabled=${!!cancel}
-					onClick=${() => viewContext()}>
-					Print Context to Console
+					onClick=${() => toggleModal("context")}>
+					Show Context
 				</button>
 			</${CollapsibleGroup}>
 			${!!tokens && html`
@@ -2294,23 +2322,42 @@ export function App() {
 				<span className="error-text">${lastError}</span>`}
 		</div>
     <${Modal} isOpen=${modalState.memory} onClose=${() => closeModal("memory")}>
-        <${InputBox} label="Server"
-					className="${isMixedContent() ? 'mixed-content' : ''}"
-					tooltip="${isMixedContent() ? 'This URL might be blocked due to mixed content. If the prediction fails, download mikupad.html and run it locally.' : ''}"
-					readOnly=${!!cancel}
-					value=${endpoint}
-					onValueChange=${setEndpoint}/>
-      </${Modal}>
+      <h2>Memory</h2>
+      <p>This text will be added at the very top of your context.</p>
+      <textarea
+      readOnly=${!!cancel}
+      placeholder="Anything written here will be injected at the head of the prompt. Tokens here DO count towards the Context Limit."
+      defaultValue=${memoryTokens}
+      value=${memoryTokens}
+      onInput=${(e) => setMemoryTokens(e.target.value)}
+      class="expanded-text-area-settings"
+      id="memory-area-settings"/>
+    </${Modal}>
 
       <${Modal} isOpen=${modalState.an} onClose=${() => closeModal("an")}>
-        <p>This is the content of Modal 2!</p>
-        <Button label="Close Modal" onClick=${() => closeModal("an")} />
+        <h2>Author's Note</h2>
+        <p>This text will be injected N non-empty newlines deep into your recent context.</p>
+        <${InputBox} label="AN Injection Depth (0-N)" type="number" step="1"
+					readOnly=${!!cancel} value=${anDepth} onValueChange=${setAnDepth}/>
+        <textarea
+        readOnly=${!!cancel}
+        placeholder="Anything written here will be injected ${anDepth} newlines into context."
+        defaultValue=${anTokens}
+        value=${anTokens}
+        onInput=${(e) => setAnTokens(e.target.value)}
+        class="expanded-text-area-settings"
+        id="expanded-an-settings"/>
       </${Modal}>
       
       <${Modal} isOpen=${modalState.context} onClose=${() => closeModal("context")}>
-        <p>This is the content of Modal 2!</p>
-        <Button label="Close Modal" onClick=${() => closeModal("context")} />
-      </${Modal}>
+        <h2>Context</h2>
+        <p>This is the prompt being sent to your large language model.</p>
+        <textarea
+        readOnly=${!!cancel}
+        value=${modifiedPrompt}
+        class="expanded-text-area-settings"
+        id="context-area-settings" readOnly/>
+        </${Modal}>
     `;
 }
 

--- a/mikupad.html
+++ b/mikupad.html
@@ -1,14 +1,14 @@
 <!doctype html>
 <meta charset="utf-8">
 <!-- mikupad by Anon
-	--
-	-- To the extent possible under law, the person who associated CC0 with
-	-- mikupad has waived all copyright and related or neighboring rights
-	-- to mikupad.
-	--
-	-- You should have received a copy of the CC0 legalcode along with this
-	-- work.  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-	-->
+  --
+  -- To the extent possible under law, the person who associated CC0 with
+  -- mikupad has waived all copyright and related or neighboring rights
+  -- to mikupad.
+  --
+  -- You should have received a copy of the CC0 legalcode along with this
+  -- work.  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+  -->
 <title>mikupad</title>
 <script type="importmap">
 {
@@ -125,7 +125,10 @@ body {
 	scrollbar-gutter: stable;
 	font: inherit;
 }
-html.monospace-dark #prompt-area {
+html.monospace-dark #prompt-area,
+html.monospace-dark #memory-area,
+html.monospace-dark #an-area,
+html.monospace-dark .expanded-text-area-settings {
 	background: var(--color-bg);
 	color: var(--color-text);
 }
@@ -138,7 +141,7 @@ html.monospace-dark #prompt-area {
 	color: var(--color-base-10);
 	padding: 0.5em;
 	scrollbar-gutter: stable;
-	font: initial;
+	font-family: inherit;
 	border-radius: 2px;
 }
 #memory-area {
@@ -232,7 +235,7 @@ html.monospace-dark #probs {
 	left: 0;
 	width: 100%;
 	height: 100%;
-	background: rgba(0, 0, 0, 0.5);
+	background: rgba(0, 0, 0, 0.65);
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -246,6 +249,7 @@ html.monospace-dark #probs {
 }
 
 .modal {
+	color: var(--color-light);
 	position: relative;
 	background: var(--color-base-50);
 	width:75%;
@@ -272,7 +276,7 @@ html.monospace-dark #probs {
 hr {
 	border:unset;
 	border-top: 1px solid var(--color-base-40);
-	margin: 0.5em -1em;
+	margin: 0.75em -1em 0.5em;
 }
 
 #sidebar {
@@ -405,6 +409,7 @@ button {
 }
 button.textAreaSettings {
 	all: unset;
+	color: var(--color-base-50);
 	width:1.25em;
 	position:absolute;
 	top:calc(1.25em + 1px);
@@ -1501,8 +1506,8 @@ const defaultPresets = {
 	openaiPresets: false,
 	contextLength: 4096,
 	memoryTokens: ({ "prefix":"", "text":"", "suffix":""}),
-	anTokens: ({ "prefix":"", "text":"", "suffix":""}),
-	anDepth: 3
+	authorNoteTokens: ({ "prefix":"", "text":"", "suffix":""}),
+	authorNoteDepth: 3
 };
 
 function joinPrompt(prompt) {
@@ -1620,26 +1625,18 @@ export function App() {
 	const [contextLength, setContextLength] = useSessionState('contextLength', defaultPresets.contextLength);
 	const [memoryTokens, setMemoryTokens] = useSessionState('memoryTokens', defaultPresets.memoryTokens);
 
-	const [anTokens, setAnTokens] = useSessionState('anTokens', defaultPresets.anTokens);
-	const [anDepth, setAnDepth] = useSessionState('anDepth', defaultPresets.anDepth);
-	const handleAnDepthChange = (value) => {
-		if (!isNaN(value) && value >= 0) {
-				setAnDepth(value);
-		}
-		else {
-				console.warn('A/N depth smaller than 0, setting to 0.');
-				setAnDepth(0);
-		}
+	const [authorNoteTokens, setAuthorNoteTokens] = useSessionState('authorNoteTokens', defaultPresets.authorNoteTokens);
+	const [authorNoteDepth, setAuthorNoteDepth] = useSessionState('authorNoteDepth', defaultPresets.authorNoteDepth);
+	const handleAuthorNoteDepthChange = (value) => {
+		setAuthorNoteDepth(!isNaN(+value) && value >= 0 ? value : 0);
 	};
 
-	function handleAnTokensChange(key,value) {
-		setAnTokens((prevAnTokens) => ({ ...prevAnTokens, [key]: value }));
+	function handleauthorNoteTokensChange(key,value) {
+		setAuthorNoteTokens((prevauthorNoteTokens) => ({ ...prevauthorNoteTokens, [key]: value }));
 	}
 	function handleMemoryTokensChange(key,value) {
 		setMemoryTokens((prevMemoryTokens) => ({ ...prevMemoryTokens, [key]: value }));
-	}
-
-
+	};
 
 	const [modalState, setModalState] = useState({});
 	const toggleModal = (modalKey) => {
@@ -1664,40 +1661,41 @@ export function App() {
 	const modifiedPrompt = useMemo(() => {
 		// assemble individual contexts if text not empty
 		const order = ["prefix","text","suffix"]
-		const assMemory = memoryTokens.text && memoryTokens.text !== ""
-	    ? order.map(key => memoryTokens[key]).join("").replace(/\\n/g,'\n')
-	    : "";
-		const assAn = anTokens.text && anTokens.text !== ""
-	    ? order.map(key => anTokens[key]).join("").replace(/\\n/g,'\n')
-	    : "";
+		const assembledMemory = memoryTokens.text && memoryTokens.text !== ""
+			? order.map(key => memoryTokens[key]).join("").replace(/\\n/g,'\n')
+			: "";
+		const assembledAuthorNote = authorNoteTokens.text && authorNoteTokens.text !== ""
+			? order.map(key => authorNoteTokens[key]).join("").replace(/\\n/g,'\n')
+			: "";
 
 		// prompt length estimation
 		const tokenRatio = 3.3;
-		const additionalContext = (assMemory + assAn).length; // TODO add active WI
-		const estimatedPromptLength = Math.round(
+		const additionalContext = (assembledMemory + assembledAuthorNote).length; // TODO add active WI
+		const estimatedContextStart = Math.round(
 			promptText.length - contextLength * tokenRatio + additionalContext / tokenRatio) + 1;
 
 		// truncate prompt
-		const truncPrompt = promptText.substring(estimatedPromptLength);
-
-		// assemble context in order
-		const permContextPrompt = assMemory.concat(promptText.substring(estimatedPromptLength));
+		const truncPrompt = promptText.substring(estimatedContextStart);
 
 		// make injection depth valid
 		const truncPromptLen = truncPrompt.split('\n').length;
-		const injDepth = truncPromptLen >= anDepth ? anDepth : truncPromptLen
+		const injDepth = truncPromptLen > authorNoteDepth ? authorNoteDepth : truncPromptLen
 
-		// Insert author's note N newlines up from the bottom and return
-		if (anTokens !== '') {
-			const lines = permContextPrompt.match(/.*\n?/g);
-			const injIndex = lines.length-injDepth-1
-			lines.splice(injIndex,0,assAn)
-			return lines.join('');
-		}
+		const lines = truncPrompt.match(/.*\n?/g);
+		const injIndex = lines.length-injDepth-1
+		// inject an
+		lines.splice(injIndex,0,assembledAuthorNote)
+		// if an, return an context, else return original truncated context
+		const authorNotePrompt = assembledAuthorNote != ""
+			? lines.join('')
+			: truncPrompt;
+
+		// assemble context in order
+		const permContextPrompt = assembledMemory.concat(authorNotePrompt);
 
 		// if no author's note, return original memory context
 		return permContextPrompt;
-	}, [contextLength, promptText, memoryTokens, anTokens, anDepth]);
+	}, [contextLength, promptText, memoryTokens, authorNoteTokens, authorNoteDepth]);
 
 	async function predict(prompt = modifiedPrompt, chunkCount = promptChunks.length) {
 		if (cancel) {
@@ -2216,7 +2214,7 @@ export function App() {
 						disabled=${!!cancel} value=${openaiPresets} onValueChange=${setOpenaiPresets}/>`}
 				<${InputBox} label="Seed (-1 = random)" type="text" inputmode="numeric"
 					readOnly=${!!cancel} value=${seed} onValueChange=${setSeed}/>
-				<${InputBox} label="Max Context Length (estimate, characters * 3.3)" type="text" inputmode="numeric"
+				<${InputBox} tooltip="Currently not accurate to the token count, it will be used as an estimate." label="Max Context Length" type="text" inputmode="numeric"
 					readOnly=${!!cancel} value=${contextLength} onValueChange=${setContextLength}/>
 				<${InputBox} label="Max Predict Tokens${endpointAPI != 0 ? ' (-1 = 1024)' : ' (-1 = infinite)'}" type="text" inputmode="numeric"
 					readOnly=${!!cancel} value=${maxPredictTokens} onValueChange=${setMaxPredictTokens}/>
@@ -2305,10 +2303,10 @@ export function App() {
 					Author's Note
 					<textarea
 					readOnly=${!!cancel}
-					placeholder="Anything written here will be injected ${anDepth} newlines from bottom into context."
-					defaultValue=${anTokens.text}
-					value=${anTokens.text}
-					onInput=${(e) => handleAnTokensChange("text", e.target.value) }
+					placeholder="Anything written here will be injected ${authorNoteDepth} newlines from bottom into context."
+					defaultValue=${authorNoteTokens.text}
+					value=${authorNoteTokens.text}
+					onInput=${(e) => handleauthorNoteTokensChange("text", e.target.value) }
 					id="an-area"/>
 					<button
 					className="textAreaSettings"
@@ -2380,18 +2378,18 @@ export function App() {
 		Prefix and suffix will be attached at the beginning or end of your author's note respectively. \\n for newlines in pre/suffix.">
 			<div className="hbox">
 				<${InputBox} label="Prefix" type="text" placeholder="[INST]"
-					readOnly=${!!cancel} value=${anTokens.prefix} onValueChange=${(value) => handleAnTokensChange("prefix", value)}/>
+					readOnly=${!!cancel} value=${authorNoteTokens.prefix} onValueChange=${(value) => handleauthorNoteTokensChange("prefix", value)}/>
 				<${InputBox} label="Suffix" type="text" placeholder="[/INST]"
-					readOnly=${!!cancel} value=${anTokens.suffix} onValueChange=${(value) => handleAnTokensChange("suffix", value)}/>
+					readOnly=${!!cancel} value=${authorNoteTokens.suffix} onValueChange=${(value) => handleauthorNoteTokensChange("suffix", value)}/>
 				<${InputBox} label="AN Injection Depth (0-N)" type="number" step="1"
-					readOnly=${!!cancel} value=${anDepth} onValueChange=${handleAnDepthChange}/>
+					readOnly=${!!cancel} value=${authorNoteDepth} onValueChange=${handleAuthorNoteDepthChange}/>
 			</div>
 			<textarea
 			readOnly=${!!cancel}
-			placeholder="Anything written here will be injected ${anDepth} newlines from bottom into context."
-			defaultValue=${anTokens.text}
-			value=${anTokens.text}
-			onInput=${(e) => handleAnTokensChange("text", e.target.value) }
+			placeholder="Anything written here will be injected ${authorNoteDepth} newlines from bottom into context."
+			defaultValue=${authorNoteTokens.text}
+			value=${authorNoteTokens.text}
+			onInput=${(e) => handleauthorNoteTokensChange("text", e.target.value) }
 			class="expanded-text-area-settings"
 			id="expanded-an-settings"/>
 		</${Modal}>

--- a/mikupad.html
+++ b/mikupad.html
@@ -1593,18 +1593,18 @@ export function App() {
 	const [lastError, setLastError] = useState(undefined);
 	const [contextLength, setContextLength] = useSessionState('contextLength', defaultPresets.contextLength);
 	const [memoryTokens, setMemoryTokens] = useSessionState('memoryTokens', defaultPresets.memoryTokens);
-  
+	
 	const [anTokens, setAnTokens] = useSessionState('anTokens', defaultPresets.anTokens);
 	const [anDepth, setAnDepth] = useSessionState('anDepth', defaultPresets.anDepth);
-  const handleAnDepthChange = (value) => {
-    if (!isNaN(value) && value >= 0) {
-        setAnDepth(value);
-    }
-    else {
-        console.warn('A/N depth smaller than 0, setting to 0.');
-        setAnDepth(0);
-    }
-  };
+	const handleAnDepthChange = (value) => {
+		if (!isNaN(value) && value >= 0) {
+				setAnDepth(value);
+		}
+		else {
+				console.warn('A/N depth smaller than 0, setting to 0.');
+				setAnDepth(0);
+		}
+	};
 	
 	const [modalState, setModalState] = useState({});
 	const toggleModal = (modalKey) => {
@@ -1645,7 +1645,6 @@ export function App() {
 		// Insert author's note N newlines up from the bottom and return
 		if (anTokens !== '') {
 			const lines = permContextPrompt.match(/.*\n?/g);
-			
 			const injIndex = lines.length-injDepth-1
 			lines.splice(injIndex,0,anTokens)
 			return lines.join('');
@@ -2262,7 +2261,7 @@ export function App() {
 					disabled=${!!cancel}
 					onClick=${() => toggleModal("memory")}>
 					
-					<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="-1 -6 8 7" xmlns="http://www.w3.org/2000/svg"><path d="M0 0 3-3C3-4 3-5 5-5L4-4 5-3 6-4C6-2 5-2 4-2L1 1C0 2-1 1 0 0"></path></svg>
+					<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="-1 -5 8 7" xmlns="http://www.w3.org/2000/svg"><path d="M0 0 3-3C3-4 3-5 5-5L4-4 5-3 6-4C6-2 5-2 4-2L1 1C0 2-1 1 0 0"></path></svg>
 					</button>
 				</label>
 				<label className="TextArea">
@@ -2278,7 +2277,7 @@ export function App() {
 					className="textAreaSettings"
 					disabled=${!!cancel}
 					onClick=${() => toggleModal("an")}>
-					<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="-1 -6 8 7" xmlns="http://www.w3.org/2000/svg"><path d="M0 0 3-3C3-4 3-5 5-5L4-4 5-3 6-4C6-2 5-2 4-2L1 1C0 2-1 1 0 0"></path></svg>
+					<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="-1 -5 8 7" xmlns="http://www.w3.org/2000/svg"><path d="M0 0 3-3C3-4 3-5 5-5L4-4 5-3 6-4C6-2 5-2 4-2L1 1C0 2-1 1 0 0"></path></svg>
 					</button>
 				</label>
 				<button

--- a/mikupad.html
+++ b/mikupad.html
@@ -222,7 +222,7 @@ html.monospace-dark #probs {
   left: 0;
   width: 100%;
   height: 100%;
-  background: rgba(0, 0, 0, 0.5); /* Dimmed background color */
+  background: rgba(0, 0, 0, 0.5);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -236,10 +236,11 @@ html.monospace-dark #probs {
 }
 
 .modal {
-  background: white;
-  padding: 20px;
-  border-radius: 8px;
-  box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
+  background: var(--color-base-50);
+  width:50%;
+  height:fit-content;
+  padding: 1em;
+  border-radius: 2px;
 }
 
 #sidebar {
@@ -2293,13 +2294,22 @@ export function App() {
 				<span className="error-text">${lastError}</span>`}
 		</div>
     <${Modal} isOpen=${modalState.memory} onClose=${() => closeModal("memory")}>
-        <p>This is the content of Modal 1!</p>
-        <Button label="Close Modal" onClick=${() => closeModal("memory")} />
+        <${InputBox} label="Server"
+					className="${isMixedContent() ? 'mixed-content' : ''}"
+					tooltip="${isMixedContent() ? 'This URL might be blocked due to mixed content. If the prediction fails, download mikupad.html and run it locally.' : ''}"
+					readOnly=${!!cancel}
+					value=${endpoint}
+					onValueChange=${setEndpoint}/>
       </${Modal}>
 
       <${Modal} isOpen=${modalState.an} onClose=${() => closeModal("an")}>
         <p>This is the content of Modal 2!</p>
         <Button label="Close Modal" onClick=${() => closeModal("an")} />
+      </${Modal}>
+      
+      <${Modal} isOpen=${modalState.context} onClose=${() => closeModal("context")}>
+        <p>This is the content of Modal 2!</p>
+        <Button label="Close Modal" onClick=${() => closeModal("context")} />
       </${Modal}>
     `;
 }


### PR DESCRIPTION
First things first, I cannibalized some of @Magiwarriorx 's code from #4 to add memory, as well as an author's note that is injected N newlines from the bottom into the context.
I apologize if this is against etiquette. This is my first time contributing to a public project.

In the process of adding these two fields, I also implemented simple modal windows to access advanced settings, though currently, that is just a bigger working area, and the injection depth for the author's note.
Since the opportunity arose with modals, I added a window to check the context being sent to the model for debugging purposes too.

![firefox_2023-12-15_12-07-30](https://github.com/lmg-anon/mikupad/assets/50079394/84c45008-1b13-4723-959c-02e1883820b5)

Feel free to let me know if there's anything you need me to fix here.