### PR TITLE
Redo button fix

### DIFF
--- a/mikupad.html
+++ b/mikupad.html
@@ -2167,9 +2167,8 @@ export function App() {
 		if (!undoStack.current.length) return;
 		const lastGenerationChunks = undoStack.current.pop();
 		const newPromptChunks = promptChunks.slice(0, lastGenerationChunks);
-   		setPromptChunks(newPromptChunks);
-
-		predict(joinPrompt(newPromptChunks), newPromptChunks.length);
+		setPromptChunks(newPromptChunks);
+		predict(modifiedPrompt, newPromptChunks.length);
 	}
 
 	useLayoutEffect(() => {

--- a/mikupad.html
+++ b/mikupad.html
@@ -2165,11 +2165,26 @@ export function App() {
 
 	function undoAndPredict() {
 		if (!undoStack.current.length) return;
-		const lastGenerationChunks = undoStack.current.pop();
-		const newPromptChunks = promptChunks.slice(0, lastGenerationChunks);
-		setPromptChunks(newPromptChunks);
-		predict(modifiedPrompt, newPromptChunks.length);
+		// Trigger undo operation to update promptChunks
+		const didUndo = undo();
+		// If undo succeeded, set a flag that will trigger prediction in useEffect
+		if (didUndo) {
+			setTriggerPredict(true);
+		}
 	}
+	
+	// State to trigger predict after undo
+	const [triggerPredict, setTriggerPredict] = useState(false);
+	
+	// useEffect to call predict after promptChunks has been updated by undo
+	useEffect(() => {
+		if (triggerPredict) {
+			// Call predict with the modified prompt
+			predict();
+			// Reset the trigger
+			setTriggerPredict(false);
+		}
+	}, [triggerPredict, predict]);
 
 	useLayoutEffect(() => {
 		if (attachSidebar)

--- a/mikupad.html
+++ b/mikupad.html
@@ -2165,23 +2165,17 @@ export function App() {
 
 	function undoAndPredict() {
 		if (!undoStack.current.length) return;
-		// Trigger undo operation to update promptChunks
 		const didUndo = undo();
-		// If undo succeeded, set a flag that will trigger prediction in useEffect
 		if (didUndo) {
 			setTriggerPredict(true);
 		}
 	}
 	
-	// State to trigger predict after undo
 	const [triggerPredict, setTriggerPredict] = useState(false);
 	
-	// useEffect to call predict after promptChunks has been updated by undo
 	useEffect(() => {
 		if (triggerPredict) {
-			// Call predict with the modified prompt
 			predict();
-			// Reset the trigger
 			setTriggerPredict(false);
 		}
 	}, [triggerPredict, predict]);


### PR DESCRIPTION
The redo button was not attaching the memory to the prompt when sending through ooba's text-generation-webui api. I asked chatGPT to fix it and this seemed to work, but I'm not sure if it's the ideal solution.