### PR TITLE
After generation set cursor end

### DIFF
--- a/mikupad.html
+++ b/mikupad.html
@@ -1788,6 +1788,7 @@ export function App() {
 	const [attachSidebar, setAttachSidebar] = usePersistentState('attachSidebar', false);
 	const [showProbsMode, setShowProbsMode] = usePersistentState('showProbsMode', 0);
 	const [highlightGenTokens, setHighlightGenTokens] = usePersistentState('highlightGenTokens', true);
+	const [preserveCursorPosition, setPreserveCursorPosition] = usePersistentState('preserveCursorPosition', true);
 	const [darkMode, _] = usePersistentState('darkMode', false); // legacy
 	const [theme, setTheme] = usePersistentState('theme', darkMode ? 1 : 0);
 	const [endpoint, setEndpoint] = useSessionState('endpoint', defaultPresets.endpoint);
@@ -2248,6 +2249,12 @@ export function App() {
 		if (elem.value === promptText) {
 			return;
 		} else if (elem.value.length && promptText.startsWith(elem.value)) {
+			const isTextSelected = elem.selectionStart !== elem.selectionEnd;
+			if (!isTextSelected && !preserveCursorPosition)
+			{
+				elem.value = promptText;
+				return;
+			}
 			const oldHeight = elem.scrollHeight;
 			const atBottom = (elem.scrollTarget ?? elem.scrollTop) + elem.clientHeight + 1 > oldHeight;
 			const oldLen = elem.value.length;
@@ -2831,6 +2838,8 @@ export function App() {
 					value=${attachSidebar} onValueChange=${setAttachSidebar}/>
 				<${Checkbox} label="Highlight generated tokens"
 					value=${highlightGenTokens} onValueChange=${setHighlightGenTokens}/>
+					<${Checkbox} label="Preserve cursor position after prediction"
+					value=${preserveCursorPosition} onValueChange=${setPreserveCursorPosition}/>
 				<${SelectBox}
 					label="Token probabilities"
 					value=${showProbsMode}

--- a/mikupad.html
+++ b/mikupad.html
@@ -2250,15 +2250,14 @@ export function App() {
 			return;
 		} else if (elem.value.length && promptText.startsWith(elem.value)) {
 			const isTextSelected = elem.selectionStart !== elem.selectionEnd;
-			if (!isTextSelected && !preserveCursorPosition)
-			{
-				elem.value = promptText;
-				return;
-			}
 			const oldHeight = elem.scrollHeight;
 			const atBottom = (elem.scrollTarget ?? elem.scrollTop) + elem.clientHeight + 1 > oldHeight;
 			const oldLen = elem.value.length;
-			elem.setRangeText(promptText.slice(oldLen), oldLen, oldLen, 'preserve');
+			if (!isTextSelected && !preserveCursorPosition) {
+				elem.value = promptText;
+			} else {
+				elem.setRangeText(promptText.slice(oldLen), oldLen, oldLen, 'preserve');
+			}
 			const newHeight = elem.scrollHeight;
 			if (atBottom && oldHeight !== newHeight) {
 				elem.scrollTarget = newHeight - elem.clientHeight;

--- a/mikupad.html
+++ b/mikupad.html
@@ -2838,7 +2838,7 @@ export function App() {
 					value=${attachSidebar} onValueChange=${setAttachSidebar}/>
 				<${Checkbox} label="Highlight generated tokens"
 					value=${highlightGenTokens} onValueChange=${setHighlightGenTokens}/>
-					<${Checkbox} label="Preserve cursor position after prediction"
+				<${Checkbox} label="Preserve cursor position after prediction"
 					value=${preserveCursorPosition} onValueChange=${setPreserveCursorPosition}/>
 				<${SelectBox}
 					label="Token probabilities"


### PR DESCRIPTION
Added the option (by default enabled to preserve the current behavior) to preserve the position of the cursor after a prediction, or move it to the end of the new text.

The use for this would be to allow the user to start writing right away after the generation is done.

It may have been interesting to add a space after the last word generated by the AI, but I'm not sure it would always have the desired effect, so it merely overrides the default behavior of preserving the cursor with no further modifications. If there's a selection, it will be preserved, however.