### PR TITLE
Add regenerate button

### DIFF
--- a/mikupad.html
+++ b/mikupad.html
@@ -2148,17 +2148,19 @@ export function App() {
 
 	function undo() {
 		if (!undoStack.current.length)
-			return;
+			return false;
 		redoStack.current.push(promptChunks.slice(undoStack.current.at(-1)));
 		setPromptChunks(p => p.slice(0, undoStack.current.pop()));
+		return true;
 	}
 
 	function redo() {
 		if (!redoStack.current.length)
-			return;
+			return false;
 		undoStack.current.push(promptChunks.length);
 		setPromptChunks(p => [...p, ...redoStack.current.pop()]);
 		setUndoHovered(false);
+		return true;
 	}
 
 	function undoAndPredict() {
@@ -2341,12 +2343,12 @@ export function App() {
 				break;
 			case 'false:true:false:z':
 			case 'false:false:true:z':
-				undo();
+				if (cancel || !undo()) return;
 				break;
 			case 'false:true:true:Z':
 			case 'false:true:false:y':
 			case 'false:false:true:y':
-				redo();
+				if (cancel || !redo()) return;
 				break;
 
 			default:

--- a/mikupad.html
+++ b/mikupad.html
@@ -2785,7 +2785,7 @@ export function App() {
 				</button>
 				<div className="shorts">
 				${!cancel && (!!undoStack.current.length || !!redoStack.current.length) && html`
-				<button 
+					<button 
 						title="Regenerate (Ctrl + R)"
 						disabled=${!undoStack.current.length}
 						onClick=${() => undoAndPredict()}

--- a/mikupad.html
+++ b/mikupad.html
@@ -1829,6 +1829,9 @@ export function App() {
 
 	const [authorNoteTokens, setAuthorNoteTokens] = useSessionState('authorNoteTokens', defaultPresets.authorNoteTokens);
 	const [authorNoteDepth, setAuthorNoteDepth] = useSessionState('authorNoteDepth', defaultPresets.authorNoteDepth);
+
+	const [shouldCallPredict, setShouldCallPredict] = useState(false);
+
 	const handleAuthorNoteDepthChange = (value) => {
 		setAuthorNoteDepth(!isNaN(+value) && value >= 0 ? value : 0);
 	};
@@ -2160,6 +2163,17 @@ export function App() {
 		setUndoHovered(false);
 	}
 
+
+	function undoAndPredict() {
+		if (!undoStack.current.length) return;
+		redoStack.current.push(promptChunks.slice(undoStack.current.at(-1)));
+		setPromptChunks(p => p.slice(0, undoStack.current.pop()));
+		setShouldCallPredict(true);
+	}
+
+
+	
+
 	useLayoutEffect(() => {
 		if (attachSidebar)
 			document.body.classList.add('attachSidebar');
@@ -2183,6 +2197,14 @@ export function App() {
 			break;
 		}
 	}, [theme]);
+
+
+	useEffect(() => {
+		if (shouldCallPredict) {
+			predict();
+			setShouldCallPredict(false);
+		}
+	}, [promptChunks]); 
 
 	useEffect(() => {
 		try {
@@ -2324,6 +2346,19 @@ export function App() {
 			case 'false:false:false:Escape':
 				cancel();
 				break;
+			case 'false:true:false:r':
+        	case 'false:false:true:r':
+				undoAndPredict();
+            	break;
+			case 'false:true:false:z':
+        	case 'false:false:true:z':
+				undo();
+            	break;
+			case 'false:true:false:y':
+        	case 'false:false:true:y':
+				redo();
+            	break;
+
 			default:
 				keyState.current = e;
 				return;
@@ -2343,7 +2378,7 @@ export function App() {
 			window.removeEventListener('keydown', onKeyDown);
 			window.removeEventListener('keyup', onKeyUp)
 		};
-	}, [predict, cancel]);
+	}, [predict, cancel, undoAndPredict, undo, redo]);
 
 	function onInput({ target }) {
 		setPromptChunks(oldPrompt => {
@@ -2746,15 +2781,39 @@ export function App() {
 				<${InputBox} label="Tokens" value=${tokens} readOnly/>`}
 			<div className="buttons">
 				<button
+					title="Run next prediction (Ctrl + Enter)"
 					className=${cancel ? (predictStartTokens === tokens ? 'processing' : 'completing') : ''}
 					disabled=${!!cancel || stoppingStringsError}
 					onClick=${() => predict()}>
 					Predict
 				</button>
-				<button disabled=${!cancel} onClick=${cancel}>Cancel</button>
+			
+				<button 
+					title="Cancel prediction (Escape)"
+					disabled=${!cancel}
+					onClick=${cancel}>
+					Cancel
+				</button>
+
+				<div className="shorts">
+
+				${!cancel && (!!undoStack.current.length || !!redoStack.current.length) && html`
+				<button 
+						title="Regenerate (Ctrl + R)"
+						disabled=${!undoStack.current.length}
+						onClick=${() => undoAndPredict()}
+						onMouseEnter=${() => setUndoHovered(true)}
+						onMouseLeave=${() => setUndoHovered(false)}>
+						<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24">
+						<path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10h-2c0 4.418-3.582 8-8 8s-8-3.582-8-8 3.582-8 8-8c1.847 0 3.54.634 4.899 1.684l-1.399 1.682h4.5v-4.5l-1.5 1.5C14.306 4.175 13.196 4 12 4v2z" fill="var(--color-light)"/>
+						</svg>
+					</button>`}
+				</div>
+
 				<div className="shorts">
 					${!cancel && (!!undoStack.current.length || !!redoStack.current.length) && html`
 						<button
+							title="Undo (Ctrl + Z)"
 							disabled=${!undoStack.current.length}
 							onClick=${() => undo()}
 							onMouseEnter=${() => setUndoHovered(true)}
@@ -2763,6 +2822,7 @@ export function App() {
 						</button>`}
 					${!cancel && (!!undoStack.current.length || !!redoStack.current.length) && html`
 						<button
+							title="Redo (Ctrl + Y)"
 							disabled=${!redoStack.current.length}
 							onClick=${() => redo()}>
 							<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24"><path d="M6.974 22.957c-10.957-11.421 2.326-20.865 10.384-13.309l-2.464 2.352h9.106v-8.947l-2.232 2.229c-14.794-13.203-31.51 7.051-14.794 17.675z" fill="var(--color-light)"/></svg>

--- a/mikupad.html
+++ b/mikupad.html
@@ -2343,17 +2343,17 @@ export function App() {
 				cancel();
 				break;
 			case 'false:true:false:r':
-        	case 'false:false:true:r':
+			case 'false:false:true:r':
 				undoAndPredict();
-            	break;
+				break;
 			case 'false:true:false:z':
-        	case 'false:false:true:z':
+			case 'false:false:true:z':
 				undo();
-            	break;
+				break;
 			case 'false:true:false:y':
-        	case 'false:false:true:y':
+			case 'false:false:true:y':
 				redo();
-            	break;
+				break;
 
 			default:
 				keyState.current = e;

--- a/mikupad.html
+++ b/mikupad.html
@@ -2163,16 +2163,12 @@ export function App() {
 		setUndoHovered(false);
 	}
 
-
 	function undoAndPredict() {
 		if (!undoStack.current.length) return;
 		redoStack.current.push(promptChunks.slice(undoStack.current.at(-1)));
 		setPromptChunks(p => p.slice(0, undoStack.current.pop()));
 		setShouldCallPredict(true);
 	}
-
-
-	
 
 	useLayoutEffect(() => {
 		if (attachSidebar)
@@ -2787,16 +2783,13 @@ export function App() {
 					onClick=${() => predict()}>
 					Predict
 				</button>
-			
 				<button 
 					title="Cancel prediction (Escape)"
 					disabled=${!cancel}
 					onClick=${cancel}>
 					Cancel
 				</button>
-
 				<div className="shorts">
-
 				${!cancel && (!!undoStack.current.length || !!redoStack.current.length) && html`
 				<button 
 						title="Regenerate (Ctrl + R)"

--- a/mikupad.html
+++ b/mikupad.html
@@ -2374,7 +2374,7 @@ export function App() {
 			window.removeEventListener('keydown', onKeyDown);
 			window.removeEventListener('keyup', onKeyUp)
 		};
-	}, [predict, cancel, undoAndPredict, undo, redo]);
+	}, [predict, cancel]);
 
 	function onInput({ target }) {
 		setPromptChunks(oldPrompt => {

--- a/mikupad.html
+++ b/mikupad.html
@@ -2350,6 +2350,7 @@ export function App() {
 			case 'false:false:true:z':
 				undo();
 				break;
+			case 'false:true:true:Z':
 			case 'false:true:false:y':
 			case 'false:false:true:y':
 				redo();

--- a/mikupad.html
+++ b/mikupad.html
@@ -2164,10 +2164,10 @@ export function App() {
 	function undoAndPredict() {
 		if (!undoStack.current.length) return;
 		const lastGenerationChunks = undoStack.current.pop();
-    	const newPromptChunks = promptChunks.slice(0, lastGenerationChunks);
+		const newPromptChunks = promptChunks.slice(0, lastGenerationChunks);
    		setPromptChunks(newPromptChunks);
 
-	    predict(joinPrompt(newPromptChunks), newPromptChunks.length);
+		predict(joinPrompt(newPromptChunks), newPromptChunks.length);
 	}
 
 	useLayoutEffect(() => {

--- a/mikupad.html
+++ b/mikupad.html
@@ -1830,8 +1830,6 @@ export function App() {
 	const [authorNoteTokens, setAuthorNoteTokens] = useSessionState('authorNoteTokens', defaultPresets.authorNoteTokens);
 	const [authorNoteDepth, setAuthorNoteDepth] = useSessionState('authorNoteDepth', defaultPresets.authorNoteDepth);
 
-	const [shouldCallPredict, setShouldCallPredict] = useState(false);
-
 	const handleAuthorNoteDepthChange = (value) => {
 		setAuthorNoteDepth(!isNaN(+value) && value >= 0 ? value : 0);
 	};
@@ -2165,9 +2163,11 @@ export function App() {
 
 	function undoAndPredict() {
 		if (!undoStack.current.length) return;
-		redoStack.current.push(promptChunks.slice(undoStack.current.at(-1)));
-		setPromptChunks(p => p.slice(0, undoStack.current.pop()));
-		setShouldCallPredict(true);
+		const lastGenerationChunks = undoStack.current.pop();
+    	const newPromptChunks = promptChunks.slice(0, lastGenerationChunks);
+   		setPromptChunks(newPromptChunks);
+
+	    predict(joinPrompt(newPromptChunks), newPromptChunks.length);
 	}
 
 	useLayoutEffect(() => {
@@ -2194,13 +2194,6 @@ export function App() {
 		}
 	}, [theme]);
 
-
-	useEffect(() => {
-		if (shouldCallPredict) {
-			predict();
-			setShouldCallPredict(false);
-		}
-	}, [promptChunks]); 
 
 	useEffect(() => {
 		try {
@@ -2798,9 +2791,7 @@ export function App() {
 						onClick=${() => undoAndPredict()}
 						onMouseEnter=${() => setUndoHovered(true)}
 						onMouseLeave=${() => setUndoHovered(false)}>
-						<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24">
-						<path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10h-2c0 4.418-3.582 8-8 8s-8-3.582-8-8 3.582-8 8-8c1.847 0 3.54.634 4.899 1.684l-1.399 1.682h4.5v-4.5l-1.5 1.5C14.306 4.175 13.196 4 12 4v2z" fill="var(--color-light)"/>
-						</svg>
+						<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 40.499 40.5"><path d="M39.622,21.746l-6.749,6.75c-0.562,0.562-1.326,0.879-2.122,0.879s-1.56-0.316-2.121-0.879l-6.75-6.75		c-1.171-1.171-1.171-3.071,0-4.242c1.171-1.172,3.071-1.172,4.242,0l1.832,1.832C27.486,13.697,22.758,9.25,17,9.25		c-6.064,0-11,4.935-11,11c0,6.064,4.936,11,11,11c1.657,0,3,1.343,3,3s-1.343,3-3,3c-9.373,0-17-7.626-17-17s7.627-17,17-17		c8.936,0,16.266,6.933,16.936,15.698l1.442-1.444c1.172-1.172,3.072-1.172,4.242,0C40.792,18.674,40.792,20.574,39.622,21.746z" fill="var(--color-light)"/></svg>
 					</button>`}
 				</div>
 


### PR DESCRIPTION
A regenerate button discards the previous generation (undo) and starts a new one. If no undo operation is possible, regenerate is not shown or enabled.

It's pretty useful when the user is not happy with the last generation and wishes to redo it.

The button is small with a round arrow:

![2024-01-20 12_49_09-Regenerate (Ctrl + R)](https://github.com/lmg-anon/mikupad/assets/136095681/bca1b7a0-ae2c-4620-8d65-bc382219da25)

Also added a Ctrl + R shortcut for it, and added shortcuts for undo and redo as well (Ctrl + Z, Ctrl + Y) which are pretty standard.