### PR TITLE
Preserve spaces when replacing token

### DIFF
--- a/mikupad.html
+++ b/mikupad.html
@@ -2485,11 +2485,26 @@ export function App() {
 			...promptChunks.slice(0, i),
 			{
 				...promptChunks[i],
-				content: tok,
+				content: adjustTokenSpacing(promptChunks[i].content, tok),
 			},
 		];
 		setPromptChunks(newPrompt);
 		predict(joinPrompt(newPrompt), newPrompt.length);
+	}
+
+	function adjustTokenSpacing(tokenToReplace, newToken) {
+		let adjustedToken = newToken;
+
+		if (tokenToReplace.startsWith(' ') && !isEnglishPunctuationMark(newToken)) {
+			adjustedToken = ' ' + adjustedToken;
+		}
+
+		return adjustedToken;
+	}
+
+	function isEnglishPunctuationMark(token) {
+		const punctuationMarks = ['\'', ',', '.', '!', '?', ':', ';', '-', '"', ')', ']', '}', ')', '>', '/', '_', '|'];
+		return punctuationMarks.some(mark => token.startsWith(mark));
 	}
 
 	function switchEndpointAPI(value) {


### PR DESCRIPTION
When choosing another token from the probabilities, the token's text (content) that may have had a space before it to indicate a new word was not preserved. So for example, if we had

The maid cafe was located in Tokyo

And I wanted to replace "located" (assuming it was its own token) with "situated", what happens is as follows:

 - The text for located is actually " located"
 - However, when replaced, we put "situated", no starting space. This means it becomes

The maid cafe wassituated in Tokyo

What the updated code does is:

1. Check if the token that will be replaced at position i starts with a space, If not, we do nothing, as we're replacing a token that was part of a word (e.g. joi-ned if we replace the token 'ned')
2. Adds to the new token a starting space, unless the new token is an English punctuation mark. For example, if we replace 'went' in 'the man went', if the token is the apostrophe ' (e.g. the man's luggage) then there will be no space prepended.