### PR TITLE
Feature/token bias

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,16 @@
 
 ## Features
 
-* **Multiple Backends**: Multiple backends are supported, namely **llamacpp**, **legacy oobabooga**, **koboldcpp**, and any other backend with **openai-compatible** APIs. You can seamlessly switch between these backends to get different text generation experiences.
-  * As of 10/10/2023 (commit [4aabff3](https://github.com/oobabooga/text-generation-webui/commit/4aabff3728e00ee2a4afa5e6ee8079bab0523dbd)), **oobabooga** uses a openai-compatible API, so make sure you use it instead of the legacy API.
+* **Multiple Backends**: Multiple backends are supported, namely **llama.cpp**, **koboldcpp**, and any other backend with **OpenAI compatible** APIs. You can seamlessly switch between these backends to get different text generation experiences.
 * **Session Persistence**: Your text generation sessions are automatically saved and restored. This means you can work on your text in multiple sittings and continue right where you left off. Import and export your sessions to share your creative work or switch devices effortlessly.
+* **Persistent Context**:
+  * **Memory**: Seamlessly inject a text of your choice at the beginning of the context.
+  * **Author's Note**: Seamlessly inject a text of your choice at the end of the context, with adjustable depth.
+  * **World Info**: Dynamically include extra information in the context, triggered by specific keywords.
 * **Prediction Undo/Redo**: It's possible to undo and redo predictions, making it easy to experiment and fine-tune your generated text until it's just right.
 * **Token Probability** *(llamacpp/openai backend)*: When you hover over a token in the generated text, a list will show at most 10 tokens with their probabilities. This information can be a valuable aid in refining your text. Moreover, you can click on another token's probability to restart text generation from that point.
   * If you're using oobabooga, make sure to use an _HF sampler for this feature to function properly.
-* **Dark Mode Switch**: Customize your environment to suit your preferences with a convenient dark mode switch.
+* **Themes**: Customize your environment by choosing from a variety of themes.
 
 ## Getting Started
 

--- a/mikupad.html
+++ b/mikupad.html
@@ -3622,10 +3622,11 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 								value=${logitBiasInput.power} 
 								id="logitBiasPower"/>
 						</div>
-						<${InputBox} label="Token (string or /IDs/)" type="text"
+						<${InputBox} label="Token" type="text"
 							tooltip="Currently, only the first token of multi-token strings will be biased."
 							readOnly=${!!cancel}
 							value=${logitBiasInput.string}
+							placeholder="String or /ID,.../"
 							onValueChange=${() => {} }
 							onInput=${(e) => {handleLogitBiasInput("string",e.target.value)} }
 							children=${ html`
@@ -3784,10 +3785,11 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 								value=${logitBiasInput.power} 
 								id="logitBiasPower"/>
 						</div>
-						<${InputBox} label="Token (string or /IDs/)" type="text"
+						<${InputBox} label="Token" type="text"
 							tooltip="Currently, only the first token of multi-token strings will be biased."
 							readOnly=${!!cancel}
 							value=${logitBiasInput.string}
+							placeholder="String or /ID,.../"
 							onValueChange=${() => {} }
 							onInput=${(e) => {handleLogitBiasInput("string",e.target.value)} }
 							/>
@@ -3812,10 +3814,11 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 								onValueChange=${(value) => {handleBiasTempChange(key,"power", index, value)} }
 								value=${bias.power}/>
 
-							<${InputBox} label="Token (string or /IDs/)" type="text"
+							<${InputBox} label="Token" type="text"
 								tooltip="Currently, only the first token of multi-token strings will be biased."
 								readOnly=${!!cancel}
 								value=${bias.value}
+								placeholder="String or /ID,.../"
 								onValueChange=${() => {} }
 								onInput=${(e) => handleBiasTempChange(key,"value", index, e.target.value) }
 								/>

--- a/mikupad.html
+++ b/mikupad.html
@@ -1194,7 +1194,6 @@ async function llamaCppDetokenize({ endpoint, endpointAPIKey, proxyEndpoint, sig
 	if (!res.ok)
 		throw new Error(`HTTP ${res.status}`);
 	const { content } = await res.json();
-	//console.log("detokenized","." + content + ".")
 	return content
 }
 
@@ -1248,7 +1247,6 @@ async function koboldCppTokenCount({ endpoint, proxyEndpoint, signal, ...options
 }
 
 async function koboldCppTokenize({ endpoint, proxyEndpoint, signal, ...options }) {
-	//console.log("kcpp",options.content)
 	const res = await fetch(new URL('/api/extra/tokencount', endpoint), {
 		method: 'POST',
 		headers: {
@@ -1263,9 +1261,7 @@ async function koboldCppTokenize({ endpoint, proxyEndpoint, signal, ...options }
 	if (!res.ok)
 		throw new Error(`HTTP ${res.status}`);
 	const { ids } = await res.json();
-	//console.log(ids)
 	ids.shift() // kobold automatically adds a token, so we need to remove it
-	//console.log("shift",ids)
 	return {ids:ids,str:""};
 	
 }
@@ -2348,6 +2344,10 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 	const [logitBiasTemp, setLogitBiasTemp] = useState([]);
 	const [logitBiasSorted, setLogitBiasSorted] = useState([]);
 	const [logitBiasInput, setLogitBiasInput] = useState({power:"0",string:""});
+	const [contextLength, setContextLength] = useSessionState('contextLength', defaultPresets.contextLength);
+	const [memoryTokens, setMemoryTokens] = useSessionState('memoryTokens', defaultPresets.memoryTokens);
+	const [authorNoteTokens, setAuthorNoteTokens] = useSessionState('authorNoteTokens', defaultPresets.authorNoteTokens);
+	const [authorNoteDepth, setAuthorNoteDepth] = useSessionState('authorNoteDepth', defaultPresets.authorNoteDepth);
 
 	const handleLogitBiasInput = (key,value) => {
 		setLogitBiasInput((prevLogitBiasInput) => {
@@ -2361,7 +2361,6 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 
 	const logitBiasAdd = async (biasPower="",biasString="",origValue="") => {
 		setLastError(undefined)
-		//console.log("values",biasPower,biasString,origValue)
 		// abort if no input or power is NaN
 		if(!biasString) {return}
 		if (isNaN(+biasPower) || biasPower == "") { 
@@ -2390,13 +2389,10 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 		}
 		// if overwriting the string value of an entry, delete the original one
 		if (origValue && origValue != biasString) {
-			console.log("delete orig",origValue)
 			delete modBias[origValue]
 		}
 
 		const ac = new AbortController();
-		//console.log("input","."+biasString+".",biasPower)
-		//console.log("replace","."+biasString.replace(/\\n/g, '\n')+".")
 		try {
 			// if the string is a comma separated list of numbers wrapped in /
 			var tokens
@@ -2448,12 +2444,11 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 				Array.isArray(tokens.str) ? "'"+tokens.str.join("|")+"'"
 					: "'"+biasString+"'",
 				"by power",biasPower)
-			//console.log("shift",[ ...tokens.ids ],[ ...tokens.ids ].shift())
 			await setLogitBias((prevLogitBias) => ({
 				...prevLogitBias,
 				bias: {
 					...modBias,
-					[biasString]: { // REMOVED STRING() HERE IF SHIT BREAKS
+					[biasString]: { // removed Number() here
 						ids: [ ...tokens.ids ],
 						strings: [ ...tokens.str ],
 						power: biasPower
@@ -2490,7 +2485,6 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 			const power = logitBias.bias[entry].power < -99 ? false : Number(logitBias.bias[entry].power) / 10;
 			param.push( [ Number(logitBias.bias[entry].ids[0]), power ] );
 		})
-		//console.log("params",param)
 		setLogitBiasParam(param)
 	};
 	const koboldCppSetLogitBiasParams = () => {
@@ -2499,7 +2493,6 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 			// no manip needed here. range is documented to be 100 to -100
 			param[Number(logitBias.bias[entry].ids[0])] = Number(logitBias.bias[entry].power)
 		})
-		//console.log("params",param)
 		setLogitBiasParam(param)
 	};
 	const updateLogitBiasParam = useMemo(() => {
@@ -2531,7 +2524,6 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 
 
 	const handleBiasTempChange = (posneg, key, index, value) => {
-		// console.log("up temp",key, value)
 		setLogitBiasTemp((prevLogitBiasTemp) => {
 			const rest = { ...prevLogitBiasTemp };
 			const updatedTemp = [ ...prevLogitBiasTemp[posneg] ];
@@ -2566,18 +2558,8 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 		setLogitBiasSorted(resultArray);
 	}, [logitBias]);
 
-	// const debugLogitBias = useMemo(() => {
-	// 	console.log("logit bias",logitBias)
-	// }, [logitBias]);
 
-
-
-	const [contextLength, setContextLength] = useSessionState('contextLength', defaultPresets.contextLength);
-	const [memoryTokens, setMemoryTokens] = useSessionState('memoryTokens', defaultPresets.memoryTokens);
-
-	const [authorNoteTokens, setAuthorNoteTokens] = useSessionState('authorNoteTokens', defaultPresets.authorNoteTokens);
-	const [authorNoteDepth, setAuthorNoteDepth] = useSessionState('authorNoteDepth', defaultPresets.authorNoteDepth);
-
+	// AN and Memory
 	const handleAuthorNoteDepthChange = (value) => {
 		setAuthorNoteDepth(!isNaN(+value) && value >= 0 ? value : 0);
 	};
@@ -2845,8 +2827,6 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 			promptArea.current.scrollTarget = undefined;
 			useScrollSmoothing.current = true;
 
-			console.log("AAAAAAAAAAAAAAAAAAAA",logitBiasParam)
-			//console.log(Object.keys(logitBias.bias).length, Object.keys(logitBias.bias).length > 0)
 			for await (const chunk of completion({
 				endpoint,
 				endpointAPI,

--- a/mikupad.html
+++ b/mikupad.html
@@ -1168,7 +1168,7 @@ async function llamaCppDetokenize({ endpoint, endpointAPIKey, signal, ...options
 	if (!res.ok)
 		throw new Error(`HTTP ${res.status}`);
 	const { content } = await res.json();
-	console.log("detokenized","." + content + ".")
+	//console.log("detokenized","." + content + ".")
 	return content
 }
 
@@ -1324,6 +1324,7 @@ async function koboldCppTokenCount({ endpoint, signal, ...options }) {
 }
 
 async function koboldCppTokenize({ endpoint, signal, ...options }) {
+	// console.log("kcpp",options.content)
 	const res = await fetch(new URL('/api/extra/tokencount', endpoint), {
 		method: 'POST',
 		headers: {
@@ -1337,8 +1338,10 @@ async function koboldCppTokenize({ endpoint, signal, ...options }) {
 	if (!res.ok)
 		throw new Error(`HTTP ${res.status}`);
 	const { ids } = await res.json();
-	return {ids:ids,str:"Not implemented in KCCP"};
-	// that can't be right, surely there's a detokenize endpoint
+	ids.shift() // kobold automatically adds a token, so we need to remove it
+	// console.log("shift",ids)
+	return {ids:ids,str:""};
+	
 }
 
 function koboldCppConvertOptions(options) {
@@ -2159,31 +2162,36 @@ export function App() {
 	const [logitBiasInput, setLogitBiasInput] = useState({power:"2",string:"string"});
 
 	const handleLogitBiasInput = (key,value) => {
-		console.log(key, value)
+		// console.log(key, value)
 		setLogitBiasInput((prevLogitBiasInput) => {
 			return {
 				...prevLogitBiasInput,
 				[key]: value
 			}
 		});
-		console.log(logitBiasInput)
+		// console.log(logitBiasInput)
 
 	}
 
-	const logitBiasAdd = async (biasPower="",biasTokens="",origValue="") => {
-		console.log("values",biasPower,biasTokens,origValue)
-		console.log(logitBiasInput)
+	const logitBiasAdd = async (biasPower="",biasString="",origValue="") => {
+		setLastError(undefined)
+		console.log("values",biasPower,biasString,origValue)
+		// console.log(logitBiasInput)
 		// abort if no input or power is NaN
-		if(!biasTokens) {return}
-		if (isNaN(+biasPower)) { return }
+		if(!biasString) {return}
+		console.log("power",biasPower)
+		if (isNaN(+biasPower) || biasPower == "") { 
+			setLastError("Error: Bias is NaN")
+			return
+		}
 
 		const modBias = logitBias.bias;	
 		
 		// delete entry if power 0 or empty
-		if (biasPower == 0 || biasPower == "" && logitBias[biasTokens]) {
-			console.log("delete",biasTokens)
+		if (biasPower == 0 && logitBias[biasString]) {
+			console.log("delete",biasString)
 			setLogitBias((prevLogitBias) => {
-				delete modBias[biasTokens]
+				delete modBias[biasString]
 				return { 
 					...prevLogitBias,
 					bias: {
@@ -2194,21 +2202,20 @@ export function App() {
 			return
 		}
 		// if overwriting the string value of an entry, delete the original one
-		if (origValue && origValue != biasTokens) {
+		if (origValue && origValue != biasString) {
 			console.log("delete orig",origValue)
 			delete modBias[origValue]
 		}
 
 		const ac = new AbortController();
-		console.log("input","."+biasTokens+".",biasPower)
+		// console.log("input","."+biasString+".",biasPower)
 
-		setLastError(undefined)
 		try {
 			const tokens = await getTokens({
 				endpoint,
 				endpointAPI,
 				...(endpointAPI == 3 || endpointAPI == 0 ? { endpointAPIKey } : {}),
-				content: `${biasTokens}`,
+				content: `${biasString}`,
 				signal: ac.signal,
 			})
 			console.log("add",tokens)
@@ -2216,10 +2223,10 @@ export function App() {
 				...prevLogitBias,
 				bias: {
 					...modBias,
-					[biasTokens]: {
+					[biasString]: {
 						ids: [ ...tokens.ids ],
 						strings: [ ...tokens.str ],
-						power: biasPower
+						power: Number(biasPower)
 					}
 				}
 			}));
@@ -2240,32 +2247,56 @@ export function App() {
 			return
 		}
 	};
-
-	const updateLogitBiasParam = useEffect(() => {
-		console.log("endpoint",endpointAPI)
-		if (endpoint == 0) {
-			// const param = logitBias.bias.map((entry, index) => {
-			// 	return [Number(entry.ids),Number(entry.power)];
-			// })	
-			
-
+	const logitBiasRetokenize = async () => { // I don't understand why this doesn't work.
+		for (const key in logitBias.bias) {
+			console.log("retok",key,logitBias.bias[key])
+			await logitBiasAdd(Number(logitBias.bias[key].power),key);
+			await new Promise(r => setTimeout(r, 200));
 		}
+	};
+
+
+
+	const llamaCppSetLogitBiasParams = () => {
 		const param = [];
+		// TODO grab multi-token strings here and put them in a separate state variable
 		Object.keys(logitBias.bias).forEach(entry => {
-			console.log("help me",logitBias.bias[entry])
+			// console.log("help me",logitBias.bias[entry])
 			param.push([Number(logitBias.bias[entry].ids[0]),Number(logitBias.bias[entry].power)]);
 		})
 		console.log("params",param)
 		setLogitBiasParam(param)
-
+	};
+	const koboldCppSetLogitBiasParams = () => {
+		const param = {};
+		Object.keys(logitBias.bias).forEach(entry => {
+			param[Number(logitBias.bias[entry].ids[0])] = Number(logitBias.bias[entry].power)
+			// console.log(logitBias.bias[entry].ids[0])
+			// console.log("help me",param)
+		})
+		console.log("params",param)
+		setLogitBiasParam(param)
+	};
+	const updateLogitBiasParam = useEffect(() => {
+		// console.log("endpoint",endpointAPI)
+		switch (endpointAPI) {
+			case 0:
+				llamaCppSetLogitBiasParams()
+				break;
+			
+			case 2:
+				koboldCppSetLogitBiasParams()
+				break;
+		}
 	}, [logitBias, endpointAPI]);
 
 
-	function updateLogitBiasTemp() {
+	const updateLogitBiasTemp = () => {
 		const tempArray = logitBiasSorted.map((string, index) =>  ({
 			value: string,
 			valueBack: string,
 			strings: logitBias.bias[string].strings,
+			tokens: logitBias.bias[string].ids.length,
 			power: logitBias.bias[string].power
 		}));
 		setLogitBiasTemp({
@@ -2279,7 +2310,7 @@ export function App() {
 	},[logitBiasSorted]);
 
 	const handleBiasTempChange = (posneg, key, index, value) => {
-		console.log("up temp",key, value)
+		// console.log("up temp",key, value)
 		setLogitBiasTemp((prevLogitBiasTemp) => {
 			const rest = { ...prevLogitBiasTemp };
 			const updatedTemp = [ ...prevLogitBiasTemp[posneg] ];
@@ -3228,9 +3259,8 @@ export function App() {
 						<div class="small-inputBox">
 							<${InputBox} label="Bias" classList="logitBiasPower-container"
 								type="enumber"  max=100 min=-100 step=1
-								pattern='^-?[0-9]*$'
 								readOnly=${!!cancel}
-								onValueChange=${(value) => { console.log("aa",value);handleLogitBiasInput("power",value)} }
+								onValueChange=${(value) => { handleLogitBiasInput("power",value)} }
 								value=${logitBiasInput.power} 
 								id="logitBiasPower"/>
 						</div>
@@ -3406,13 +3436,39 @@ export function App() {
 
 		<${Modal} isOpen=${modalState.bias} onClose=${() => {updateLogitBiasTemp(); closeModal("bias")}}
 		title="Logit Bias"
-		description="Make certain tokens more or less likely to be generated. Values range from -100 to 100.
-		-100 is a ban, +100 means the model will only generate that token. 0 is neutral.
+		description="Make certain tokens more or less likely to be generated. 
 		Currently only works on the first token of multi-token phrases/words.
 		
 		Different models might tokenize words differently. Always Re-Tokenize when switching models!">
 		${modalState.bias 
 			&& html`
+					<div className="hbox-flex logitBiasContainer">
+						<button style=${{"margin-top":"auto"}}
+							id="retokenize" disabled=${!!cancel}
+							onClick=${logitBiasRetokenize}>
+								Retokenize
+						</button>
+						<div class="small-inputBox">
+							<${InputBox} label="Bias" classList="logitBiasPower-container"
+								type="enumber"  max=100 min=-100 step=1
+								readOnly=${!!cancel}
+								onValueChange=${(value) => { handleLogitBiasInput("power",value)} }
+								value=${logitBiasInput.power} 
+								id="logitBiasPower"/>
+						</div>
+						<label className="InputBox">
+							Token
+						<input label="Token" type="text" id="logitBiasTokens-container"
+							readOnly=${!!cancel} 
+							onInput=${(e) => {logitBiasSearch(e.target.value); handleLogitBiasInput("string",e.target.value)} }
+							value=${logitBiasInput.string} 
+							id="logitBiasTokens"/>
+						</label>
+						<button disabled=${!!cancel} class="hbox-button" onClick=${() => logitBiasAdd(logitBiasInput.power,logitBiasInput.string)}>+</button>
+					</div>
+			${!!lastError && html`
+				<div style=${{"margin":"8px auto"}} className="error-text">${lastError}</div>`}
+			<hr style=${{"width":"95%","margin":"8px auto"}} />
 			<div class="lb-modal-biasList" >
 				${ Object.keys(logitBiasTemp).map((key) => {
 					return html`
@@ -3426,21 +3482,21 @@ export function App() {
 								type="enumber" inputmode="numeric" max=100 min=-100 step=1
 								id="lb-modal-power-${index}"
 								readOnly=${!!cancel}
-								onValueChange=${(value) => handleBiasTempChange(key,"power", index, value) }
+								onValueChange=${(value) => {console.log(value); handleBiasTempChange(key,"power", index, value)} }
 								value=${bias.power}/>
-								<!-- I'm going to lose my mind, why does this ONLY take numbers -->
-								
-								
 							<label className="InputBox">
 								Token
-								<input label="Token" type="text" class="lb-modal-stringInput"
+								<input label="String" type="text" class="lb-modal-stringInput"
 									readOnly=${!!cancel} 
 									onInput=${(e) => handleBiasTempChange(key,"value", index, e.target.value) }
 									value=${bias.value}
 									id="lb-modal-input-${index}"/>
 							</label>
 							<div class="lb-modal-tokenized">
-								[${bias.strings.join("|")}] (${bias.strings.length})
+								${endpointAPI == 0
+									? "["+bias.strings.join("|")+"] "
+									: "["+bias.value+"]" } (${bias.tokens} tokens)
+								
 							</div>
 							<button disabled=${!!cancel} class="hbox-button lb-modal-button" onClick=${() => logitBiasAdd(bias.power, bias.value, bias.valueBack)}>+</button>
 							<hr/>

--- a/mikupad.html
+++ b/mikupad.html
@@ -2202,6 +2202,12 @@ export function App() {
 			setLastError("Error: Bias is NaN")
 			return
 		}
+		//biasPower = Number(biasPower)
+
+
+		//biasPower = (endpointAPI == 0 && Number(biasPower) < -99) ? false : biasPower;
+		// don't know what format kobold wants for ban
+
 
 		const modBias = logitBias.bias;	
 		
@@ -2244,7 +2250,7 @@ export function App() {
 					[biasString]: {
 						ids: [ ...tokens.ids ],
 						strings: [ ...tokens.str ],
-						power: Number(biasPower)
+						power: biasPower
 					}
 				}
 			}));
@@ -2279,8 +2285,9 @@ export function App() {
 		const param = [];
 		// TODO grab multi-token strings here and put them in a separate state variable
 		Object.keys(logitBias.bias).forEach(entry => {
-			// console.log("help me",logitBias.bias[entry])
-			param.push([Number(logitBias.bias[entry].ids[0]),Number(logitBias.bias[entry].power)]);
+			// set banned tokens to false
+			const power = logitBias.bias[entry].power < -99 ? false : logitBias.bias[entry].power;
+			param.push([Number(logitBias.bias[entry].ids[0]),power]);
 		})
 		console.log("params",param)
 		setLogitBiasParam(param)
@@ -2290,7 +2297,6 @@ export function App() {
 		Object.keys(logitBias.bias).forEach(entry => {
 			param[Number(logitBias.bias[entry].ids[0])] = Number(logitBias.bias[entry].power)
 			// console.log(logitBias.bias[entry].ids[0])
-			// console.log("help me",param)
 		})
 		console.log("params",param)
 		setLogitBiasParam(param)

--- a/mikupad.html
+++ b/mikupad.html
@@ -568,18 +568,19 @@ html.monospace-dark .lb-search-entry {
 	padding-right: .75em;
 }
 .lb-modal-grid-row  {
-  display: grid;
-  grid-template-columns: 4em 1fr min-content;
-  grid-template-rows: min-content min-content min-content;
-  gap: 0 8px;
-  grid-template-areas: 
-    "power input add"
-    ". tokens ."
-	"hr hr hr"; 
+	display: grid;
+	grid-template-columns: 4em 1fr min-content;
+	grid-template-rows: min-content min-content min-content;
+	gap: 0 8px;
+	grid-template-areas: 
+		"power input add"
+		". tokens ."
+		"hr hr hr"; 
+	padding: 1px;
 }
 .lb-modal-power {
 	grid-area: power;
-	text-align: right;
+	text-align: center;
 }
 .lb-modal-input { 
 	grid-area: input;
@@ -2148,48 +2149,32 @@ export function App() {
 	const [stoppingStringsError, setStoppingStringsError] = useState(undefined);
 	const [savedScrollTop, setSavedScrollTop] = useSessionState('scrollTop', defaultPresets.scrollTop);
 
+	//- Logit Bias --//
 	const [logitBias, setLogitBias] = useSessionState('logitBias', defaultPresets.logitBias);
 	const [logitBiasTemp, setLogitBiasTemp] = useState([]);
 	const [logitBiasSearchList, setLogitBiasSearchList] = useState([]);
 	const [logitBiasSorted, setLogitBiasSorted] = useState([]);
 	const [logitBiasSearchState, setLogitBiasSearchState] = useState(false);
+	const [logitBiasInput, setLogitBiasInput] = useState({power:2,string:"string"});
 
-	const doNothing = () => { return } // very elegant.
+	const handleLogitBiasInput = (key,value) => {
+		setLogitBiasInput((prevLogitBiasInput) => {
+			const rest = { ...prevLogitBiasInput }
+			rest[key] = value;
+			console.log(rest)
+			return { ...rest };
+		});
 
-	const logitBiasAdd = async (index,posneg="",origValue="") => {
-		const [biasTokens,biasPower] = (()=>{
-			switch (true) {
-				case index == "sidebar":
-					console.log("sidebar");
-					const biasTokens = document.querySelector("#logitBiasTokens").value;
-					const biasPower = document.querySelector("#logitBiasPower").value;
-					return [biasTokens,biasPower];
-				case !isNaN(+index):
-					try {
-						// need to change handling here?
-						console.log("modal",index,posneg)
-						const biasTokens = document.querySelector("#lb-modal-"+posneg+" #lb-modal-input-"+index).value;
-						const biasPower = document.querySelector("#lb-modal-"+posneg+" #lb-modal-power-"+index).value;
-						return [biasTokens,biasPower];
-					}
-					catch {
-						console.warn("Attempted to modify an out of range index in logit bias modal")
-						return
-					}
-				default:
-					console.log("switch defaulted")
-					return [false,false]
-			}
-		})();
-		
+	}
+
+	const logitBiasAdd = async (biasPower="",biasTokens="",origValue="") => {
+		console.log("values",biasPower,biasTokens,origValue)
+		console.log(logitBiasInput)
 		// abort if no input or power is NaN
 		if(!biasTokens) {return}
 		if (isNaN(+biasPower)) { return }
 
-		console.log("values",biasTokens,biasPower)
-
-		const modBias = logitBias.bias;
-		
+		const modBias = logitBias.bias;	
 		
 		// delete entry if power 0 or empty
 		if (biasPower == 0 || biasPower == "" && logitBias[biasTokens]) {
@@ -2214,7 +2199,6 @@ export function App() {
 		const ac = new AbortController();
 		console.log("input","."+biasTokens+".",biasPower)
 
-		// in some models it will add spaces to the start of your input
 		const tokens = await getTokens({
 				endpoint,
 				endpointAPI,
@@ -2235,15 +2219,12 @@ export function App() {
 				}
 			}
 		}));
-		//console.log("temp",logitBiasTemp)
-		// if (!isNaN(index)) {
-		// 	repopLogitBiasModal()
-		// }
 	};
 
-	const updateLogitBiasTemp = (() => {
+	function updateLogitBiasTemp() {
 		const tempArray = logitBiasSorted.map((string, index) =>  ({
 			value: string,
+			valueBack: string,
 			strings: logitBias.bias[string].strings,
 			power: logitBias.bias[string].power
 		}));
@@ -2251,19 +2232,14 @@ export function App() {
 			positive: tempArray.filter(item => item.power > 0),
 			negative: tempArray.filter(item => item.power < 0)
 		});
-	});
+	};
 
-	// const handleBiasTempChange = ((key,index,value) => {
-	// 	console.log("cur temp",logitBiasTemp)
-	// 	console.log("update temp",key, index, value)
-	// 	setLogitBiasTemp((prevLogitBiasTemp) => {
-	// 		const updatedTemp = prevLogitBiasTemp;
-	// 		updatedTemp[index][key] = String(value);
-	// 		return updatedTemp;
-	// 	})
-	// 	console.log("up temp",logitBiasTemp[index])
-	// })
-	const handleBiasTempChange = (posneg,key, index, value) => {
+	const updateLogitBiasTempUse = useMemo(() => {
+		updateLogitBiasTemp()
+	},[logitBiasSorted]);
+
+	const handleBiasTempChange = (posneg, key, index, value) => {
+		console.log("up temp",key, value)
 		setLogitBiasTemp((prevLogitBiasTemp) => {
 			const rest = { ...prevLogitBiasTemp };
 			const updatedTemp = [ ...prevLogitBiasTemp[posneg] ];
@@ -2277,30 +2253,13 @@ export function App() {
 				[posneg]: updatedTemp
 			};
 		});
-		console.log("up temp",logitBiasTemp[index])
 	};
-
-	// const handleWorldInfoChange = (key,index,value) => {
-	// 	setWorldInfo((prevWorldInfo) => {
-	// 		const updatedEntries = [...prevWorldInfo.entries];
-	// 		const updatedEntry = key == "keys"
-	// 			? { ...updatedEntries[index], [key]: value.split(/(?<!\\), ?/) }
-	// 			: { ...updatedEntries[index], [key]: value };
-	// 		updatedEntries[index] = updatedEntry;
-
-	// 		return {
-	// 			...prevWorldInfo,
-	// 			entries: updatedEntries,
-	// 		};
-	// 	});
-	// }
 
 	const logitBiasSearch = (value) => {
 		const filteredList = value ? Object.keys(logitBias.bias).filter(key => key.startsWith(value)) : []
 		const sorted = logitBiasSorted;
 		setLogitBiasSearchList(filteredList)
 	}
-
 
 	const logitBiasSort = useMemo(() => {
 
@@ -2313,19 +2272,6 @@ export function App() {
 		setLogitBiasSorted(resultArray)
 	}, [logitBias]);
 
-	// const repopLogitBiasModal = (() => {
-	// 	try {
-	// 		const lbModalInputs = document.querySelectorAll(".lb-modal-power, .lb-modal-stringInput");
-	// 		lbModalInputs.forEach( input => {
-	// 			input.value = input.defaultValue;
-	// 		});
-	// 	}
-	// 	catch {
-	// 		return
-	// 	}
-	// });
-
-
 	const debugLogitBias = useMemo(() => {
 		console.log("logit bias",logitBias)
 	}, [logitBias]);
@@ -2333,6 +2279,8 @@ export function App() {
 	const debugLogitBiasSearch = useMemo(() => {
 		console.log("searchlist",logitBiasSearchList)
 	}, [logitBiasSearchList]);
+
+	//- Persistent Context --//
 
 	const [contextLength, setContextLength] = useSessionState('contextLength', defaultPresets.contextLength);
 	const [memoryTokens, setMemoryTokens] = useSessionState('memoryTokens', defaultPresets.memoryTokens);
@@ -3234,26 +3182,30 @@ export function App() {
 				${(endpointAPI == 0 || endpointAPI == 2) && html`
 					<div className="hbox-flex logitBiasContainer">
 						<div class="small-inputBox">
-							<${InputBox} label="Bias" classList="logitBiasPower-container" type="number" max=100 min=-100 step="1"
-								readOnly=${!!cancel} onValueChange=${doNothing} defaultValue=0 id="logitBiasPower"/>
+							<${InputBox} label="Bias" classList="logitBiasPower-container"
+								type="number" max=100 min=-100 step=1
+								readOnly=${!!cancel}
+								onValueChange=${(e) => {handleLogitBiasInput("power",e)} }
+								value=${logitBiasInput.power} 
+								id="logitBiasPower"/>
 						</div>
 						<label className="InputBox">
 							Token
 						<input label="Token" type="text" id="logitBiasTokens-container"
 							readOnly=${!!cancel} 
-							onInput=${(e) => {logitBiasSearch(e.target.value)} }
+							onInput=${(e) => {logitBiasSearch(e.target.value);handleLogitBiasInput("tokens",e.target.value)} }
 							onFocus=${(e) => {logitBiasSearch(e.target.value); setLogitBiasSearchState(true)} }
 							onBlur=${() => setLogitBiasSearchState(false)}
-							defaultValue="testing " 
+							value=${logitBiasInput.string} 
 							id="logitBiasTokens"/>
 							<button
 								className="textAreaSettings"
 								disabled=${!!cancel}
-								onClick=${() => {updateLogitBiasTemp(); toggleModal("bias")}}>
+								onClick=${() => { toggleModal("bias")}}>
 								<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="-1 -5 8 7" xmlns="http://www.w3.org/2000/svg"><path d="M0 0 3-3C3-4 3-5 5-5L4-4 5-3 6-4C6-2 5-2 4-2L1 1C0 2-1 1 0 0"></path></svg>
 							</button>
 						</label>
-						<button disabled=${!!cancel} class="hbox-button" onClick=${() => logitBiasAdd("sidebar")}>+</button>
+						<button disabled=${!!cancel} class="hbox-button" onClick=${() => logitBiasAdd(logitBiasInput.power,logitBiasInput.string)}>+</button>
 						${logitBiasSearchState 
 							&& logitBiasSearchList.length > 0
 							&& html`<div id="logitBiasSearchSuggestions">
@@ -3407,7 +3359,7 @@ export function App() {
 			</div>
 		</${Modal}>
 
-		<${Modal} isOpen=${modalState.bias} onClose=${() => {closeModal("bias")}}
+		<${Modal} isOpen=${modalState.bias} onClose=${() => {updateLogitBiasTemp(); closeModal("bias")}}
 		title="Logit Bias"
 		description="Make certain tokens more or less likely to be generated. Values range from -100 to 100.
 		-100 is a ban, +100 means the model will only generate that token. 0 is neutral.
@@ -3426,23 +3378,26 @@ export function App() {
 						<div class="lb-modal-entry lb-modal-grid-row" key=${index}>
 
 							<${InputBox} label="Bias" class="lb-modal-power"
-								type="number" max=100 min=-100 step="1"
+								type="number" max=100 min=-100 step=1
 								id="lb-modal-power-${index}"
 								readOnly=${!!cancel}
 								onValueChange=${(value) => handleBiasTempChange(key,"power", index, value) }
 								value=${bias.power}/>
+								<!-- I'm going to lose my mind, why does this ONLY take numbers -->
+								
+								
 							<label className="InputBox">
 								Token
-							<input label="Token" type="text" class="lb-modal-stringInput"
-								readOnly=${!!cancel} 
-								onInput=${(e) => handleBiasTempChange(key,"value", index, e.target.value) }
-								value=${bias.value}
-								id="lb-modal-input-${index}"/>
+								<input label="Token" type="text" class="lb-modal-stringInput"
+									readOnly=${!!cancel} 
+									onInput=${(e) => handleBiasTempChange(key,"value", index, e.target.value) }
+									value=${bias.value}
+									id="lb-modal-input-${index}"/>
 							</label>
 							<div class="lb-modal-tokenized">
 								[${bias.strings.join("|")}] (${bias.strings.length})
 							</div>
-							<button disabled=${!!cancel} class="hbox-button lb-modal-button" onClick=${() => logitBiasAdd(index,"positive",bias.value)}>+</button>
+							<button disabled=${!!cancel} class="hbox-button lb-modal-button" onClick=${() => logitBiasAdd(bias.power, bias.value, bias.valueBack)}>+</button>
 							<hr/>
 						</div>
 

--- a/mikupad.html
+++ b/mikupad.html
@@ -2422,13 +2422,13 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 
 		const ac = new AbortController();
 		console.log("input","."+biasString+".",biasPower)
-
+		console.log("replace","."+biasString.replace(/\\n/g, '\n')+".")
 		try {
 			const tokens = await getTokens({
 				endpoint,
 				endpointAPI,
 				...(endpointAPI == 3 || endpointAPI == 0 ? { endpointAPIKey } : {}),
-				content: `${biasString}`,
+				content: `${biasString}`.replace(/\\n/g, '\n'),
 				signal: ac.signal,
 				...(isMikupadEndpoint ? { proxyEndpoint: sessionStorage.proxyEndpoint } : {})
 			});
@@ -2465,7 +2465,7 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 		for (const key in logitBias.bias) {
 			console.log("retok",key,logitBias.bias[key])
 			await logitBiasAdd(Number(logitBias.bias[key].power),key);
-			await new Promise(r => setTimeout(r, 200));
+			//await new Promise(r => setTimeout(r, 200));
 		}
 	};
 
@@ -2474,6 +2474,7 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 	const llamaCppSetLogitBiasParams = () => {
 		const param = [];
 		// TODO grab multi-token strings here and put them in a separate state variable
+		// for phrase bias
 		Object.keys(logitBias.bias).forEach(entry => {
 			// set banned tokens to false
 			const power = logitBias.bias[entry].power < -99 ? false : Number(logitBias.bias[entry].power);
@@ -2492,12 +2493,11 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 		setLogitBiasParam(param)
 	};
 	const updateLogitBiasParam = useMemo(() => {
-		// console.log("endpoint",endpointAPI)
+		// set the parameters sent to the model in the format expected by the endpoint
 		switch (endpointAPI) {
 			case 0:
 				llamaCppSetLogitBiasParams()
 				break;
-			
 			case 2:
 				koboldCppSetLogitBiasParams()
 				break;
@@ -2846,7 +2846,9 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 			setUndoHovered(false);
 			setRejectedAPIKey(false);
 
-			console.log("AAAAAAAAAAAAAAAAAAAA",logitBiasParam)
+			console.log("AAAAAAAAAAAAAAAAAAAA",logitBias)
+			console.log(logitBias.bias)
+			console.log(logitBias.bias.length)
 			for await (const chunk of completion({
 				endpoint,
 				endpointAPI,
@@ -2865,7 +2867,7 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 					penalize_nl: penalizeNl,
 					ignore_eos: ignoreEos,
 				} : {}),
-				...(logitBias.bias.length > 0 ? {
+				...(Object.keys(logitBias.bias).length > 0 ? {
 					logit_bias: logitBiasParam, // [[39,-20],[37934,-20]], //
 				} : {}),
 				presence_penalty: presencePenalty,

--- a/mikupad.html
+++ b/mikupad.html
@@ -480,6 +480,135 @@ html.nockoffAI .wi-entry-name input {
 	margin-bottom:4px;
 }
 
+/* logit bias */
+.hbox-button {
+	margin-top: auto;
+	width: 1.625rem;
+}
+.hbox-flex {
+	display: flex;
+	flex-direction: row;
+	gap: 8px;
+}
+.hbox-flex > .InputBox {
+  width: 100%;
+}
+.small-inputBox {
+	width: 8em;
+}
+.logitBiasContainer {
+	position: relative;
+}
+
+.overflow-container {
+	overflow-y:auto;
+}
+#logitBiasPower {
+	text-align: center;
+}
+
+#logitBiasSearchSuggestions {
+	--search-width: 95%;
+	position: absolute;
+	bottom:2.75em;
+	left: calc( (100% - var(--search-width)) / 2 );
+	width: var(--search-width);
+	background: var(--color-base-40);
+	min-height:0em;
+	margin: 0 auto 0;
+	border-radius: 5px;
+	box-shadow: 0 0 .5em black;
+}
+html.nockoffAI #logitBiasSearchSuggestions {
+	background: var(--color-disabled);
+}
+#logitBiasSearchSuggestions > .overflow-container {
+	max-height: 19.5em;
+	margin: .2em;
+}
+.lb-search-entry {
+	display: grid;
+	grid-template-columns: minmax(min-content, 1fr) min-content 5fr min-content;
+	gap: 8px;
+	padding: 0.25em;
+	margin: 0.2em;
+	background: var(--color-base-50);
+	border-radius: 3px;
+	word-break: break-all;
+}
+.lb-search-entry > * {
+	margin: auto 0 auto;
+}
+html.nockoffAI .lb-search-entry {
+	background: var(--color-base-10);
+	color: var(--color-text);
+}
+html.monospace-dark .lb-search-entry {
+	background: var(--color-base-20);
+}
+
+.lb-search-power {
+	text-align: right;
+}
+
+.lb-search-string,
+.lb-tokenCount {
+	font-family: monospace;
+	font-size: 0.8rem;
+}
+
+
+
+
+.lb-modal-grid-column {
+	display: grid;
+	gap: 8px;
+	max-height: 60vh;
+	padding-right: .75em;
+}
+.lb-modal-grid-row  {
+  display: grid;
+  grid-template-columns: 4em 1fr min-content;
+  grid-template-rows: 1fr min-content min-content;
+  gap: 0 8px;
+  grid-template-areas: 
+    "power input add"
+    ". tokens ."
+	"hr hr hr"; 
+}
+.lb-modal-power {
+	grid-area: power;
+	text-align: right;
+}
+.lb-modal-input { 
+	grid-area: input;
+	text-align: left;
+}
+.lb-modal-button { 
+	grid-area: add;
+}
+.lb-modal-tokenized { 
+	grid-area: tokens;
+	margin-top: auto;
+	display: grid;
+	align-content: center;
+	height: 1.625rem;
+}
+.lb-modal-biasList hr {
+	grid-area: hr;
+	width: 90%;
+	margin: 4px auto auto auto;
+}
+
+.lb-modal-biasList {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 8px;
+}
+
+
+
+
 #sidebar {
 	font-family: inherit;
 	width: 250px;
@@ -889,6 +1018,20 @@ export async function getTokenCount({ endpoint, endpointAPI, endpointAPIKey, sig
 	}
 }
 
+export async function getTokens({ endpoint, endpointAPI, endpointAPIKey, signal, ...options }) {
+	// currently only implemented for llama.cpp and koboldcpp
+	// to implement other APIs, make a function that takes an input of a string and
+	// returns a json object in the format of:
+	// { ids:[ array of token ids ], str:[ array of detokenized ids ] }
+	// example: { ids:[9288,4731],str:["test"," string"] }
+	switch (endpointAPI) {
+		case 0: // llama.cpp
+			return await llamaCppTokenize({ endpoint, endpointAPIKey, signal, ...options });
+		case 2: // koboldcpp
+			return await koboldCppTokenize({ endpoint, signal, ...options });
+	}
+}
+
 export async function getModels({ endpoint, endpointAPI, endpointAPIKey, signal, ...options }) {
 	switch (endpointAPI) {
 		case 3: // openai
@@ -981,6 +1124,50 @@ async function llamaCppTokenCount({ endpoint, endpointAPIKey, signal, ...options
 	return tokens.length + 1; // + 1 for BOS, I guess.
 }
 
+async function llamaCppTokenize({ endpoint, endpointAPIKey, signal, ...options }) {
+	const res = await fetch(new URL('/tokenize', endpoint), {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			...(endpointAPIKey ? { 'Authorization': `Bearer ${endpointAPIKey}` } : {}),
+		},
+		body: JSON.stringify(options),
+		signal,
+	});
+	if (!res.ok)
+		throw new Error(`HTTP ${res.status}`);
+	const { tokens } = await res.json();
+
+	const strings = [];
+	for (let i=0; i<tokens.length; i++) {
+		const string = await llamaCppDetokenize({
+				endpoint,
+				endpointAPIKey,
+				tokens: [ tokens[i] ],
+				signal: signal,
+		}); // maybe batch all tokens together with a bos token between them
+			// something? don't know what's more efficient.
+		strings.push(string);
+	};
+	return {ids:tokens,str:strings};
+}
+async function llamaCppDetokenize({ endpoint, endpointAPIKey, signal, ...options }) {
+	const res = await fetch(new URL('/detokenize', endpoint), {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			...(endpointAPIKey ? { 'Authorization': `Bearer ${endpointAPIKey}` } : {}),
+		},
+		body: JSON.stringify(options),
+		signal,
+	});
+	if (!res.ok)
+		throw new Error(`HTTP ${res.status}`);
+	const { content } = await res.json();
+	console.log("detokenized","." + content + ".")
+	return content
+}
+
 async function* llamaCppCompletion({ endpoint, endpointAPIKey, signal, ...options }) {
 	const res = await fetch(new URL('/completion', endpoint), {
 		method: 'POST',
@@ -1000,6 +1187,121 @@ async function* llamaCppCompletion({ endpoint, endpointAPIKey, signal, ...option
 	return yield* await parseEventStream(res.body);
 }
 
+async function oobaTokenCount({ endpoint, signal, ...options }) {
+	try {
+		endpoint = `http:${endpoint.split(":")[1]}:5000`; // HACK!
+		const res = await fetch(new URL('/api/v1/token-count', endpoint), {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				prompt: options.content
+			}),
+			signal,
+		});
+		if (!res.ok)
+			throw new Error(`HTTP ${res.status}`);
+		const { results } = await res.json();
+		return results[0].tokens;
+	} catch (e) {
+		reportError(e);
+		return 0;
+	}
+}
+
+async function oobaTokenize({ endpoint, signal, ...options }) {
+	try {
+		endpoint = `http:${endpoint.split(":")[1]}:5000`; // HACK!
+		const res = await fetch(new URL('/api/v1/token-count', endpoint), {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				prompt: options.content
+			}),
+			signal,
+		});
+		if (!res.ok)
+			throw new Error(`HTTP ${res.status}`);
+		const { results } = await res.json();
+		return results[0]; // TODO TEST
+	} catch (e) {
+		reportError(e);
+		return 0;
+	}
+}
+
+function oobaConvertOptions(options) {
+	const swapOption = (lhs, rhs) => {
+		if (lhs in options) {
+			options[rhs] = options[lhs];
+			delete options[lhs];
+		}
+	};
+	if (options.n_predict === -1) {
+		options.n_predict = 1024;
+	}
+	swapOption("n_ctx", "truncation_length");
+	swapOption("n_predict", "max_new_tokens");
+	swapOption("repeat_penalty", "repetition_penalty");
+	swapOption("repeat_last_n", "repetition_penalty_range");
+	swapOption("ignore_eos", "ban_eos_token");
+	swapOption("stop", "stopping_strings");
+	return options;
+}
+
+async function* oobaCompletion({ endpoint, signal, ...options }) {
+	const ws = new WebSocket(new URL('/api/v1/stream', endpoint));
+	let connected = false;
+
+	ws.onopen = () => {
+		connected = true;
+		ws.send(JSON.stringify(oobaConvertOptions(options)));
+	};
+
+	const wsStream = () => new EventIterator(
+		queue => {
+			ws.onmessage = queue.push;
+			ws.onclose = queue.stop;
+			ws.onerror = (e) => queue.fail(new Error(connected ? "WebSocket Error" : "Failed to connect"));
+			if (signal) {
+				signal.addEventListener("abort", queue.stop);
+			}
+
+			return () => {
+				ws.close();
+				if (signal) {
+					signal.removeEventListener("abort", queue.stop);
+				}
+			}
+		}
+	);
+
+	for await (const event of wsStream()) {
+		const data = JSON.parse(event.data);
+		console.log('event', data);
+
+		if (data.event === "text_stream") {
+			yield { content: data.text };
+		} else if (data.event === "stream_end") {
+			break;
+		}
+	}
+}
+
+async function oobaAbortCompletion({ endpoint }) {
+	try {
+		endpoint = `http:${endpoint.split(":")[1]}:5000`; // HACK!
+		await fetch(new URL('/api/v1/stop-stream', endpoint), {
+			method: 'POST',
+		});
+	} catch (e) {
+		reportError(e);
+	}
+}
+
 async function koboldCppTokenCount({ endpoint, signal, ...options }) {
 	const res = await fetch(new URL('/api/extra/tokencount', endpoint), {
 		method: 'POST',
@@ -1015,6 +1317,24 @@ async function koboldCppTokenCount({ endpoint, signal, ...options }) {
 		throw new Error(`HTTP ${res.status}`);
 	const { value } = await res.json();
 	return value;
+}
+
+async function koboldCppTokenize({ endpoint, signal, ...options }) {
+	const res = await fetch(new URL('/api/extra/tokencount', endpoint), {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify({
+			prompt: options.content
+		}),
+		signal,
+	});
+	if (!res.ok)
+		throw new Error(`HTTP ${res.status}`);
+	const { ids } = await res.json();
+	return {ids:ids,str:"Not implemented in KCCP"};
+	// that can't be right, surely there's a detokenize endpoint
 }
 
 function koboldCppConvertOptions(options) {
@@ -1698,6 +2018,7 @@ const defaultPresets = {
 		"prefix": "",
 		"suffix": ""
 	}),
+	logitBias:{ bias:{},model:"none" },
 	scrollTop: 0
 };
 
@@ -1823,6 +2144,131 @@ export function App() {
 	const [stoppingStrings, setStoppingStrings] = useSessionState('stoppingStrings', defaultPresets.stoppingStrings);
 	const [stoppingStringsError, setStoppingStringsError] = useState(undefined);
 	const [savedScrollTop, setSavedScrollTop] = useSessionState('scrollTop', defaultPresets.scrollTop);
+
+	const [logitBias, setLogitBias] = useSessionState('logitBias', defaultPresets.logitBias);
+	const [logitBiasSearchList, setLogitBiasSearchList] = useState([]);
+	const [logitBiasSorted, setLogitBiasSorted] = useState([]);
+	const [logitBiasSearchState, setLogitBiasSearchState] = useState(false);
+
+	const doNothing = () => { return } // very elegant.
+
+	const logitBiasAdd = async (index,posneg="",origValue="") => {
+		
+		const [biasTokens,biasPower] = (()=>{
+			switch (true) {
+				case index == "sidebar":
+					console.log("sidebar");
+					const biasTokens = document.querySelector("#logitBiasTokens").value;
+					const biasPower = document.querySelector("#logitBiasPower").value;
+					return [biasTokens,biasPower];
+
+				case !isNaN(+index):
+					try {
+						console.log("modal",index,posneg)
+						const biasTokens = document.querySelector("#lb-modal-"+posneg+" #lb-modal-input-"+index).value;
+						const biasPower = document.querySelector("#lb-modal-"+posneg+" #lb-modal-power-"+index).value;
+						return [biasTokens,biasPower];
+					}
+					catch {
+						console.warn("Attempted to modify an out of range index in logit bias modal")
+						return
+					}
+					return [false,false]
+
+				default:
+					console.log("switch defaulted")
+					return [false,false]
+			}
+		})();
+		
+		// abort if no input
+		if(!biasTokens) {return}
+
+		console.log("values",biasTokens,biasPower)
+
+		const modBias = logitBias.bias;
+		
+		// abort if power isn't a number
+		if (isNaN(+biasPower)) { return }
+		// delete entry if power 0 or empty
+		if (biasPower == 0 || biasPower == "" && logitBias[biasTokens]) {
+			console.log("delete",biasTokens)
+			setLogitBias((prevLogitBias) => {
+				delete modBias[biasTokens]
+				return { 
+					...prevLogitBias,
+					bias: {
+						...modBias
+					}
+				};
+			})
+			return
+		}
+		// if overwriting the string value of an entry, delete the original one
+		if (origValue && origValue != biasTokens) {
+			console.log("delete orig",origValue)
+			delete modBias[origValue]
+		}
+
+		const ac = new AbortController();
+		console.log("input","."+biasTokens+".",biasPower)
+
+		// in some models it will add spaces to the start of your input
+		const tokens = await getTokens({
+				endpoint,
+				endpointAPI,
+				...(endpointAPI == 3 || endpointAPI == 0 ? { endpointAPIKey } : {}),
+				content: `${biasTokens}`,
+				signal: ac.signal,
+		})
+		console.log("add",tokens)
+
+		setLogitBias((prevLogitBias) => ({
+			...prevLogitBias,
+			bias: {
+				...modBias,
+				[biasTokens]: {
+					ids: [ ...tokens.ids ],
+					strings: [ ...tokens.str ],
+					power: biasPower
+				}
+			}
+		}));
+
+		if (!isNaN(index)) {
+			toggleModal("bias");
+			toggleModal("bias");
+		}
+	};
+
+	const logitBiasSearch = async (value) => {
+		const filteredList = value ? Object.keys(logitBias.bias).filter(key => key.startsWith(value)) : []
+		const sorted = logitBiasSorted;
+		setLogitBiasSearchList(filteredList)
+	}
+
+
+	const logitBiasSort = useMemo(() => {
+
+		const biasListToSort = Object.entries(logitBias.bias);
+		const biasListSorted = biasListToSort
+			.sort((a, b) => parseInt(b[1].power) - parseInt(a[1].power));
+		
+		const resultArray = biasListSorted.map(([key]) => key);
+
+		setLogitBiasSorted(resultArray)
+	}, [logitBias]);
+
+
+
+
+	const debugLogitBias = useMemo(() => {
+		console.log(logitBias)
+	}, [logitBias]);
+
+	const debugLogitBiasSearch = useMemo(() => {
+		console.log("searchlist",logitBiasSearchList)
+	}, [logitBiasSearchList]);
 
 	const [contextLength, setContextLength] = useSessionState('contextLength', defaultPresets.contextLength);
 	const [memoryTokens, setMemoryTokens] = useSessionState('memoryTokens', defaultPresets.memoryTokens);
@@ -2693,6 +3139,60 @@ export function App() {
 				${(!openaiPresets || endpointAPI != 3) && html`
 					<${Checkbox} label="Ignore <eos>"
 						disabled=${!!cancel} value=${ignoreEos} onValueChange=${setIgnoreEos}/>`}
+
+				${(endpointAPI == 0 || endpointAPI == 2) && html`
+					<div className="hbox-flex logitBiasContainer">
+						<div class="small-inputBox">
+							<${InputBox} label="Bias" classList="logitBiasPower-container" type="number" max=100 min=-100 step="1"
+								readOnly=${!!cancel} onValueChange=${doNothing} defaultValue=0 id="logitBiasPower"/>
+						</div>
+						<label className="InputBox">
+							Token
+						<input label="Token" type="text" id="logitBiasTokens-container"
+							readOnly=${!!cancel} 
+							onInput=${(e) => {logitBiasSearch(e.target.value)} }
+							onFocus=${(e) => {logitBiasSearch(e.target.value); setLogitBiasSearchState(true)} }
+							onBlur=${() => setLogitBiasSearchState(false)}
+							defaultValue="testing " 
+							id="logitBiasTokens"/>
+							<button
+								className="textAreaSettings"
+								disabled=${!!cancel}
+								onClick=${() => toggleModal("bias")}>
+								<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="-1 -5 8 7" xmlns="http://www.w3.org/2000/svg"><path d="M0 0 3-3C3-4 3-5 5-5L4-4 5-3 6-4C6-2 5-2 4-2L1 1C0 2-1 1 0 0"></path></svg>
+							</button>
+						</label>
+						<button disabled=${!!cancel} class="hbox-button" onClick=${() => logitBiasAdd("sidebar")}>+</button>
+						${logitBiasSearchState 
+							&& logitBiasSearchList.length > 0
+							&& html`<div id="logitBiasSearchSuggestions">
+							<div class="overflow-container">
+								${ !Array.isArray(logitBiasSearchList) ? null : logitBiasSorted.map((string, index) => {
+									if (logitBiasSearchList.includes(string)) {
+										return !logitBias.bias[string] ? null : html`
+											<div class="lb-search-entry" key=${index}>
+												<div class="lb-search-power">
+													${logitBias.bias[string].power}  
+												</div>
+												<div>></div>
+												<div class="lb-search-string">
+													[${logitBias.bias[string].strings.join("|")}]
+												</div>
+												<div class="lb-tokenCount">
+													(${logitBias.bias[string].ids.length})
+												</div>
+
+												
+											</div>`
+									}
+								}
+								)}
+
+							</div>
+						</div>`}
+						
+					</div>`}
+
 			</${CollapsibleGroup}>
 			<${CollapsibleGroup} label="Persistent Context">
 				<label className="TextArea">
@@ -2794,6 +3294,52 @@ export function App() {
 						{ name: 'Don\'t show', value: -1 },
 					]}/>
 			</div>
+		</${Modal}>
+
+		<${Modal} isOpen=${modalState.bias} onClose=${() => closeModal("bias")}
+		title="Logit Bias"
+		description="Make certain tokens more or less likely to be generated. Values range from -100 to 100.
+		-100 is a ban, +100 means the model will only generate that token. 0 is neutral.
+		Currently only works on the first token of multi-token phrases/words.
+		
+		Different models might tokenize words differently. Always Re-Tokenize when switching models!">
+			
+		${modalState.bias 
+			&& logitBiasSorted.length > 0
+			&& html`
+			<div class="lb-modal-biasList" >
+				<div class="overflow-container lb-modal-grid-column" id="lb-modal-positive">
+					${ logitBiasSorted.map((string, index) => {
+		
+							return !logitBias.bias[string] || logitBias.bias[string].power < 0 ? null : html`
+								<div class="lb-modal-entry lb-modal-grid-row" key=${index}>
+
+									<${InputBox} label="Bias" classList="lb-modal-power"
+										type="number" max=100 min=-100 step="1"
+										id="lb-modal-power-${index}"
+										readOnly=${!!cancel}
+										onValueChange=${doNothing}
+										defaultValue=${logitBias.bias[string].power}/>
+									<label className="InputBox">
+										Token
+									<input label="Token" type="text" class="lb-modal-stringInput"
+										readOnly=${!!cancel} 
+										defaultValue="${string}" 
+										id="lb-modal-input-${index}"/>
+									</label>
+									<div class="lb-modal-tokenized">
+										[${logitBias.bias[string].strings.join("|")}] (${logitBias.bias[string].ids.length})
+									</div>
+									<button disabled=${!!cancel} class="hbox-button lb-modal-button" onClick=${() => logitBiasAdd(index,"positive",string)}>+</button>
+									<hr/>
+								</div>`
+
+					}
+					)}
+
+				</div>
+			</div>`}
+
 		</${Modal}>
 
 		<${Modal} isOpen=${modalState.memory} onClose=${() => closeModal("memory")}

--- a/mikupad.html
+++ b/mikupad.html
@@ -397,6 +397,10 @@ html.nockoffAI .modal-desc {
 	margin-bottom: .25em;
 }
 
+.modal-content {
+	overflow: hidden;
+}
+
 hr {
 	border:unset;
 	border-top: 1px solid var(--color-base-40);
@@ -514,7 +518,7 @@ html.nockoffAI .wi-entry-name input {
 	display: grid;
 	grid-auto-rows: min-content;
 	gap: 8px;
-	max-height: 55vh;
+	max-height: 40vh;
 	padding-right: .75em;
 
 }
@@ -3819,27 +3823,27 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 		Different models might tokenize words differently. Always Re-Tokenize your biases when switching models by pressing the '+' button again for every entry.">
 		${modalState.bias 
 			&& html`
-					<div className="hbox-flex logitBiasContainer">
-						<div class="small-inputBox">
-							<${InputBox} label="Bias" className="logitBiasPower-container"
-								type="enumber"  max=100 min=-100 step=1
-								readOnly=${!!cancel}
-								onValueChange=${(value) => { handleLogitBiasInput("power",value)} }
-								value=${logitBiasInput.power} 
-								id="logitBiasPower"/>
-						</div>
-						<${InputBox} label="Token" type="text"
-							tooltip="Currently, only the first token of multi-token strings will be biased."
+				<div className="hbox-flex logitBiasContainer">
+					<div class="small-inputBox">
+						<${InputBox} label="Bias" className="logitBiasPower-container"
+							type="enumber"  max=100 min=-100 step=1
 							readOnly=${!!cancel}
-							value=${logitBiasInput.string}
-							placeholder="String or /ID,.../"
-							onValueChange=${() => {} }
-							onInput=${(e) => {handleLogitBiasInput("string",e.target.value)} }
-							/>
-						<button disabled=${!!cancel} class="hbox-button" onClick=${() => logitBiasAdd(logitBiasInput.power,logitBiasInput.string)}>+</button>
+							onValueChange=${(value) => { handleLogitBiasInput("power",value)} }
+							value=${logitBiasInput.power} 
+							id="logitBiasPower"/>
 					</div>
-					${!!lastBiasError && html`
-						<div style=${{"margin":"8px auto"}} className="error-text">${lastBiasError}</div>`}
+					<${InputBox} label="Token" type="text"
+						tooltip="Currently, only the first token of multi-token strings will be biased."
+						readOnly=${!!cancel}
+						value=${logitBiasInput.string}
+						placeholder="String or /ID,.../"
+						onValueChange=${() => {} }
+						onInput=${(e) => {handleLogitBiasInput("string",e.target.value)} }
+						/>
+					<button disabled=${!!cancel} class="hbox-button" onClick=${() => logitBiasAdd(logitBiasInput.power,logitBiasInput.string)}>+</button>
+				</div>
+				${!!lastBiasError && html`
+					<div style=${{"margin":"8px auto"}} className="error-text">${lastBiasError}</div>`}
 			<hr style=${{"width":"95%","margin":"8px auto"}} />
 			<div class="lb-modal-biasList" >
 				${ Object.keys(logitBiasTemp).map((key) => {

--- a/mikupad.html
+++ b/mikupad.html
@@ -510,59 +510,6 @@ html.nockoffAI .wi-entry-name input {
 	text-align: center;
 }
 
-#logitBiasSearchSuggestions {
-	--search-width: 95%;
-	position: absolute;
-	bottom:2.75em;
-	left: calc( (100% - var(--search-width)) / 2 );
-	width: var(--search-width);
-	background: var(--color-base-40);
-	min-height:0em;
-	margin: 0 auto 0;
-	border-radius: 5px;
-	box-shadow: 0 0 .5em black;
-}
-html.nockoffAI #logitBiasSearchSuggestions {
-	background: var(--color-disabled);
-}
-#logitBiasSearchSuggestions > .overflow-container {
-	max-height: 19.5em;
-	margin: .2em;
-}
-.lb-search-entry {
-	display: grid;
-	grid-template-columns: minmax(min-content, 1fr) min-content 5fr min-content;
-	gap: 8px;
-	padding: 0.25em;
-	margin: 0.2em;
-	background: var(--color-base-50);
-	border-radius: 3px;
-	word-break: break-all;
-}
-.lb-search-entry > * {
-	margin: auto 0 auto;
-}
-html.nockoffAI .lb-search-entry {
-	background: var(--color-base-10);
-	color: var(--color-text);
-}
-html.monospace-dark .lb-search-entry {
-	background: var(--color-base-20);
-}
-
-.lb-search-power {
-	text-align: right;
-}
-
-.lb-search-string,
-.lb-tokenCount {
-	font-family: monospace;
-	font-size: 0.8rem;
-}
-
-
-
-
 .lb-modal-grid-column {
 	display: grid;
 	grid-auto-rows: min-content;
@@ -574,10 +521,10 @@ html.monospace-dark .lb-search-entry {
 	display: grid;
 	grid-template-columns: 4em 1fr min-content;
 	grid-template-rows: min-content min-content min-content;
-	gap: 0 8px;
+	gap: 1px 8px;
 	grid-template-areas: 
 		"power input add"
-		". tokens ."
+		". tokens remove"
 		"hr hr hr"; 
 	padding: 1px;
 }
@@ -589,8 +536,11 @@ html.monospace-dark .lb-search-entry {
 	grid-area: input;
 	text-align: left;
 }
-.lb-modal-button { 
+.lb-modal-button.lb-modal-button-add { 
 	grid-area: add;
+}
+.lb-modal-button.lb-modal-button-remove { 
+	grid-area: remove;
 }
 .lb-modal-tokenized { 
 	grid-area: tokens;
@@ -809,6 +759,10 @@ button.textAreaSettings {
 	position:absolute;
 	top:calc(1.25em + 1px);
 	right:1px;
+}
+button.textAreaSettings.textAreaSettings-bias {
+	top: 1.45em;
+	right: 5px;
 }
 button:hover {
 	background: var(--color-base-40);
@@ -2388,9 +2342,7 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 	const [logitBias, setLogitBias] = useSessionState('logitBias', defaultPresets.logitBias);
 	const [logitBiasParam, setLogitBiasParam] = useState({});
 	const [logitBiasTemp, setLogitBiasTemp] = useState([]);
-	const [logitBiasSearchList, setLogitBiasSearchList] = useState([]);
 	const [logitBiasSorted, setLogitBiasSorted] = useState([]);
-	const [logitBiasSearchState, setLogitBiasSearchState] = useState(false);
 	const [logitBiasInput, setLogitBiasInput] = useState({power:"2",string:"string"});
 
 	const handleLogitBiasInput = (key,value) => {
@@ -2405,7 +2357,7 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 
 	const logitBiasAdd = async (biasPower="",biasString="",origValue="") => {
 		setLastError(undefined)
-		//console.log("values",biasPower,biasString,origValue)
+		console.log("values",biasPower,biasString,origValue)
 		// abort if no input or power is NaN
 		if(!biasString) {return}
 		//console.log("power",biasPower)
@@ -2521,18 +2473,6 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 			return
 		}
 	};
-	const logitBiasRetokenize = async () => { // I don't understand why this doesn't work.
-		console.log(logitBias.bias)
-		const logitBiasLocal = logitBias.bias
-		for (const key in logitBiasLocal) {
-			console.log("retok",key,logitBiasLocal[key].ids)
-
-			await logitBiasAdd(Number(logitBiasLocal[key].power),key,key);
-			await new Promise(r => setTimeout(r, 2000));
-			console.log("done",key,logitBias.bias[key].ids)
-			console.log("--------------------")
-		}
-	};
 
 
 
@@ -2603,12 +2543,6 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 		});
 	};
 
-	const logitBiasSearch = (value) => {
-		const filteredList = value ? Object.keys(logitBias.bias).filter(key => key.startsWith(value)) : []
-		const sorted = logitBiasSorted;
-		setLogitBiasSearchList(filteredList);
-	}
-
 	const logitBiasSort = useMemo(() => {
 		const biasListToSort = Object.entries(logitBias.bias);
 		const sortPowerString = (a, b) => {
@@ -2632,11 +2566,7 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 	// 	console.log("logit bias",logitBias)
 	// }, [logitBias]);
 
-	// const debugLogitBiasSearch = useMemo(() => {
-	// 	console.log("searchlist",logitBiasSearchList)
-	// }, [logitBiasSearchList]);
 
-	//- Persistent Context --//
 
 	const [contextLength, setContextLength] = useSessionState('contextLength', defaultPresets.contextLength);
 	const [memoryTokens, setMemoryTokens] = useSessionState('memoryTokens', defaultPresets.memoryTokens);
@@ -3708,57 +3638,21 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 								id="logitBiasPower"/>
 						</div>
 						<${InputBox} label="Token (string or /IDs/)" type="text"
-							tooltip="aaaaaaaaa"
+							tooltip="Currently, only the first token of multi-token strings will be biased."
 							readOnly=${!!cancel}
 							value=${logitBiasInput.string}
-							onInput=${(e) => {logitBiasSearch(e.target.value); handleLogitBiasInput("string",e.target.value)} }
-							onFocus=${(e) => {logitBiasSearch(e.target.value); setLogitBiasSearchState(true)} }
-							onBlur=${() => setLogitBiasSearchState(false)}
-							/>
-						<label className="InputBox">
-							Token
-						<input label="Token" type="text" id="logitBiasTokens-container"
-							readOnly=${!!cancel} 
-							onInput=${(e) => {logitBiasSearch(e.target.value); handleLogitBiasInput("string",e.target.value)} }
-							onFocus=${(e) => {logitBiasSearch(e.target.value); setLogitBiasSearchState(true)} }
-							onBlur=${() => setLogitBiasSearchState(false)}
-							value=${logitBiasInput.string} 
-							id="logitBiasTokens"/>
-							<button
-								className="textAreaSettings"
+							onValueChange=${() => {} }
+							onInput=${(e) => {handleLogitBiasInput("string",e.target.value)} }
+							children=${ html`
+								<button
+								className="textAreaSettings textAreaSettings-bias"
 								disabled=${!!cancel}
-								onClick=${() => { toggleModal("bias")}}>
+								onClick=${() => toggleModal("bias")}>
 								<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="-1 -5 8 7" xmlns="http://www.w3.org/2000/svg"><path d="M0 0 3-3C3-4 3-5 5-5L4-4 5-3 6-4C6-2 5-2 4-2L1 1C0 2-1 1 0 0"></path></svg>
-							</button>
-						</label>
+								</button>
+							`}
+							/>
 						<button disabled=${!!cancel} class="hbox-button" onClick=${() => logitBiasAdd(logitBiasInput.power,logitBiasInput.string)}>+</button>
-						${logitBiasSearchState 
-							&& logitBiasSearchList.length > 0
-							&& html`<div id="logitBiasSearchSuggestions">
-							<div class="overflow-container">
-								${ !Array.isArray(logitBiasSearchList) ? null : logitBiasSorted.map((string, index) => {
-									if (logitBiasSearchList.includes(string)) {
-										return !logitBias.bias[string] ? null : html`
-											<div class="lb-search-entry" key=${index}>
-												<div class="lb-search-power">
-													${logitBias.bias[string].power}  
-												</div>
-												<div>></div>
-												<div class="lb-search-string">
-													[${logitBias.bias[string].strings.join("|")}]
-												</div>
-												<div class="lb-tokenCount">
-													(${logitBias.bias[string].ids.length})
-												</div>
-
-												
-											</div>`
-									}
-								}
-								)}
-
-							</div>
-						</div>`}
 						
 					</div>`}
 
@@ -3898,11 +3792,6 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 		${modalState.bias 
 			&& html`
 					<div className="hbox-flex logitBiasContainer">
-						<button style=${{"margin-top":"auto"}}
-							id="retokenize" disabled=${!!cancel}
-							onClick=${logitBiasRetokenize}>
-								Retokenize
-						</button>
 						<div class="small-inputBox">
 							<${InputBox} label="Bias" className="logitBiasPower-container"
 								type="enumber"  max=100 min=-100 step=1
@@ -3911,14 +3800,13 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 								value=${logitBiasInput.power} 
 								id="logitBiasPower"/>
 						</div>
-						<label className="InputBox">
-							Token
-						<input label="Token" type="text" id="logitBiasTokens-container"
-							readOnly=${!!cancel} 
-							onInput=${(e) => {logitBiasSearch(e.target.value); handleLogitBiasInput("string",e.target.value)} }
-							value=${logitBiasInput.string} 
-							id="logitBiasTokens"/>
-						</label>
+						<${InputBox} label="Token (string or /IDs/)" type="text"
+							tooltip="Currently, only the first token of multi-token strings will be biased."
+							readOnly=${!!cancel}
+							value=${logitBiasInput.string}
+							onValueChange=${() => {} }
+							onInput=${(e) => {handleLogitBiasInput("string",e.target.value)} }
+							/>
 						<button disabled=${!!cancel} class="hbox-button" onClick=${() => logitBiasAdd(logitBiasInput.power,logitBiasInput.string)}>+</button>
 					</div>
 			${!!lastError && html`
@@ -3939,21 +3827,34 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 								readOnly=${!!cancel}
 								onValueChange=${(value) => {handleBiasTempChange(key,"power", index, value)} }
 								value=${bias.power}/>
-							<label className="InputBox">
-								Token
-								<input label="String" type="text" class="lb-modal-stringInput"
-									readOnly=${!!cancel} 
-									onInput=${(e) => handleBiasTempChange(key,"value", index, e.target.value) }
-									value=${bias.value}
-									id="lb-modal-input-${index}"/>
-							</label>
+
+							<${InputBox} label="Token (string or /IDs/)" type="text"
+								tooltip="Currently, only the first token of multi-token strings will be biased."
+								readOnly=${!!cancel}
+								value=${bias.value}
+								onValueChange=${() => {} }
+								onInput=${(e) => handleBiasTempChange(key,"value", index, e.target.value) }
+								/>
 							<div class="lb-modal-tokenized">
 								${endpointAPI == 0 && bias.strings != ""
 									? "["+bias.strings.join("|")+"] "
 									: "["+bias.tokens+"]" } (${bias.tokens.length} tokens)
 								
 							</div>
-							<button disabled=${!!cancel} class="hbox-button lb-modal-button" onClick=${() => logitBiasAdd(bias.power, bias.value, bias.valueBack)}>+</button>
+							<button
+								disabled=${!!cancel}
+								class="hbox-button lb-modal-button lb-modal-button-add"
+								onClick=${() => logitBiasAdd(bias.power, bias.value, bias.valueBack)}
+								>
+								+
+							</button>
+							<button
+								disabled=${!!cancel}
+								class="hbox-button lb-modal-button lb-modal-button-remove"
+								onClick=${() => logitBiasAdd(Number(0), bias.valueBack, bias.valueBack)}
+								>
+								-
+							</button>
 							<hr/>
 						</div>
 

--- a/mikupad.html
+++ b/mikupad.html
@@ -381,9 +381,9 @@ html.nockoffAI  #context-order-desc,
 html.nockoffAI .modal-desc {
 	color:var(--color-base-80);
 }
-.modal-content {
+/* .modal-content {
 	overflow-y: auto;
-}
+} */
 
 .button-modal-top {
 	all:unset;
@@ -412,7 +412,8 @@ hr {
 .modal-wi-content {
 	display: flex;
 	flex-direction:column;
-	overflow-y: auto;
+	margin-top:0.5em;
+	max-height:50vh;
 }
 
 #modal-wi-global{
@@ -423,9 +424,6 @@ hr {
 
 #button-wi-new {
 	width: 100%;
-}
-.modal-wi-content{
-	margin-top:0.5em;
 }
 
 .wi-entry {
@@ -501,6 +499,7 @@ html.nockoffAI .wi-entry-name input {
 }
 .logitBiasContainer {
 	position: relative;
+	flex-wrap: unset !important;
 }
 
 .overflow-container {
@@ -514,8 +513,9 @@ html.nockoffAI .wi-entry-name input {
 	display: grid;
 	grid-auto-rows: min-content;
 	gap: 8px;
-	max-height: 60vh;
+	max-height: 55vh;
 	padding-right: .75em;
+
 }
 .lb-modal-grid-row  {
 	display: grid;
@@ -545,11 +545,14 @@ html.nockoffAI .wi-entry-name input {
 .lb-modal-tokenized { 
 	grid-area: tokens;
 	font-family: monospace;
-	font-size:0.85rem;
+	font-size:0.7rem;
 	margin-top: auto;
 	display: grid;
 	align-content: center;
-	height: 1.625rem;
+	margin: auto 0 auto 0;
+	/* height: 1.625rem; */
+	width: 100%;
+	overflow-wrap: anywhere;
 }
 .lb-modal-biasList hr {
 	grid-area: hr;
@@ -1171,7 +1174,8 @@ async function llamaCppTokenize({ endpoint, endpointAPIKey, proxyEndpoint, signa
 				tokens: [ tokens[i] ],
 				signal: signal,
 		}); // maybe batch all tokens together with a bos token between them
-			// something? don't know what's more efficient.
+			// something? that'd probably be more efficient. don't know how
+			// to get the bos token ID though.
 		strings.push(string);
 	};
 	return {ids:tokens,str:strings};
@@ -2343,7 +2347,7 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 	const [logitBiasParam, setLogitBiasParam] = useState({});
 	const [logitBiasTemp, setLogitBiasTemp] = useState([]);
 	const [logitBiasSorted, setLogitBiasSorted] = useState([]);
-	const [logitBiasInput, setLogitBiasInput] = useState({power:"2",string:"string"});
+	const [logitBiasInput, setLogitBiasInput] = useState({power:"0",string:""});
 
 	const handleLogitBiasInput = (key,value) => {
 		setLogitBiasInput((prevLogitBiasInput) => {
@@ -2357,10 +2361,9 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 
 	const logitBiasAdd = async (biasPower="",biasString="",origValue="") => {
 		setLastError(undefined)
-		console.log("values",biasPower,biasString,origValue)
+		//console.log("values",biasPower,biasString,origValue)
 		// abort if no input or power is NaN
 		if(!biasString) {return}
-		//console.log("power",biasPower)
 		if (isNaN(+biasPower) || biasPower == "") { 
 			setLastError("Error: Bias is NaN")
 			return
@@ -2403,8 +2406,7 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 				tokens = {
 					ids: isTokenIds[0].replaceAll("/","").split(",").map( item => Number(item.trim()) ),
 					str: ""
-				} 
-				console.log("token ids RAW!!!", tokens.ids)
+				}
 			}
 			// else process like normal
 			else {
@@ -2442,7 +2444,10 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 				}
 			}
 
-			console.log("add",tokens.ids)
+			console.log("Biasing tokens [",tokens.ids.join(", "),"]",
+				Array.isArray(tokens.str) ? "'"+tokens.str.join("|")+"'"
+					: "'"+biasString+"'",
+				"by power",biasPower)
 			//console.log("shift",[ ...tokens.ids ],[ ...tokens.ids ].shift())
 			await setLogitBias((prevLogitBias) => ({
 				...prevLogitBias,
@@ -2455,7 +2460,6 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 					}
 				}
 			}));
-			console.log("added",logitBias.bias[biasString].ids)
 		}
 		catch(e) {
 			if (e.name !== 'AbortError') {
@@ -3783,10 +3787,9 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 
 		<${Modal} isOpen=${modalState.bias} onClose=${() => { closeModal("bias")}}
 		title="Logit Bias"
-		description="Make certain tokens more or less likely to be generated. 
+		description="Make certain tokens more or less likely to be generated. Recommended ranges are 100 to -100, with -100 being a total ban of the token.
 		Currently only works on the first token of multi-token phrases/words.
-		
-		Some models prepend spaces to any input sent to their detokenizer. If your bias doesn't appear to be working, try inputting the correct token IDs manually in a comma separated list, wrapped in '/'. Example: /382,1449,1802/
+		You can bias IDs directly in a comma separated list, wrapped in '/'. Example: /382,1449,1802/
 
 		Different models might tokenize words differently. Always Re-Tokenize your biases when switching models by pressing the '+' button again for every entry.">
 		${modalState.bias 
@@ -3838,7 +3841,7 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 							<div class="lb-modal-tokenized">
 								${endpointAPI == 0 && bias.strings != ""
 									? "["+bias.strings.join("|")+"] "
-									: "["+bias.tokens+"]" } (${bias.tokens.length} tokens)
+									: "["+bias.tokens+"]" } 
 								
 							</div>
 							<button
@@ -3851,7 +3854,7 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 							<button
 								disabled=${!!cancel}
 								class="hbox-button lb-modal-button lb-modal-button-remove"
-								onClick=${() => logitBiasAdd(Number(0), bias.valueBack, bias.valueBack)}
+								onClick=${() => logitBiasAdd("0", bias.valueBack, bias.valueBack)}
 								>
 								-
 							</button>
@@ -3984,7 +3987,7 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 				</${CollapsibleGroup}>
 				<button id="button-wi-new" disabled=${!!cancel} onClick=${handleWorldInfoNew}>New Entry</button>
 			</div>
-			<div className="modal-wi-content">
+			<div className="modal-wi-content overflow-container">
 				${ !Array.isArray(worldInfo.entries) ? null : worldInfo.entries.map((entry, index) => html`
 				<div class="wi-entry" key=${index}>
 					<div class="wi-entry-controls">

--- a/mikupad.html
+++ b/mikupad.html
@@ -2382,6 +2382,7 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 	const [tokens, setTokens] = useState(0);
 	const [predictStartTokens, setPredictStartTokens] = useState(0);
 	const [lastError, setLastError] = useState(undefined);
+	const [lastBiasError, setLastBiasError] = useState(undefined);
 	const [stoppingStrings, setStoppingStrings] = useSessionState('stoppingStrings', defaultPresets.stoppingStrings);
 	const [stoppingStringsError, setStoppingStringsError] = useState(undefined);
 	const [savedScrollTop, setSavedScrollTop] = useSessionState('scrollTop', defaultPresets.scrollTop);
@@ -2407,11 +2408,11 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 	}
 
 	const logitBiasAdd = async (biasPower="",biasString="",origValue="") => {
-		setLastError(undefined)
+		setLastBiasError(undefined)
 		// abort if no input or power is NaN
 		if(!biasString) {return}
 		if (isNaN(+biasPower) || biasPower == "") { 
-			setLastError("Error: Bias is NaN")
+			setLastBiasError("Error: Bias must be a number")
 			return
 		}
 		biasPower = Number(biasPower)
@@ -2421,7 +2422,7 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 		// delete entry if power 0 or empty
 		if (biasPower == 0) {	
 			if (!logitBias.bias[biasString]) {
-				setLastError("Error: Bias is 0")
+				setLastBiasError("Error: Bias 0 = no Bias")
 				return
 			}
 			console.log("delete",biasString)
@@ -3671,36 +3672,14 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 							</div>`}
 					`}
 				`}
-				
-				${(!openaiPresets || endpointAPI != 3) && html`
-					<div className="hbox-flex logitBiasContainer">
-						<div class="logitBiasPower-sidebar">
-							<${InputBox} label="Bias" className="logitBiasPower-container"
-								type="enumber"  max=100 min=-100 step=1
-								readOnly=${!!cancel}
-								onValueChange=${(value) => { handleLogitBiasInput("power",value)} }
-								value=${logitBiasInput.power} 
-								id="logitBiasPower"/>
-						</div>
-						<${InputBox} label="Token" type="text"
-							tooltip="Currently, only the first token of multi-token strings will be biased."
-							readOnly=${!!cancel}
-							value=${logitBiasInput.string}
-							placeholder="String or /ID,.../"
-							onValueChange=${() => {} }
-							onInput=${(e) => {handleLogitBiasInput("string",e.target.value)} }
-							children=${ html`
-								<button
-								className="textAreaSettings textAreaSettings-bias"
-								disabled=${!!cancel}
-								onClick=${() => toggleModal("bias")}>
-								<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="-1 -5 8 7" xmlns="http://www.w3.org/2000/svg"><path d="M0 0 3-3C3-4 3-5 5-5L4-4 5-3 6-4C6-2 5-2 4-2L1 1C0 2-1 1 0 0"></path></svg>
-								</button>
-							`}
-							/>
-						<button disabled=${!!cancel} class="hbox-button" onClick=${() => logitBiasAdd(logitBiasInput.power,logitBiasInput.string)}>+</button>
-					</div>`}
-			
+				${(endpointAPI != 3) && html`
+					<button
+						disabled=${!!cancel}
+						onClick=${() => toggleModal("bias")}>
+						Logit Bias
+						</button>
+					${!!lastBiasError && html`
+						<div className="error-text">${lastBiasError}</div>`}`}
 				${(!openaiPresets || endpointAPI != 3) && html`
 					<${Checkbox} label="Ignore <eos>"
 						disabled=${!!cancel} value=${ignoreEos} onValueChange=${setIgnoreEos}/>`}
@@ -3859,8 +3838,8 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 							/>
 						<button disabled=${!!cancel} class="hbox-button" onClick=${() => logitBiasAdd(logitBiasInput.power,logitBiasInput.string)}>+</button>
 					</div>
-			${!!lastError && html`
-				<div style=${{"margin":"8px auto"}} className="error-text">${lastError}</div>`}
+					${!!lastBiasError && html`
+						<div style=${{"margin":"8px auto"}} className="error-text">${lastBiasError}</div>`}
 			<hr style=${{"width":"95%","margin":"8px auto"}} />
 			<div class="lb-modal-biasList" >
 				${ Object.keys(logitBiasTemp).map((key) => {

--- a/mikupad.html
+++ b/mikupad.html
@@ -501,6 +501,10 @@ html.nockoffAI .wi-entry-name input {
 	position: relative;
 	flex-wrap: unset !important;
 }
+.logitBiasPower-sidebar {
+	width:10ch !important;
+} 
+
 
 .overflow-container {
 	overflow-y:auto;
@@ -3608,13 +3612,9 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 							</div>`}
 					`}
 				`}
-				${(!openaiPresets || endpointAPI != 3) && html`
-					<${Checkbox} label="Ignore <eos>"
-						disabled=${!!cancel} value=${ignoreEos} onValueChange=${setIgnoreEos}/>`}
-
 				${(endpointAPI == 0 || endpointAPI == 2) && html`
 					<div className="hbox-flex logitBiasContainer">
-						<div class="small-inputBox">
+						<div class="logitBiasPower-sidebar">
 							<${InputBox} label="Bias" className="logitBiasPower-container"
 								type="enumber"  max=100 min=-100 step=1
 								readOnly=${!!cancel}
@@ -3640,7 +3640,12 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 							/>
 						<button disabled=${!!cancel} class="hbox-button" onClick=${() => logitBiasAdd(logitBiasInput.power,logitBiasInput.string)}>+</button>
 						
-					</div>`}
+					</div>
+				`}
+				${(!openaiPresets || endpointAPI != 3) && html`
+					<${Checkbox} label="Ignore <eos>"
+						disabled=${!!cancel} value=${ignoreEos} onValueChange=${setIgnoreEos}/>`}
+
 
 			</${CollapsibleGroup}>
 			<${CollapsibleGroup} label="Persistent Context">

--- a/mikupad.html
+++ b/mikupad.html
@@ -2202,12 +2202,14 @@ export function App() {
 			setLastError("Error: Bias is NaN")
 			return
 		}
+		biasPower = Number(biasPower)
 
-
-		const modBias = logitBias.bias;	
+		const modBias = logitBias.bias;
 		
 		// delete entry if power 0 or empty
-		if (biasPower == 0 && logitBias[biasString]) {
+		if (biasPower == 0) {	
+			if (!logitBias.bias[biasString])
+				return
 			console.log("delete",biasString)
 			setLogitBias((prevLogitBias) => {
 				delete modBias[biasString]
@@ -2281,7 +2283,7 @@ export function App() {
 		// TODO grab multi-token strings here and put them in a separate state variable
 		Object.keys(logitBias.bias).forEach(entry => {
 			// set banned tokens to false
-			const power = logitBias.bias[entry].power < -99 ? false : logitBias.bias[entry].power;
+			const power = logitBias.bias[entry].power < -99 ? false : Number(logitBias.bias[entry].power);
 			param.push([Number(logitBias.bias[entry].ids[0]),power]);
 		})
 		console.log("params",param)
@@ -2296,7 +2298,7 @@ export function App() {
 		console.log("params",param)
 		setLogitBiasParam(param)
 	};
-	const updateLogitBiasParam = useEffect(() => {
+	const updateLogitBiasParam = useMemo(() => {
 		// console.log("endpoint",endpointAPI)
 		switch (endpointAPI) {
 			case 0:
@@ -2325,7 +2327,7 @@ export function App() {
 	};
 
 	const updateLogitBiasTempUse = useMemo(() => {
-		updateLogitBiasTemp()
+		updateLogitBiasTemp();
 	},[logitBiasSorted]);
 
 	const handleBiasTempChange = (posneg, key, index, value) => {
@@ -2348,7 +2350,7 @@ export function App() {
 	const logitBiasSearch = (value) => {
 		const filteredList = value ? Object.keys(logitBias.bias).filter(key => key.startsWith(value)) : []
 		const sorted = logitBiasSorted;
-		setLogitBiasSearchList(filteredList)
+		setLogitBiasSearchList(filteredList);
 	}
 
 	const logitBiasSort = useMemo(() => {

--- a/mikupad.html
+++ b/mikupad.html
@@ -630,10 +630,16 @@ html.monospace-dark .lb-search-entry {
 }
 html.monospace-dark #sidebar {
 	background: #282833;
+	width: 265px;
 }
 html.nockoffAI #sidebar {
 	background: var(--color-sidebar);
 	color: var(--color-base-50);
+	width: 255px;
+}
+
+.flex1 {
+	flex: 1;
 }
 
 .hbox {
@@ -642,6 +648,12 @@ html.nockoffAI #sidebar {
 	grid: auto / auto-flow minmax(min-content, 1fr);
 	gap: 8px;
 }
+.hbox-flex {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+}
+
 .vbox {
 	flex: none;
 	display: grid;
@@ -657,7 +669,7 @@ html.nockoffAI #sidebar {
 	font-size: 0.75rem;
 	padding: 0 8px;
 }
-.InputBox > input, .SelectBox > select, .TextArea > textarea {
+.InputBox > div > input, .SelectBox > select, .TextArea > textarea {
 	appearance: none;
 	border: none;
 	outline: none;
@@ -673,30 +685,30 @@ html.nockoffAI #sidebar {
 	flex: none;
 }
 
-html.monospace-dark .InputBox > input, html.monospace-dark .SelectBox > select,
-html.nockoffAI .InputBox > input, html.nockoffAI .SelectBox > select {
+html.monospace-dark .InputBox > div > input, html.monospace-dark .SelectBox > select,
+html.nockoffAI .InputBox > div > input, html.nockoffAI .SelectBox > select {
 	color: var(--color-light);
 }
 
-.InputBox > input:read-only {
+.InputBox > div > input:read-only {
 	background: var(--color-base-60);
 }
-html.monospace-dark .InputBox > input:read-only {
+html.monospace-dark .InputBox > div > input:read-only {
 	background: var(--color-base-30);
 }
-html.nockoffAI .InputBox > input:read-only {
+html.nockoffAI .InputBox > div > input:read-only {
 	background: var(--color-disabled);
 }
 html.nockoffAI .SelectBox > select,
 html.nockoffAI .collapsible-header,
-html.nockoffAI .InputBox > input {
+html.nockoffAI .InputBox > div > input {
 	background: var(--color-input);
 }
 html.nockoffAI .horz-separator {
 	border-top: 3px dotted color-mix(in oklch, var(--color-base-100) 90%, var(--color-light));
 }
 
-.InputBox > input:focus-visible {
+.InputBox > div > input:focus-visible {
 	outline: 1px solid var(--color-base-0);
 }
 .SelectBox > select:disabled {
@@ -714,11 +726,18 @@ html.nockoffAI .SelectBox > select:disabled {
   	bottom: .08em;
 }
 
-.InputBox > input.mixed-content {
+.InputBox > div > input.mixed-content {
 	outline: 1px solid yellow;
 }
-.InputBox > input.rejected {
+.InputBox > div > input.rejected {
 	outline: 1px solid #ff3131;
+}
+
+.InputBox > div > button {
+	margin-left: 4px;
+	padding: 4px;
+	line-height: 0;
+	margin-right: -8px;
 }
 
 .tooltip {
@@ -971,6 +990,23 @@ html.monospace-dark .Session.selected {
 	margin-right: 5%;
 }
 
+#error-bar {
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	min-height: 0;
+
+	background-color: #4E3534;
+	color: #FF8080;
+	text-align: center;
+	box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+#error-bar div {
+	padding: 10px;
+}
+
 .flex-separator {
 	margin-left: auto;
 }
@@ -1013,8 +1049,17 @@ export async function getTokenCount({ endpoint, endpointAPI, endpointAPIKey, sig
 			return await llamaCppTokenCount({ endpoint, endpointAPIKey, signal, ...options });
 		case 2: // koboldcpp
 			return await koboldCppTokenCount({ endpoint, signal, ...options });
-		case 3: // openai // TODO: Fix this for official OpenAI?
+		case 3: // openai
+			// These endpoints don't have a token count endpoint...
+			if (new URL(endpoint).host === 'api.openai.com' || new URL(endpoint).host === 'api.together.xyz')
+				return 0;
+
+			// Each backend that exposes an OpenAI-compatible API may have a different token count endpoint.
+			// Instead of asking the user which backend they are using, let's try each one.
 			let tokenCount = 0;
+			tokenCount = await openaiAphroditeTokenCount({ endpoint, endpointAPIKey, signal, ...options });
+			if (tokenCount != -1)
+				return tokenCount;
 			tokenCount = await openaiOobaTokenCount({ endpoint, signal, ...options });
 			if (tokenCount != -1)
 				return tokenCount;
@@ -1059,12 +1104,12 @@ export async function* completion({ endpoint, endpointAPI, endpointAPIKey, signa
 	}
 }
 
-export async function abortCompletion({ endpoint, endpointAPI }) {
+export async function abortCompletion({ endpoint, endpointAPI, ...options }) {
 	switch (endpointAPI) {
 		case 2: // koboldcpp
-			return await koboldCppAbortCompletion({ endpoint });
+			return await koboldCppAbortCompletion({ endpoint, ...options });
 		case 3: // openai (ooba)
-			return await openaiOobaAbortCompletion({ endpoint });
+			return await openaiOobaAbortCompletion({ endpoint, ...options });
 	}
 }
 
@@ -1103,6 +1148,8 @@ async function* parseEventStream(eventStream) {
 			}
 			// We only emit message-type events for now (and assume JSON)
 			if (data && (type || 'message') === 'message') {
+				if (data === '[DONE]')
+					break;
 				const json = JSON.parse(data);
 				// Both Chrome and Firefox suck at debugging
 				// text/event-stream, so make it easier by logging events
@@ -1115,12 +1162,13 @@ async function* parseEventStream(eventStream) {
 	}
 }
 
-async function llamaCppTokenCount({ endpoint, endpointAPIKey, signal, ...options }) {
-	const res = await fetch(new URL('/tokenize', endpoint), {
+async function llamaCppTokenCount({ endpoint, endpointAPIKey, proxyEndpoint, signal, ...options }) {
+	const res = await fetch(`${proxyEndpoint ?? endpoint}/tokenize`, {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json',
 			...(endpointAPIKey ? { 'Authorization': `Bearer ${endpointAPIKey}` } : {}),
+			...(proxyEndpoint ? { 'X-Real-URL': endpoint } : {})
 		},
 		body: JSON.stringify(options),
 		signal,
@@ -1131,12 +1179,13 @@ async function llamaCppTokenCount({ endpoint, endpointAPIKey, signal, ...options
 	return tokens.length + 1; // + 1 for BOS, I guess.
 }
 
-async function llamaCppTokenize({ endpoint, endpointAPIKey, signal, ...options }) {
+async function llamaCppTokenize({ endpoint, endpointAPIKey, proxyEndpoint, signal, ...options }) {
 	const res = await fetch(new URL('/tokenize', endpoint), {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json',
 			...(endpointAPIKey ? { 'Authorization': `Bearer ${endpointAPIKey}` } : {}),
+			...(proxyEndpoint ? { 'X-Real-URL': endpoint } : {})
 		},
 		body: JSON.stringify(options),
 		signal,
@@ -1158,12 +1207,13 @@ async function llamaCppTokenize({ endpoint, endpointAPIKey, signal, ...options }
 	};
 	return {ids:tokens,str:strings};
 }
-async function llamaCppDetokenize({ endpoint, endpointAPIKey, signal, ...options }) {
+async function llamaCppDetokenize({ endpoint, endpointAPIKey, proxyEndpoint, signal, ...options }) {
 	const res = await fetch(new URL('/detokenize', endpoint), {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json',
 			...(endpointAPIKey ? { 'Authorization': `Bearer ${endpointAPIKey}` } : {}),
+			...(proxyEndpoint ? { 'X-Real-URL': endpoint } : {})
 		},
 		body: JSON.stringify(options),
 		signal,
@@ -1171,16 +1221,17 @@ async function llamaCppDetokenize({ endpoint, endpointAPIKey, signal, ...options
 	if (!res.ok)
 		throw new Error(`HTTP ${res.status}`);
 	const { content } = await res.json();
-	//console.log("detokenized","." + content + ".")
+	console.log("detokenized","." + content + ".")
 	return content
 }
 
-async function* llamaCppCompletion({ endpoint, endpointAPIKey, signal, ...options }) {
-	const res = await fetch(new URL('/completion', endpoint), {
+async function* llamaCppCompletion({ endpoint, endpointAPIKey, proxyEndpoint, signal, ...options }) {
+	const res = await fetch(`${proxyEndpoint ?? endpoint}/completion`, {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json',
 			...(endpointAPIKey ? { 'Authorization': `Bearer ${endpointAPIKey}` } : {}),
+			...(proxyEndpoint ? { 'X-Real-URL': endpoint } : {})
 		},
 		body: JSON.stringify({
 			...options,
@@ -1194,11 +1245,24 @@ async function* llamaCppCompletion({ endpoint, endpointAPIKey, signal, ...option
 	return yield* await parseEventStream(res.body);
 }
 
-async function koboldCppTokenCount({ endpoint, signal, ...options }) {
-	const res = await fetch(new URL('/api/extra/tokencount', endpoint), {
+function koboldFixEndpoint(endpoint) {
+	const url = new URL(endpoint.trim());
+	url.pathname = url.pathname.replace(/\/+/g, "/"); // normalize consecutive slashes
+	
+	let urlString = url.toString();
+	urlString = urlString.replace(/\/api\/?$/, ""); // remove "/api" from the end of the string
+	urlString = urlString.replace(/\/$/, ""); // remove "/" from the end of the string
+	
+	return urlString;
+}
+
+async function koboldCppTokenCount({ endpoint, proxyEndpoint, signal, ...options }) {
+	endpoint = koboldFixEndpoint(endpoint);
+	const res = await fetch(`${proxyEndpoint ?? endpoint}/api/extra/tokencount`, {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json',
+			...(proxyEndpoint ? { 'X-Real-URL': endpoint } : {})
 		},
 		body: JSON.stringify({
 			prompt: options.content
@@ -1254,11 +1318,13 @@ function koboldCppConvertOptions(options) {
 	return options;
 }
 
-async function* koboldCppCompletion({ endpoint, signal, ...options }) {
-	const res = await fetch(new URL('/api/extra/generate/stream', endpoint), {
+async function* koboldCppCompletion({ endpoint, proxyEndpoint, signal, ...options }) {
+	endpoint = koboldFixEndpoint(endpoint);
+	const res = await fetch(`${proxyEndpoint ?? endpoint}/api/extra/generate/stream`, {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json',
+			...(proxyEndpoint ? { 'X-Real-URL': endpoint } : {})
 		},
 		body: JSON.stringify({
 			...koboldCppConvertOptions(options),
@@ -1273,18 +1339,64 @@ async function* koboldCppCompletion({ endpoint, signal, ...options }) {
 	}
 }
 
-async function koboldCppAbortCompletion({ endpoint }) {
-	await fetch(new URL('/api/extra/abort', endpoint), {
-		method: 'POST',
-	});
+async function koboldCppAbortCompletion({ endpoint, proxyEndpoint, ...options }) {
+	try {
+		endpoint = koboldFixEndpoint(endpoint);
+		await fetch(`${proxyEndpoint ?? endpoint}/api/extra/abort`, {
+			method: 'POST',
+			headers: {
+				...(proxyEndpoint ? { 'X-Real-URL': endpoint } : {})
+			},
+		});
+	} catch (e) {
+		reportError(e);
+	}
 }
 
-async function openaiOobaTokenCount({ endpoint, signal, ...options }) {
+function openaiFixEndpoint(endpoint) {
+	const url = new URL(endpoint.trim());
+	url.pathname = url.pathname.replace(/\/+/g, "/"); // normalize consecutive slashes
+	
+	let urlString = url.toString();
+	urlString = urlString.replace(/\/v1\/?$/, ""); // remove "/v1" from the end of the string
+	urlString = urlString.replace(/\/$/, ""); // remove "/" from the end of the string
+	
+	return urlString;
+}
+
+async function openaiAphroditeTokenCount({ endpoint, endpointAPIKey, proxyEndpoint, signal, ...options }) {
 	try {
-		const res = await fetch(new URL('/v1/internal/token-count', endpoint), {
+		endpoint = openaiFixEndpoint(endpoint);
+		const res = await fetch(`${proxyEndpoint ?? endpoint}/v1/token/encode`, {
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',
+				'Authorization': `Bearer ${endpointAPIKey}`,
+				...(proxyEndpoint ? { 'X-Real-URL': endpoint } : {})
+			},
+			body: JSON.stringify({
+				prompt: options.content
+			}),
+			signal,
+		});
+		if (!res.ok)
+			throw new Error(`HTTP ${res.status}`);
+		const tokens = await res.json();
+		return tokens.length;
+	} catch (e) {
+		reportError(e);
+		return -1;
+	}
+}
+
+async function openaiOobaTokenCount({ endpoint, proxyEndpoint, signal, ...options }) {
+	try {
+		endpoint = openaiFixEndpoint(endpoint);
+		const res = await fetch(`${proxyEndpoint ?? endpoint}/v1/internal/token-count`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				...(proxyEndpoint ? { 'X-Real-URL': endpoint } : {})
 			},
 			body: JSON.stringify({
 				text: options.content
@@ -1301,13 +1413,15 @@ async function openaiOobaTokenCount({ endpoint, signal, ...options }) {
 	}
 }
 
-async function openaiTabbyTokenCount({ endpoint, endpointAPIKey, signal, ...options }) {
+async function openaiTabbyTokenCount({ endpoint, endpointAPIKey, proxyEndpoint, signal, ...options }) {
 	try {
-		const res = await fetch(new URL('/v1/token/encode', endpoint), {
+		endpoint = openaiFixEndpoint(endpoint);
+		const res = await fetch(`${proxyEndpoint ?? endpoint}/v1/token/encode`, {
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',
 				'Authorization': `Bearer ${endpointAPIKey}`,
+				...(proxyEndpoint ? { 'X-Real-URL': endpoint } : {})
 			},
 			body: JSON.stringify({
 				text: options.content
@@ -1324,12 +1438,14 @@ async function openaiTabbyTokenCount({ endpoint, endpointAPIKey, signal, ...opti
 	}
 }
 
-async function openaiModels({ endpoint, endpointAPIKey, signal, ...options }) {
-	const res = await fetch(new URL('/v1/models', endpoint), {
+async function openaiModels({ endpoint, endpointAPIKey, proxyEndpoint, signal, ...options }) {
+	endpoint = openaiFixEndpoint(endpoint);
+	const res = await fetch(`${proxyEndpoint ?? endpoint}/v1/models`, {
 		method: 'GET',
 		headers: {
 			'Content-Type': 'application/json',
 			'Authorization': `Bearer ${endpointAPIKey}`,
+			...(proxyEndpoint ? { 'X-Real-URL': endpoint } : {})
 		},
 		signal,
 	});
@@ -1339,7 +1455,9 @@ async function openaiModels({ endpoint, endpointAPIKey, signal, ...options }) {
 	return data.map(item => item.id);
 }
 
-function openaiConvertOptions(options, isOpenAI) {
+function openaiConvertOptions(options, endpoint){
+	const isOpenAI = endpoint.toLowerCase().includes("openai.com");
+	const isTogetherAI = endpoint.toLowerCase().includes("together.xyz");
 	const swapOption = (lhs, rhs) => {
 		if (lhs in options) {
 			options[rhs] = options[lhs];
@@ -1362,6 +1480,10 @@ function openaiConvertOptions(options, isOpenAI) {
 		// oobabooga specific.
 		options.do_sample = false;
 	}
+	if (isTogetherAI) {
+		// errors 400 without this.
+		delete options.logprobs;
+	}
 	swapOption("n_ctx", "max_context_length");
 	swapOption("n_predict", "max_tokens");
 	swapOption("n_probs", "logprobs");
@@ -1373,15 +1495,17 @@ function openaiConvertOptions(options, isOpenAI) {
 	return options;
 }
 
-async function* openaiCompletion({ endpoint, endpointAPIKey, signal, ...options }) {
-	const res = await fetch(new URL('/v1/completions', endpoint), {
+async function* openaiCompletion({ endpoint, endpointAPIKey, proxyEndpoint, signal, ...options }) {
+	endpoint = openaiFixEndpoint(endpoint);
+	const res = await fetch(`${proxyEndpoint ?? endpoint}/v1/completions`, {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json',
 			'Authorization': `Bearer ${endpointAPIKey}`,
+			...(proxyEndpoint ? { 'X-Real-URL': endpoint } : {})
 		},
 		body: JSON.stringify({
-			...openaiConvertOptions(options, endpoint.toLowerCase().includes("openai.com")),
+			...openaiConvertOptions(options, endpoint),
 			stream: true,
 		}),
 		signal,
@@ -1401,37 +1525,45 @@ async function* openaiCompletion({ endpoint, endpointAPIKey, signal, ...options 
 	}
 }
 
-async function openaiOobaAbortCompletion({ endpoint }) {
+async function openaiOobaAbortCompletion({ endpoint, proxyEndpoint, ...options }) {
+	endpoint = openaiFixEndpoint(endpoint);
 	try {
-		await fetch(new URL('/v1/internal/stop-generation', endpoint), {
+		await fetch(`${proxyEndpoint ?? endpoint}/v1/internal/stop-generation`, {
 			method: 'POST',
+			headers: {
+				...(proxyEndpoint ? { 'X-Real-URL': endpoint } : {})
+			},
 		});
 	} catch (e) {
 		reportError(e);
 	}
 }
 
-function InputBox({ label, tooltip, tooltipSize, value, type, datalist, onValueChange, ...props }) {
+function InputBox({ label, className, tooltip, tooltipSize, value, type, datalist, onValueChange, children, ...props }) {
 	return html`
 		<label className="InputBox ${tooltip ? 'tooltip' : ''}">
 			${label}
-			<input
-				type=${ (type === "enumber") ? "number" : (type === "" ? "text" : type) }
-				list="${datalist ? label : ''}"
-				value=${value}
-				size="1"
-				onChange=${({ target }) => {
-					let value = type === 'number' ? target.valueAsNumber : target.value;
-					if (props.inputmode === 'numeric') {
-						props.pattern = '^-?[0-9]*$';
-						if (value && !isNaN(+value))
-							value = +target.value;
-					}
-					if (props.pattern && !new RegExp(props.pattern).test(value))
-						return;
-					onValueChange(value);
-				}}
-				...${props}/>
+			<div className="${children ? 'hbox-flex' : ''}">
+				<input
+					className="flex1 ${className}"
+					type=${type || 'text'}
+					list="${datalist ? label : ''}"
+					value=${value}
+					size="1"
+					onChange=${({ target }) => {
+						let value = type === 'number' ? target.valueAsNumber : target.value;
+						if (props.inputmode === 'numeric') {
+							props.pattern = '^-?[0-9]*$';
+							if (value && !isNaN(+value))
+								value = +target.value;
+						}
+						if (props.pattern && !new RegExp(props.pattern).test(value))
+							return;
+						onValueChange(value);
+					}}
+					...${props}/>
+				${children}
+			</div>
 			${datalist && html`
 				<datalist id="${label}">
 					${datalist.map(opt => html`
@@ -1545,7 +1677,7 @@ function CollapsibleGroup({ label, expanded, children }) {
 		`;
 	}
 
-function Sessions({ sessionStorage, onSessionChange, disabled }) {
+function Sessions({ sessionStorage, onSessionChange, onSessionError, disabled }) {
 	const [version, setVersion] = useState(0);
 	const [newSessionName, setNewSessionName] = useState('');
 	const [renameSessionName, setRenameSessionName] = useState('');
@@ -1555,9 +1687,11 @@ function Sessions({ sessionStorage, onSessionChange, disabled }) {
 	useEffect(() => {
 		sessionStorage.onchange = () => setVersion(v => v + 1);
 		sessionStorage.onsessionchange = onSessionChange;
+		sessionStorage.onerror = onSessionError;
 		return () => {
 			sessionStorage.onchange = null;
 			sessionStorage.onsessionchange = null;
+			sessionStorage.onerror = null;
 		};
 	}, []);
 
@@ -1739,25 +1873,25 @@ class SessionStorage {
 		this.sessionTemplate = { ...defaultPresets };
 		this.onchange = null;
 		this.onsessionchange = null;
+		this.onerror = null;
 	}
 
 	async init() {
-		try {
-			const db = await this.openDatabase();
-			this.nextId = (await this.loadFromDatabase(db, 'nextSessionId')) || 0;
-			this.selectedSession = (await this.loadFromDatabase(db, 'selectedSessionId')) || 0;
-			await this.loadSessions(db);
-			this.saveTimer = setInterval(async () => await this.saveTimerHandler(), 500);
-		} catch (e) {
-			reportError(e);
-		}
+		const db = await this.openDatabase();
+		this.nextId = (await this.loadFromDatabase(db, 'nextSessionId')) || 0;
+		this.selectedSession = (await this.loadFromDatabase(db, 'selectedSessionId')) || 0;
+		await this.loadSessions(db);
+		this.saveTimer = setInterval(async () => await this.saveTimerHandler(), 500);
 	}
 
 	async openDatabase() {
 		return new Promise((resolve, reject) => {
 			const openRequest = indexedDB.open(this.dbName);
 
-			openRequest.onerror = () => reject(openRequest.error);
+			openRequest.onerror = () => {
+				this.onerror?.(openRequest.error);
+				reject(openRequest.error);
+			};
 			openRequest.onsuccess = () => resolve(openRequest.result);
 			openRequest.onupgradeneeded = (event) => {
 				const db = event.target.result;
@@ -1787,8 +1921,12 @@ class SessionStorage {
 	}
 
 	async saveTimerHandler() {
+		const sessions = [];
 		while (this.saveQueue.length) {
-			const sessionId = this.saveQueue.pop();
+			sessions.push(this.saveQueue.pop());
+		}
+
+		for (const sessionId of sessions) {
 			if (!this.sessions[sessionId])
 				continue;
 			await this.saveToDatabase(sessionId, this.sessions[sessionId]);
@@ -1971,6 +2109,115 @@ class SessionStorage {
 	}
 }
 
+class WebSessionStorage extends SessionStorage {
+	constructor(defaultPresets, sessionEndpoint) {
+		super(defaultPresets);
+		this.sessionEndpoint = sessionEndpoint;
+		this.proxyEndpoint = `${sessionEndpoint}/proxy`;
+	}
+
+	async openDatabase() {
+		return async (route, options) => {
+			try {
+				return await fetch(new URL(route, this.sessionEndpoint), {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+					},
+					body: JSON.stringify(options),
+				});
+			} catch (e) {
+				this.onerror?.(e);
+				reportError(e);
+				return { ok: false, status: e.toString() };
+			}
+		};
+	}
+
+	async loadFromDatabase(db, key) {
+		return new Promise(async (resolve, reject) => {
+			const res = await db("/load", { key });
+			if (!res.ok) {
+				if (res.status == 404) {
+					resolve(undefined);
+				} else {
+					reject(res.status);
+				}
+				return;
+			}
+			const { result } = await res.json();
+			resolve(result);
+		});
+	}
+
+	async saveToDatabase(key, data) {
+		const db = await this.openDatabase();
+		return new Promise(async (resolve, reject) => {
+			const res = await db("/save", { data, key });
+			if (!res.ok) {
+				reject(res.status);
+				return;
+			}
+			const { result } = await res.json();
+			resolve(result);
+		});
+	}
+
+	async loadSessions(db) {
+		return new Promise(async (resolve, reject) => {
+			const res = await db("/sessions");
+			if (!res.ok) {
+				reject(res.status);
+				return;
+			}
+			const { result } = await res.json();
+			const sessions = result;
+
+			for (const [key, value] of Object.entries(sessions)) {
+				if (key !== 'nextSessionId' && key !== 'selectedSessionId') {
+					this.sessions[key] = value;
+				}
+			}
+
+			if (Object.keys(this.sessions).length === 0) {
+				if (!await this.migrateSessions()) {
+					await this.createSession('MikuPad #1');
+				}
+			}
+
+			await this.switchSession(this.selectedSession);
+			resolve();
+		});
+	}
+
+	async deleteSession(sessionId) {
+		if (Object.keys(this.sessions).length === 1)
+			return;
+		if (!window.confirm("Are you sure you want to delete this session? This action can't be undone."))
+			return;
+		const db = await this.openDatabase();
+		return new Promise(async (resolve, reject) => {
+			const res = await db("/delete", { sessionId });
+			if (!res.ok) {
+				reject(res.status);
+				return;
+			}
+			
+			// Select another session if the current was deleted
+			if (sessionId == this.selectedSession) {
+				const sessionIds = Object.keys(this.sessions).map(x => +x);
+				const sessionIdx = sessionIds.indexOf(sessionId);
+				const newSessionId = sessionIds[sessionIdx - 1] ?? sessionIds[sessionIdx + 1];
+				await this.switchSession(+newSessionId)
+			}
+
+			delete this.sessions[sessionId];
+			this.onchange?.();
+			resolve();
+		});
+	}
+}
+
 const defaultPrompt = `[INST] <<SYS>>
 You are a talented writing assistant. Always respond by incorporating the instructions into expertly written prose that is highly detailed, evocative, vivid and engaging.
 <</SYS>>
@@ -2086,13 +2333,14 @@ function usePersistentState(name, initialState) {
 	return [value, updateState];
 }
 
-export function App({ sessionStorage, useSessionState }) {
+export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 	const promptArea = useRef();
 	const promptOverlay = useRef();
 	const undoStack = useRef([]);
 	const redoStack = useRef([]);
 	const probsDelayTimer = useRef();
 	const keyState = useRef({});
+	const sessionReconnectTimer = useRef();
 	const [currentPromptChunk, setCurrentPromptChunk] = useState(undefined);
 	const [undoHovered, setUndoHovered] = useState(false);
 	const [showProbs, setShowProbs] = useState(true);
@@ -2102,8 +2350,10 @@ export function App({ sessionStorage, useSessionState }) {
 	const [showProbsMode, setShowProbsMode] = usePersistentState('showProbsMode', 0);
 	const [highlightGenTokens, setHighlightGenTokens] = usePersistentState('highlightGenTokens', true);
 	const [preserveCursorPosition, setPreserveCursorPosition] = usePersistentState('preserveCursorPosition', true);
-	const [darkMode, _] = usePersistentState('darkMode', false); // legacy
-	const [theme, setTheme] = usePersistentState('theme', darkMode ? 1 : 0);
+	const [promptAreaWidth, setPromptAreaWidth] = usePersistentState('promptAreaWidth', undefined);
+	const [theme, setTheme] = usePersistentState('theme', 0);
+	const [sessionEndpointConnecting, setSessionEndpointConnecting] = useState(false);
+	const [sessionEndpointError, setSessionEndpointError] = useState(undefined);
 	const [endpoint, setEndpoint] = useSessionState('endpoint', defaultPresets.endpoint);
 	const [endpointAPI, setEndpointAPI] = useSessionState('endpointAPI', defaultPresets.endpointAPI);
 	const [endpointAPIKey, setEndpointAPIKey] = useSessionState('endpointAPIKey', defaultPresets.endpointAPIKey);
@@ -2197,7 +2447,7 @@ export function App({ sessionStorage, useSessionState }) {
 		}
 
 		const ac = new AbortController();
-		// console.log("input","."+biasString+".",biasPower)
+		console.log("input","."+biasString+".",biasPower)
 
 		try {
 			const tokens = await getTokens({
@@ -2206,13 +2456,14 @@ export function App({ sessionStorage, useSessionState }) {
 				...(endpointAPI == 3 || endpointAPI == 0 ? { endpointAPIKey } : {}),
 				content: `${biasString}`,
 				signal: ac.signal,
-			})
+				...(isMikupadEndpoint ? { proxyEndpoint: sessionStorage.proxyEndpoint } : {})
+			});
 			console.log("add",tokens)
 			setLogitBias((prevLogitBias) => ({
 				...prevLogitBias,
 				bias: {
 					...modBias,
-					[biasString]: {
+					[String(biasString)]: {
 						ids: [ ...tokens.ids ],
 						strings: [ ...tokens.str ],
 						power: biasPower
@@ -2252,7 +2503,7 @@ export function App({ sessionStorage, useSessionState }) {
 		Object.keys(logitBias.bias).forEach(entry => {
 			// set banned tokens to false
 			const power = logitBias.bias[entry].power < -99 ? false : Number(logitBias.bias[entry].power);
-			param.push([Number(logitBias.bias[entry].ids[0]),power]);
+			param.push( [ Number(logitBias.bias[entry].ids[0]), power ] );
 		})
 		console.log("params",param)
 		setLogitBiasParam(param)
@@ -2322,15 +2573,23 @@ export function App({ sessionStorage, useSessionState }) {
 	}
 
 	const logitBiasSort = useMemo(() => {
-
 		const biasListToSort = Object.entries(logitBias.bias);
-		const biasListSorted = biasListToSort
-			.sort((a, b) => parseInt(b[1].power) - parseInt(a[1].power));
-		
-		const resultArray = biasListSorted.map(([key]) => key);
+		const sortPowerString = (a, b) => {
+			const powerDiff = parseInt(b[1].power) - parseInt(a[1].power);
+			if (powerDiff !== 0) {
+				// If powers are different, sort by power
+				return powerDiff;
+			} else {
+				// If powers are the same, sort alphabetically by string value
+				return a[0].localeCompare(b[0]);
+			}
+    };
 
-		setLogitBiasSorted(resultArray)
-	}, [logitBias]);
+    const biasListSorted = biasListToSort.sort(sortPowerString);
+    const resultArray = biasListSorted.map(([key]) => key);
+
+    setLogitBiasSorted(resultArray);
+}, [logitBias]);
 
 	const debugLogitBias = useMemo(() => {
 		console.log("logit bias",logitBias)
@@ -2580,7 +2839,11 @@ export function App({ sessionStorage, useSessionState }) {
 
 		const ac = new AbortController();
 		const cancelThis = () => {
-			abortCompletion({ endpoint, endpointAPI });
+			abortCompletion({
+				endpoint,
+				endpointAPI,
+				...(isMikupadEndpoint ? { proxyEndpoint: sessionStorage.proxyEndpoint } : {})
+			});
 			ac.abort();
 		};
 		setCancel(() => cancelThis);
@@ -2597,6 +2860,7 @@ export function App({ sessionStorage, useSessionState }) {
 				...(endpointAPI == 3 || endpointAPI == 0 ? { endpointAPIKey } : {}),
 				content: ` ${prompt}`,
 				signal: ac.signal,
+				...(isMikupadEndpoint ? { proxyEndpoint: sessionStorage.proxyEndpoint } : {})
 			});
 			setTokens(tokenCount);
 			setPredictStartTokens(tokenCount);
@@ -2608,6 +2872,7 @@ export function App({ sessionStorage, useSessionState }) {
 			setUndoHovered(false);
 			setRejectedAPIKey(false);
 
+			console.log("AAAAAAAAAAAAAAAAAAAA",logitBiasParam)
 			for await (const chunk of completion({
 				endpoint,
 				endpointAPI,
@@ -2626,7 +2891,6 @@ export function App({ sessionStorage, useSessionState }) {
 					penalize_nl: penalizeNl,
 					ignore_eos: ignoreEos,
 				} : {}),
-				// not sure if I need the openaiPresets here
 				...(logitBias.bias.length > 0 ? {
 					logit_bias: logitBiasParam, // [[39,-20],[37934,-20]], //
 				} : {}),
@@ -2647,8 +2911,9 @@ export function App({ sessionStorage, useSessionState }) {
 				}),
 				n_predict: maxPredictTokens,
 				n_probs: 10,
-				stop: JSON.parse(stoppingStrings) || [],
+				...(JSON.parse(stoppingStrings).length ? { stop: JSON.parse(stoppingStrings) } : {}),
 				signal: ac.signal,
+				...(isMikupadEndpoint ? { proxyEndpoint: sessionStorage.proxyEndpoint } : {})
 			})) {
 				ac.signal.throwIfAborted();
 				if (chunk.stopping_word)
@@ -2701,6 +2966,7 @@ export function App({ sessionStorage, useSessionState }) {
 
 	function undoAndPredict() {
 		if (!undoStack.current.length) return;
+		if (triggerPredict) return;
 		const didUndo = undo();
 		if (didUndo) {
 			setTriggerPredict(true);
@@ -2721,7 +2987,7 @@ export function App({ sessionStorage, useSessionState }) {
 			predict();
 			setTriggerPredict(false);
 		}
-	}, [triggerPredict, predict]);
+	}, [triggerPredict]);
 
 	useLayoutEffect(() => {
 		if (attachSidebar)
@@ -2729,6 +2995,14 @@ export function App({ sessionStorage, useSessionState }) {
 		else
 			document.body.classList.remove('attachSidebar');
 	}, [attachSidebar]);
+
+	useLayoutEffect(() => {
+		if (promptAreaWidth) {
+			const container = document.querySelector('#prompt-container');
+			container.style.setProperty('min-width', promptAreaWidth);
+			container.style.setProperty('max-width', promptAreaWidth);
+		}
+	}, [promptAreaWidth]);
 
 	useLayoutEffect(() => {
 		document.documentElement.classList.remove('serif-dark');
@@ -2841,6 +3115,7 @@ export function App({ sessionStorage, useSessionState }) {
 					...(endpointAPI == 3 || endpointAPI == 0 ? { endpointAPIKey } : {}),
 					content: ` ${modifiedPrompt}`,
 					signal: ac.signal,
+					...(isMikupadEndpoint ? { proxyEndpoint: sessionStorage.proxyEndpoint } : {})
 				});
 				setTokens(tokenCount);
 			} catch (e) {
@@ -2864,6 +3139,7 @@ export function App({ sessionStorage, useSessionState }) {
 					endpointAPI,
 					...(endpointAPI == 3 ? { endpointAPIKey } : {}),
 					signal: ac.signal,
+					...(isMikupadEndpoint ? { proxyEndpoint: sessionStorage.proxyEndpoint } : {})
 				});
 				setOpenaiModels(models);
 			} catch (e) {
@@ -2927,6 +3203,83 @@ export function App({ sessionStorage, useSessionState }) {
 			window.removeEventListener('keyup', onKeyUp)
 		};
 	}, [predict, cancel]);
+
+	// textarea resize
+	useEffect(() => {
+		const container = document.querySelector('#prompt-container');
+
+		let isDragging = false;
+		let startX;
+		let startMaxWidth;
+		let startEdge;
+		let edgeDetectionZone = 10; // Pixels from edge to trigger resize
+
+		function getNearEdge(e) {
+			const rect = promptArea.current.getBoundingClientRect();
+			if ((e.clientX - rect.left < edgeDetectionZone && e.clientX - rect.left > 0)) {
+				return 'left';
+			} else if ((rect.right - e.clientX < edgeDetectionZone && rect.right - e.clientX > 0)) {
+				return 'right';
+			}
+			return false;
+		}
+
+		function startDragging(e) {
+			const edge = getNearEdge(e);
+			if (!edge) return; // Only drag from edges
+
+			// reset selection
+			promptArea.current.selectionStart = promptArea.current.selectionEnd;
+
+			isDragging = true;
+
+			const invEdgePos = edge == 'right' ? promptArea.current.getBoundingClientRect().left : promptArea.current.getBoundingClientRect().right;
+			startX = e.clientX - invEdgePos;
+			startMaxWidth = getComputedStyle(container).getPropertyValue('max-width');
+			startEdge = edge;
+		}
+
+		function drag(e) {
+			switch (getNearEdge(e)) {
+				case 'right':
+					promptArea.current.style.cursor = 'col-resize';
+					promptArea.current.style.borderRight = '1px dotted var(--color-light)';
+					break;
+				case 'left':
+					promptArea.current.style.cursor = 'col-resize';
+					promptArea.current.style.borderLeft = '1px dotted var(--color-light)';
+					break;
+				default:
+					promptArea.current.style.cursor = '';
+					promptArea.current.style.border = '';
+					break;
+			}
+			
+			if (!isDragging) return;
+
+			// reset selection
+			promptArea.current.selectionStart = promptArea.current.selectionEnd;
+
+			const invEdgePos = startEdge == 'right' ? promptArea.current.getBoundingClientRect().left : promptArea.current.getBoundingClientRect().right;
+			const currentX = e.clientX - invEdgePos;
+			setPromptAreaWidth(`calc(${startMaxWidth} + ${(currentX - startX) * (startEdge == 'right' ? 1 : -1)}px)`);
+		}
+
+		function stopDragging() {
+			isDragging = false;
+		}
+
+		promptArea.current.addEventListener('mousedown', startDragging);
+		document.addEventListener('mousemove', drag);
+		document.addEventListener('mouseup', stopDragging);
+		document.addEventListener('mouseleave', stopDragging);
+		return () => {
+			promptArea.current.removeEventListener('mousedown', startDragging);
+			document.removeEventListener('mousemove', drag);
+			document.removeEventListener('mouseup', stopDragging);
+			document.removeEventListener('mouseleave', stopDragging);
+		};
+	}, [promptArea]);
 
 	function onInput({ target }) {
 		setPromptChunks(oldPrompt => {
@@ -3094,6 +3447,24 @@ export function App({ sessionStorage, useSessionState }) {
 		setTitleToSession();
 	}
 
+	function onSessionError(e) {
+		if (!sessionReconnectTimer.current) {
+			sessionReconnectTimer.current = setInterval(async () => {
+				try {
+					await sessionStorage.saveToDatabase('selectedSessionId', sessionStorage.selectedSession);
+					setSessionEndpointError(undefined);
+					clearTimeout(sessionReconnectTimer.current);
+					sessionReconnectTimer.current = undefined;
+				} catch (e) {
+					reportError(e);
+				}
+			}, 1000);
+		}
+		setSessionEndpointError("Mikupad server is unreachable!");
+		setCurrentPromptChunk(undefined);
+		setUndoHovered(false);
+	}
+
 	const probs = useMemo(() =>
 		showProbs && promptChunks[currentPromptChunk?.index]?.completion_probabilities?.[0]?.probs,
 		[promptChunks, currentPromptChunk, showProbs]);
@@ -3155,7 +3526,8 @@ export function App({ sessionStorage, useSessionState }) {
 			<${CollapsibleGroup} label="Sessions">
 				<${Sessions} sessionStorage=${sessionStorage}
 					disabled=${!!cancel}
-					onSessionChange=${onSessionChange}/>
+					onSessionChange=${onSessionChange}
+					onSessionError=${onSessionError}/>
 			</${CollapsibleGroup}>
 			<${CollapsibleGroup} label="Parameters" expanded>
 				<${InputBox} label="Server"
@@ -3386,19 +3758,18 @@ export function App({ sessionStorage, useSessionState }) {
 			<div className="buttons">
 				<button
 					title="Run next prediction (Ctrl + Enter)"
-					className=${cancel ? (predictStartTokens === tokens ? 'processing' : 'completing') : ''}
+					className=${cancel && !sessionEndpointConnecting ? (predictStartTokens === tokens ? 'processing' : 'completing') : ''}
 					disabled=${!!cancel || stoppingStringsError}
 					onClick=${() => predict()}>
 					Predict
 				</button>
 				<button
 					title="Cancel prediction (Escape)"
-					disabled=${!cancel}
+					disabled=${!cancel || sessionEndpointConnecting}
 					onClick=${cancel}>
 					Cancel
 				</button>
 				<div className="shorts">
-				${!cancel && (!!undoStack.current.length || !!redoStack.current.length) && html`
 					<button
 						title="Regenerate (Ctrl + R)"
 						disabled=${!undoStack.current.length}
@@ -3406,26 +3777,24 @@ export function App({ sessionStorage, useSessionState }) {
 						onMouseEnter=${() => setUndoHovered(true)}
 						onMouseLeave=${() => setUndoHovered(false)}>
 						<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 40.499 40.5"><path d="M39.622,21.746l-6.749,6.75c-0.562,0.562-1.326,0.879-2.122,0.879s-1.56-0.316-2.121-0.879l-6.75-6.75		c-1.171-1.171-1.171-3.071,0-4.242c1.171-1.172,3.071-1.172,4.242,0l1.832,1.832C27.486,13.697,22.758,9.25,17,9.25		c-6.064,0-11,4.935-11,11c0,6.064,4.936,11,11,11c1.657,0,3,1.343,3,3s-1.343,3-3,3c-9.373,0-17-7.626-17-17s7.627-17,17-17		c8.936,0,16.266,6.933,16.936,15.698l1.442-1.444c1.172-1.172,3.072-1.172,4.242,0C40.792,18.674,40.792,20.574,39.622,21.746z" fill="var(--color-light)"/></svg>
-					</button>`}
+					</button>
 				</div>
 
 				<div className="shorts">
-					${!cancel && (!!undoStack.current.length || !!redoStack.current.length) && html`
-						<button
-							title="Undo (Ctrl + Z)"
-							disabled=${!undoStack.current.length}
-							onClick=${() => undo()}
-							onMouseEnter=${() => setUndoHovered(true)}
-							onMouseLeave=${() => setUndoHovered(false)}>
-							<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24"><path d="M17.026 22.957c10.957-11.421-2.326-20.865-10.384-13.309l2.464 2.352h-9.106v-8.947l2.232 2.229c14.794-13.203 31.51 7.051 14.794 17.675z" fill="var(--color-light)"/></svg>
-						</button>`}
-					${!cancel && (!!undoStack.current.length || !!redoStack.current.length) && html`
-						<button
-							title="Redo (Ctrl + Y)"
-							disabled=${!redoStack.current.length}
-							onClick=${() => redo()}>
-							<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24"><path d="M6.974 22.957c-10.957-11.421 2.326-20.865 10.384-13.309l-2.464 2.352h9.106v-8.947l-2.232 2.229c-14.794-13.203-31.51 7.051-14.794 17.675z" fill="var(--color-light)"/></svg>
-						</button>`}
+					<button
+						title="Undo (Ctrl + Z)"
+						disabled=${!!cancel || !undoStack.current.length}
+						onClick=${() => undo()}
+						onMouseEnter=${() => setUndoHovered(true)}
+						onMouseLeave=${() => setUndoHovered(false)}>
+						<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24"><path d="M17.026 22.957c10.957-11.421-2.326-20.865-10.384-13.309l2.464 2.352h-9.106v-8.947l2.232 2.229c14.794-13.203 31.51 7.051 14.794 17.675z" fill="var(--color-light)"/></svg>
+					</button>
+					<button
+						title="Redo (Ctrl + Y)"
+						disabled=${!!cancel || !redoStack.current.length}
+						onClick=${() => redo()}>
+						<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24"><path d="M6.974 22.957c-10.957-11.421 2.326-20.865 10.384-13.309l-2.464 2.352h9.106v-8.947l-2.232 2.229c-14.794-13.203-31.51 7.051-14.794 17.675z" fill="var(--color-light)"/></svg>
+					</button>
 				</div>
 			</div>
 			${!!lastError && html`
@@ -3720,17 +4089,42 @@ export function App({ sessionStorage, useSessionState }) {
 				`)}
 			</div>
 		</${Modal}>
+		${sessionEndpointError && html`
+			<div className="modal-overlay">
+				<div id="error-bar">
+					<div>
+						${sessionEndpointError}
+					</div>
+				</div>
+			</div>`}
 	`;
 }
 
 async function main() {
-	const sessionStorage = new SessionStorage(defaultPresets);
-	await sessionStorage.init();
+	let sessionStorage = null;
+	let isMikupadEndpoint = false;
+
+	if (window.location.protocol != 'file:' && window.location.pathname == '/') {
+		sessionStorage = new WebSessionStorage(defaultPresets, window.location.protocol + '//' + window.location.host);
+		try {
+			await sessionStorage.init();
+			isMikupadEndpoint = true;
+		} catch (e) {
+			sessionStorage = null;
+			reportError(e);
+		}
+	}
+	
+	if (sessionStorage == null) {
+		sessionStorage = new SessionStorage(defaultPresets);
+		await sessionStorage.init();
+	}
 
 	createRoot(document.body).render(html`
 		<${App}
 			sessionStorage=${sessionStorage}
-			useSessionState=${(name, initialState) => useSessionState(sessionStorage, name, initialState)}/>`);
+			useSessionState=${(name, initialState) => useSessionState(sessionStorage, name, initialState)}
+			isMikupadEndpoint=${isMikupadEndpoint}/>`);
 }
 
 main();

--- a/mikupad.html
+++ b/mikupad.html
@@ -1276,7 +1276,7 @@ async function koboldCppTokenCount({ endpoint, proxyEndpoint, signal, ...options
 }
 
 async function koboldCppTokenize({ endpoint, signal, ...options }) {
-	// console.log("kcpp",options.content)
+	console.log("kcpp",options.content)
 	const res = await fetch(new URL('/api/extra/tokencount', endpoint), {
 		method: 'POST',
 		headers: {
@@ -1290,8 +1290,11 @@ async function koboldCppTokenize({ endpoint, signal, ...options }) {
 	if (!res.ok)
 		throw new Error(`HTTP ${res.status}`);
 	const { ids } = await res.json();
+	console.log(ids)
 	ids.shift() // kobold automatically adds a token, so we need to remove it
-	// console.log("shift",ids)
+	// at this point I think kobold just automatically adds a space to the front of
+	// requests, which fucks up the token IDs for things at the beginning of a sentence.
+	console.log("shift",ids)
 	return {ids:ids,str:""};
 	
 }
@@ -2428,7 +2431,7 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 				endpoint,
 				endpointAPI,
 				...(endpointAPI == 3 || endpointAPI == 0 ? { endpointAPIKey } : {}),
-				content: `${biasString}`.replace(/\\n/g, '\n'),
+				content: `${biasString}`.replace(/\\n/g,'\n'),
 				signal: ac.signal,
 				...(isMikupadEndpoint ? { proxyEndpoint: sessionStorage.proxyEndpoint } : {})
 			});
@@ -2472,6 +2475,7 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 
 
 	const llamaCppSetLogitBiasParams = () => {
+		// limits unclear. breaks down at around +-11
 		const param = [];
 		// TODO grab multi-token strings here and put them in a separate state variable
 		// for phrase bias
@@ -2484,10 +2488,10 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 		setLogitBiasParam(param)
 	};
 	const koboldCppSetLogitBiasParams = () => {
+		// 100.0 to -100.0
 		const param = {};
 		Object.keys(logitBias.bias).forEach(entry => {
 			param[Number(logitBias.bias[entry].ids[0])] = Number(logitBias.bias[entry].power)
-			// console.log(logitBias.bias[entry].ids[0])
 		})
 		console.log("params",param)
 		setLogitBiasParam(param)
@@ -2846,9 +2850,8 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 			setUndoHovered(false);
 			setRejectedAPIKey(false);
 
-			console.log("AAAAAAAAAAAAAAAAAAAA",logitBias)
-			console.log(logitBias.bias)
-			console.log(logitBias.bias.length)
+			console.log("AAAAAAAAAAAAAAAAAAAA",logitBiasParam)
+			console.log(Object.keys(logitBias.bias).length, Object.keys(logitBias.bias).length > 0)
 			for await (const chunk of completion({
 				endpoint,
 				endpointAPI,
@@ -2868,7 +2871,7 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 					ignore_eos: ignoreEos,
 				} : {}),
 				...(Object.keys(logitBias.bias).length > 0 ? {
-					logit_bias: logitBiasParam, // [[39,-20],[37934,-20]], //
+					logit_bias: logitBiasParam, // [[" The",false]], // [[39,-20],[37934,-20]], // { 415: 100 }, //
 				} : {}),
 				presence_penalty: presencePenalty,
 				frequency_penalty: frequencyPenalty,

--- a/mikupad.html
+++ b/mikupad.html
@@ -1236,7 +1236,7 @@ async function llamaCppDetokenize({ endpoint, endpointAPIKey, proxyEndpoint, sig
 	if (!res.ok)
 		throw new Error(`HTTP ${res.status}`);
 	const { content } = await res.json();
-	console.log("detokenized","." + content + ".")
+	//console.log("detokenized","." + content + ".")
 	return content
 }
 
@@ -1290,7 +1290,7 @@ async function koboldCppTokenCount({ endpoint, proxyEndpoint, signal, ...options
 }
 
 async function koboldCppTokenize({ endpoint, proxyEndpoint, signal, ...options }) {
-	console.log("kcpp",options.content)
+	//console.log("kcpp",options.content)
 	const res = await fetch(new URL('/api/extra/tokencount', endpoint), {
 		method: 'POST',
 		headers: {
@@ -1305,9 +1305,9 @@ async function koboldCppTokenize({ endpoint, proxyEndpoint, signal, ...options }
 	if (!res.ok)
 		throw new Error(`HTTP ${res.status}`);
 	const { ids } = await res.json();
-	console.log(ids)
+	//console.log(ids)
 	ids.shift() // kobold automatically adds a token, so we need to remove it
-	console.log("shift",ids)
+	//console.log("shift",ids)
 	return {ids:ids,str:""};
 	
 }
@@ -2385,8 +2385,6 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 	const [stoppingStrings, setStoppingStrings] = useSessionState('stoppingStrings', defaultPresets.stoppingStrings);
 	const [stoppingStringsError, setStoppingStringsError] = useState(undefined);
 	const [savedScrollTop, setSavedScrollTop] = useSessionState('scrollTop', defaultPresets.scrollTop);
-
-	//- Logit Bias --//
 	const [logitBias, setLogitBias] = useSessionState('logitBias', defaultPresets.logitBias);
 	const [logitBiasParam, setLogitBiasParam] = useState({});
 	const [logitBiasTemp, setLogitBiasTemp] = useState([]);
@@ -2396,24 +2394,21 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 	const [logitBiasInput, setLogitBiasInput] = useState({power:"2",string:"string"});
 
 	const handleLogitBiasInput = (key,value) => {
-		// console.log(key, value)
 		setLogitBiasInput((prevLogitBiasInput) => {
 			return {
 				...prevLogitBiasInput,
 				[key]: value
 			}
 		});
-		// console.log(logitBiasInput)
 
 	}
 
 	const logitBiasAdd = async (biasPower="",biasString="",origValue="") => {
 		setLastError(undefined)
-		console.log("values",biasPower,biasString,origValue)
-		// console.log(logitBiasInput)
+		//console.log("values",biasPower,biasString,origValue)
 		// abort if no input or power is NaN
 		if(!biasString) {return}
-		console.log("power",biasPower)
+		//console.log("power",biasPower)
 		if (isNaN(+biasPower) || biasPower == "") { 
 			setLastError("Error: Bias is NaN")
 			return
@@ -2445,14 +2440,14 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 		}
 
 		const ac = new AbortController();
-		console.log("input","."+biasString+".",biasPower)
-		console.log("replace","."+biasString.replace(/\\n/g, '\n')+".")
+		//console.log("input","."+biasString+".",biasPower)
+		//console.log("replace","."+biasString.replace(/\\n/g, '\n')+".")
 		try {
 			// if the string is a comma separated list of numbers wrapped in /
 			var tokens
 			const isTokenIds = biasString.match(/^(?<!\\)\/(\s*\d+\s*,?\s*)+(?<!\\)\/$/g)
 			if ( isTokenIds != null ) {
-				// split by , and use it as token ids directly
+				// split by "," and use it as token ids directly
 				tokens = {
 					ids: isTokenIds[0].replaceAll("/","").split(",").map( item => Number(item.trim()) ),
 					str: ""
@@ -2461,36 +2456,54 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 			}
 			// else process like normal
 			else {
-				// KNOWN ISSUE: some models automatically prepend a space to any tokenization input.
-				// to work around this, I'm prepending the input with a "|", then shifting the output
-				// array by one to remove the " |" token. I know this is an absolute hack, but this is
-				// the best I could come up with.
+				// KNOWN ISSUE: some models automatically prepend a space to any tokenization 
+				// input. to work around this, I'm prepending the input with a "!==", then 
+				// slicing the output array by the number of tokens of "!==".
+				// This could cause issues when trying to bias a token starting with ? where
+				// ? is any character that forms a single token together with " !==", like 
+				// this: " !==?" I've chosen "!==" because it seems to be a very conserved
+				// token between models.
+				//
+				// Now granted, I have not found any strings where this is actually an issue in 
+				// the tokenizers of the models I use, but this is still a huge hackjob of a 
+				// workaround. If anyone can think of a better solution, please let me know.
 				tokens = await getTokens({
 					endpoint,
 					endpointAPI,
 					...(endpointAPI == 3 || endpointAPI == 0 ? { endpointAPIKey } : {}),
-					content: `|${biasString}`.replace(/\\n/g,'\n'),
+					content: `!==${biasString}`.replace(/\\n/g,'\n'),
 					signal: ac.signal,
 					...(isMikupadEndpoint ? { proxyEndpoint: sessionStorage.proxyEndpoint } : {})
 				});
+				const logitBiasWorkaround = await getTokens({
+					endpoint,
+					endpointAPI,
+					...(endpointAPI == 3 || endpointAPI == 0 ? { endpointAPIKey } : {}),
+					content: `!==`,
+					signal: ac.signal,
+					...(isMikupadEndpoint ? { proxyEndpoint: sessionStorage.proxyEndpoint } : {})
+				});
+				// Remove however many tokens !== is tokenized as for the workaround
+				tokens.ids = tokens.ids.slice(logitBiasWorkaround.ids.length)
+				if ( Array.isArray(tokens.str) ) {
+					tokens.str = tokens.str.slice(logitBiasWorkaround.ids.length)
+				}
 			}
-			tokens.ids.shift()
-			if ( Array.isArray(tokens.str) ) {
-				tokens.str.shift()
-			}
-			console.log("add",tokens)
+
+			console.log("add",tokens.ids)
 			//console.log("shift",[ ...tokens.ids ],[ ...tokens.ids ].shift())
-			setLogitBias((prevLogitBias) => ({
+			await setLogitBias((prevLogitBias) => ({
 				...prevLogitBias,
 				bias: {
 					...modBias,
-					[String(biasString)]: {
+					[biasString]: { // REMOVED STRING() HERE IF SHIT BREAKS
 						ids: [ ...tokens.ids ],
 						strings: [ ...tokens.str ],
 						power: biasPower
 					}
 				}
 			}));
+			console.log("added",logitBias.bias[biasString].ids)
 		}
 		catch(e) {
 			if (e.name !== 'AbortError') {
@@ -2509,35 +2522,40 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 		}
 	};
 	const logitBiasRetokenize = async () => { // I don't understand why this doesn't work.
-		for (const key in logitBias.bias) {
-			console.log("retok",key,logitBias.bias[key])
-			await logitBiasAdd(Number(logitBias.bias[key].power),key);
-			//await new Promise(r => setTimeout(r, 200));
+		console.log(logitBias.bias)
+		const logitBiasLocal = logitBias.bias
+		for (const key in logitBiasLocal) {
+			console.log("retok",key,logitBiasLocal[key].ids)
+
+			await logitBiasAdd(Number(logitBiasLocal[key].power),key,key);
+			await new Promise(r => setTimeout(r, 2000));
+			console.log("done",key,logitBias.bias[key].ids)
+			console.log("--------------------")
 		}
 	};
 
 
 
 	const llamaCppSetLogitBiasParams = () => {
-		// limits unclear. breaks down at around +-11
 		const param = [];
 		// TODO grab multi-token strings here and put them in a separate state variable
 		// for phrase bias
 		Object.keys(logitBias.bias).forEach(entry => {
-			// set banned tokens to false
-			const power = logitBias.bias[entry].power < -99 ? false : Number(logitBias.bias[entry].power);
+			// set banned tokens to false, else divide power by 10 to remain within
+			// reasonable range
+			const power = logitBias.bias[entry].power < -99 ? false : Number(logitBias.bias[entry].power) / 10;
 			param.push( [ Number(logitBias.bias[entry].ids[0]), power ] );
 		})
-		console.log("params",param)
+		//console.log("params",param)
 		setLogitBiasParam(param)
 	};
 	const koboldCppSetLogitBiasParams = () => {
-		// 100.0 to -100.0
 		const param = {};
 		Object.keys(logitBias.bias).forEach(entry => {
+			// no manip needed here. range is documented to be 100 to -100
 			param[Number(logitBias.bias[entry].ids[0])] = Number(logitBias.bias[entry].power)
 		})
-		console.log("params",param)
+		//console.log("params",param)
 		setLogitBiasParam(param)
 	};
 	const updateLogitBiasParam = useMemo(() => {
@@ -2553,7 +2571,7 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 	}, [logitBias, endpointAPI]);
 
 
-	const updateLogitBiasTemp = () => {
+	const updateLogitBiasTemp =  useEffect(() => {
 		const tempArray = logitBiasSorted.map((string, index) =>  ({
 			value: string,
 			valueBack: string,
@@ -2565,11 +2583,8 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 			positive: tempArray.filter(item => item.power > 0),
 			negative: tempArray.filter(item => item.power < 0)
 		});
-	};
-
-	const updateLogitBiasTempUse = useMemo(() => {
-		updateLogitBiasTemp();
 	},[logitBiasSorted]);
+
 
 	const handleBiasTempChange = (posneg, key, index, value) => {
 		// console.log("up temp",key, value)
@@ -2605,21 +2620,21 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 				// If powers are the same, sort alphabetically by string value
 				return a[0].localeCompare(b[0]);
 			}
-    };
+		};
 
-    const biasListSorted = biasListToSort.sort(sortPowerString);
-    const resultArray = biasListSorted.map(([key]) => key);
+		const biasListSorted = biasListToSort.sort(sortPowerString);
+		const resultArray = biasListSorted.map(([key]) => key);
 
-    setLogitBiasSorted(resultArray);
-}, [logitBias]);
-
-	const debugLogitBias = useMemo(() => {
-		console.log("logit bias",logitBias)
+		setLogitBiasSorted(resultArray);
 	}, [logitBias]);
 
-	const debugLogitBiasSearch = useMemo(() => {
-		console.log("searchlist",logitBiasSearchList)
-	}, [logitBiasSearchList]);
+	// const debugLogitBias = useMemo(() => {
+	// 	console.log("logit bias",logitBias)
+	// }, [logitBias]);
+
+	// const debugLogitBiasSearch = useMemo(() => {
+	// 	console.log("searchlist",logitBiasSearchList)
+	// }, [logitBiasSearchList]);
 
 	//- Persistent Context --//
 
@@ -2897,7 +2912,7 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 			useScrollSmoothing.current = true;
 
 			console.log("AAAAAAAAAAAAAAAAAAAA",logitBiasParam)
-			console.log(Object.keys(logitBias.bias).length, Object.keys(logitBias.bias).length > 0)
+			//console.log(Object.keys(logitBias.bias).length, Object.keys(logitBias.bias).length > 0)
 			for await (const chunk of completion({
 				endpoint,
 				endpointAPI,
@@ -3872,7 +3887,7 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 			</div>
 		</${Modal}>
 
-		<${Modal} isOpen=${modalState.bias} onClose=${() => {updateLogitBiasTemp(); closeModal("bias")}}
+		<${Modal} isOpen=${modalState.bias} onClose=${() => { closeModal("bias")}}
 		title="Logit Bias"
 		description="Make certain tokens more or less likely to be generated. 
 		Currently only works on the first token of multi-token phrases/words.
@@ -3922,7 +3937,7 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 								type="enumber" max=100 min=-100 step=1
 								id="lb-modal-power-${index}"
 								readOnly=${!!cancel}
-								onValueChange=${(value) => {console.log(value); handleBiasTempChange(key,"power", index, value)} }
+								onValueChange=${(value) => {handleBiasTempChange(key,"power", index, value)} }
 								value=${bias.power}/>
 							<label className="InputBox">
 								Token

--- a/mikupad.html
+++ b/mikupad.html
@@ -2511,12 +2511,12 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 				reportError(e);
 				const errStr = e.toString();
 				if ((endpointAPI == 3 || endpointAPI == 0) && errStr.includes("401")) {
-					setLastError("Error: Rejected API Key");
+					setLastBiasError("Error: Rejected API Key");
 					setRejectedAPIKey(true);
 				} else if (endpointAPI == 3 && errStr.includes("429")) {
-					setLastError("Error: Insufficient Quota");
+					setLastBiasError("Error: Insufficient Quota");
 				} else {
-					setLastError(errStr);
+					setLastBiasError(errStr);
 				}
 			}
 			return

--- a/mikupad.html
+++ b/mikupad.html
@@ -381,9 +381,6 @@ html.nockoffAI  #context-order-desc,
 html.nockoffAI .modal-desc {
 	color:var(--color-base-80);
 }
-/* .modal-content {
-	overflow-y: auto;
-} */
 
 .button-modal-top {
 	all:unset;
@@ -1031,7 +1028,7 @@ export async function getTokenCount({ endpoint, endpointAPI, endpointAPIKey, sig
 			// Each backend that exposes an OpenAI-compatible API may have a different token count endpoint.
 			// Instead of asking the user which backend they are using, let's try each one.
 			let tokenCount = 0;
-			tokenCount = await openaiAphroditeTokenCount({ endpoint, endpointAPIKey, signal, ...options });
+			//tokenCount = await openaiAphroditeTokenCount({ endpoint, endpointAPIKey, signal, ...options });
 			if (tokenCount != -1)
 				return tokenCount;
 			tokenCount = await openaiOobaTokenCount({ endpoint, signal, ...options });
@@ -1055,6 +1052,8 @@ export async function getTokens({ endpoint, endpointAPI, endpointAPIKey, signal,
 			return await llamaCppTokenize({ endpoint, endpointAPIKey, signal, ...options });
 		case 2: // koboldcpp
 			return await koboldCppTokenize({ endpoint, signal, ...options });
+		case 3: // openai
+			return await openaiTokenize({ endpoint, endpointAPIKey, signal, ...options })
 	}
 }
 
@@ -1395,6 +1394,59 @@ async function openaiTabbyTokenCount({ endpoint, endpointAPIKey, proxyEndpoint, 
 		reportError(e);
 		return -1;
 	}
+}
+
+async function openaiTokenize({ endpoint, endpointAPIKey, proxyEndpoint, signal, ...options }) {
+	try {
+		const res = await fetch(`${proxyEndpoint ?? endpoint}/v1/internal/encode`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				...(proxyEndpoint ? { 'X-Real-URL': endpoint } : {})
+			},
+			body: JSON.stringify({
+				text: options.content
+			}),
+			signal,
+		});
+		if (!res.ok)
+			throw new Error(`HTTP ${res.status}`);
+		const { tokens } = await res.json();
+
+		const strings = [];
+		for (let i=0; i<tokens.length; i++) {
+			const string = await openaiDetokenize({
+					endpoint,
+					...(endpointAPIKey ? {
+						endpointAPIKey,
+					} : {}),
+					tokens: [ tokens[i] ],
+					signal: signal,
+			});
+			strings.push(string);
+		};
+		return {ids:tokens,str:strings};
+		
+	} catch (e) {
+		reportError(e);
+		return -1;
+	}
+}
+async function openaiDetokenize({ endpoint, endpointAPIKey, proxyEndpoint, signal, ...options }) {
+
+	const res = await fetch(`${proxyEndpoint ?? endpoint}/v1/internal/decode`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			...(proxyEndpoint ? { 'X-Real-URL': endpoint } : {})
+		},
+		body: JSON.stringify(options),
+		signal,
+	});
+	if (!res.ok)
+		throw new Error(`HTTP ${res.status}`);
+	const { text } = await res.json();
+	return text
 }
 
 async function openaiModels({ endpoint, endpointAPIKey, proxyEndpoint, signal, ...options }) {
@@ -2479,7 +2531,9 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 		}
 	};
 
-
+	const clamp = (num, min = -Infinity, max = Infinity) => {
+		return Math.min(Math.max(num, min), max);
+	}
 
 	const llamaCppSetLogitBiasParams = () => {
 		const param = [];
@@ -2496,11 +2550,20 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 	const koboldCppSetLogitBiasParams = () => {
 		const param = {};
 		Object.keys(logitBias.bias).forEach(entry => {
-			// no manip needed here. range is documented to be 100 to -100
-			param[Number(logitBias.bias[entry].ids[0])] = Number(logitBias.bias[entry].power)
+			// -100 to 100
+			param[Number(logitBias.bias[entry].ids[0])] = clamp(Number(logitBias.bias[entry].power),-100,100)
 		})
 		setLogitBiasParam(param)
 	};
+	const openaiSetLogitBiasParams = () => {
+		const param = {};
+		Object.keys(logitBias.bias).forEach(entry => {
+			// -100 to 100
+			param[Number(logitBias.bias[entry].ids[0])] = clamp(Number(logitBias.bias[entry].power),-100,100).toFixed(1)
+		})
+		setLogitBiasParam(param)
+	};
+
 	const updateLogitBiasParam = useMemo(() => {
 		// set the parameters sent to the model in the format expected by the endpoint
 		switch (endpointAPI) {
@@ -2509,6 +2572,10 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 				break;
 			case 2:
 				koboldCppSetLogitBiasParams()
+				break;
+			case 3:
+				//openaiSetLogitBiasParams()
+				// for some reason this causes an error
 				break;
 		}
 	}, [logitBias, endpointAPI]);
@@ -2851,7 +2918,7 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 					penalize_nl: penalizeNl,
 					ignore_eos: ignoreEos,
 				} : {}),
-				...(Object.keys(logitBias.bias).length > 0 ? {
+				...(Object.keys(logitBias.bias).length > 0 && endpointAPI != 3 ? {
 					logit_bias: logitBiasParam,
 				} : {}),
 				presence_penalty: presencePenalty,
@@ -3613,7 +3680,8 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 							</div>`}
 					`}
 				`}
-				${(endpointAPI == 0 || endpointAPI == 2) && html`
+				
+				${(!openaiPresets || endpointAPI != 3) && html`
 					<div className="hbox-flex logitBiasContainer">
 						<div class="logitBiasPower-sidebar">
 							<${InputBox} label="Bias" className="logitBiasPower-container"
@@ -3640,9 +3708,8 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 							`}
 							/>
 						<button disabled=${!!cancel} class="hbox-button" onClick=${() => logitBiasAdd(logitBiasInput.power,logitBiasInput.string)}>+</button>
-						
-					</div>
-				`}
+					</div>`}
+			
 				${(!openaiPresets || endpointAPI != 3) && html`
 					<${Checkbox} label="Ignore <eos>"
 						disabled=${!!cancel} value=${ignoreEos} onValueChange=${setIgnoreEos}/>`}

--- a/mikupad.html
+++ b/mikupad.html
@@ -2344,6 +2344,7 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 	const [stoppingStrings, setStoppingStrings] = useSessionState('stoppingStrings', defaultPresets.stoppingStrings);
 	const [stoppingStringsError, setStoppingStringsError] = useState(undefined);
 	const [savedScrollTop, setSavedScrollTop] = useSessionState('scrollTop', defaultPresets.scrollTop);
+	const [modalState, setModalState] = useState({});
 	const [logitBias, setLogitBias] = useSessionState('logitBias', defaultPresets.logitBias);
 	const [logitBiasParam, setLogitBiasParam] = useState({});
 	const [logitBiasTemp, setLogitBiasTemp] = useState([]);
@@ -2525,7 +2526,7 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 			positive: tempArray.filter(item => item.power > 0),
 			negative: tempArray.filter(item => item.power < 0)
 		});
-	},[logitBiasSorted]);
+	},[logitBiasSorted,modalState.bias]);
 
 
 	const handleBiasTempChange = (posneg, key, index, value) => {
@@ -2638,7 +2639,7 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 		}));
 	}
 
-	const [modalState, setModalState] = useState({});
+	
 	const toggleModal = (modalKey) => {
 		setModalState((prevState) => ({
 			...prevState,

--- a/mikupad.html
+++ b/mikupad.html
@@ -1191,121 +1191,6 @@ async function* llamaCppCompletion({ endpoint, endpointAPIKey, signal, ...option
 	return yield* await parseEventStream(res.body);
 }
 
-async function oobaTokenCount({ endpoint, signal, ...options }) {
-	try {
-		endpoint = `http:${endpoint.split(":")[1]}:5000`; // HACK!
-		const res = await fetch(new URL('/api/v1/token-count', endpoint), {
-			method: 'POST',
-			headers: {
-				'Content-Type': 'application/json',
-			},
-			body: JSON.stringify({
-				prompt: options.content
-			}),
-			signal,
-		});
-		if (!res.ok)
-			throw new Error(`HTTP ${res.status}`);
-		const { results } = await res.json();
-		return results[0].tokens;
-	} catch (e) {
-		reportError(e);
-		return 0;
-	}
-}
-
-async function oobaTokenize({ endpoint, signal, ...options }) {
-	try {
-		endpoint = `http:${endpoint.split(":")[1]}:5000`; // HACK!
-		const res = await fetch(new URL('/api/v1/token-count', endpoint), {
-			method: 'POST',
-			headers: {
-				'Content-Type': 'application/json',
-			},
-			body: JSON.stringify({
-				prompt: options.content
-			}),
-			signal,
-		});
-		if (!res.ok)
-			throw new Error(`HTTP ${res.status}`);
-		const { results } = await res.json();
-		return results[0]; // TODO TEST
-	} catch (e) {
-		reportError(e);
-		return 0;
-	}
-}
-
-function oobaConvertOptions(options) {
-	const swapOption = (lhs, rhs) => {
-		if (lhs in options) {
-			options[rhs] = options[lhs];
-			delete options[lhs];
-		}
-	};
-	if (options.n_predict === -1) {
-		options.n_predict = 1024;
-	}
-	swapOption("n_ctx", "truncation_length");
-	swapOption("n_predict", "max_new_tokens");
-	swapOption("repeat_penalty", "repetition_penalty");
-	swapOption("repeat_last_n", "repetition_penalty_range");
-	swapOption("ignore_eos", "ban_eos_token");
-	swapOption("stop", "stopping_strings");
-	return options;
-}
-
-async function* oobaCompletion({ endpoint, signal, ...options }) {
-	const ws = new WebSocket(new URL('/api/v1/stream', endpoint));
-	let connected = false;
-
-	ws.onopen = () => {
-		connected = true;
-		ws.send(JSON.stringify(oobaConvertOptions(options)));
-	};
-
-	const wsStream = () => new EventIterator(
-		queue => {
-			ws.onmessage = queue.push;
-			ws.onclose = queue.stop;
-			ws.onerror = (e) => queue.fail(new Error(connected ? "WebSocket Error" : "Failed to connect"));
-			if (signal) {
-				signal.addEventListener("abort", queue.stop);
-			}
-
-			return () => {
-				ws.close();
-				if (signal) {
-					signal.removeEventListener("abort", queue.stop);
-				}
-			}
-		}
-	);
-
-	for await (const event of wsStream()) {
-		const data = JSON.parse(event.data);
-		console.log('event', data);
-
-		if (data.event === "text_stream") {
-			yield { content: data.text };
-		} else if (data.event === "stream_end") {
-			break;
-		}
-	}
-}
-
-async function oobaAbortCompletion({ endpoint }) {
-	try {
-		endpoint = `http:${endpoint.split(":")[1]}:5000`; // HACK!
-		await fetch(new URL('/api/v1/stop-stream', endpoint), {
-			method: 'POST',
-		});
-	} catch (e) {
-		reportError(e);
-	}
-}
-
 async function koboldCppTokenCount({ endpoint, signal, ...options }) {
 	const res = await fetch(new URL('/api/extra/tokencount', endpoint), {
 		method: 'POST',
@@ -2657,7 +2542,7 @@ export function App() {
 					ignore_eos: ignoreEos,
 				} : {}),
 				// not sure if I need the openaiPresets here
-				...(!openaiPresets || [0,2].includes(endpointAPI) && logitBias.bias.length > 0 ? {
+				...(logitBias.bias.length > 0 ? {
 					logit_bias: logitBiasParam, // [[39,-20],[37934,-20]], //
 				} : {}),
 				presence_penalty: presencePenalty,

--- a/mikupad.html
+++ b/mikupad.html
@@ -1028,7 +1028,7 @@ export async function getTokenCount({ endpoint, endpointAPI, endpointAPIKey, sig
 			// Each backend that exposes an OpenAI-compatible API may have a different token count endpoint.
 			// Instead of asking the user which backend they are using, let's try each one.
 			let tokenCount = 0;
-			//tokenCount = await openaiAphroditeTokenCount({ endpoint, endpointAPIKey, signal, ...options });
+			tokenCount = await openaiAphroditeTokenCount({ endpoint, endpointAPIKey, signal, ...options });
 			if (tokenCount != -1)
 				return tokenCount;
 			tokenCount = await openaiOobaTokenCount({ endpoint, signal, ...options });

--- a/mikupad.html
+++ b/mikupad.html
@@ -562,6 +562,7 @@ html.monospace-dark .lb-search-entry {
 
 .lb-modal-grid-column {
 	display: grid;
+	grid-auto-rows: min-content;
 	gap: 8px;
 	max-height: 60vh;
 	padding-right: .75em;
@@ -569,7 +570,7 @@ html.monospace-dark .lb-search-entry {
 .lb-modal-grid-row  {
   display: grid;
   grid-template-columns: 4em 1fr min-content;
-  grid-template-rows: 1fr min-content min-content;
+  grid-template-rows: min-content min-content min-content;
   gap: 0 8px;
   grid-template-areas: 
     "power input add"
@@ -589,6 +590,8 @@ html.monospace-dark .lb-search-entry {
 }
 .lb-modal-tokenized { 
 	grid-area: tokens;
+	font-family: monospace;
+	font-size:0.85rem;
 	margin-top: auto;
 	display: grid;
 	align-content: center;
@@ -2146,6 +2149,7 @@ export function App() {
 	const [savedScrollTop, setSavedScrollTop] = useSessionState('scrollTop', defaultPresets.scrollTop);
 
 	const [logitBias, setLogitBias] = useSessionState('logitBias', defaultPresets.logitBias);
+	const [logitBiasTemp, setLogitBiasTemp] = useState([]);
 	const [logitBiasSearchList, setLogitBiasSearchList] = useState([]);
 	const [logitBiasSorted, setLogitBiasSorted] = useState([]);
 	const [logitBiasSearchState, setLogitBiasSearchState] = useState(false);
@@ -2153,7 +2157,6 @@ export function App() {
 	const doNothing = () => { return } // very elegant.
 
 	const logitBiasAdd = async (index,posneg="",origValue="") => {
-		
 		const [biasTokens,biasPower] = (()=>{
 			switch (true) {
 				case index == "sidebar":
@@ -2161,9 +2164,9 @@ export function App() {
 					const biasTokens = document.querySelector("#logitBiasTokens").value;
 					const biasPower = document.querySelector("#logitBiasPower").value;
 					return [biasTokens,biasPower];
-
 				case !isNaN(+index):
 					try {
+						// need to change handling here?
 						console.log("modal",index,posneg)
 						const biasTokens = document.querySelector("#lb-modal-"+posneg+" #lb-modal-input-"+index).value;
 						const biasPower = document.querySelector("#lb-modal-"+posneg+" #lb-modal-power-"+index).value;
@@ -2173,23 +2176,21 @@ export function App() {
 						console.warn("Attempted to modify an out of range index in logit bias modal")
 						return
 					}
-					return [false,false]
-
 				default:
 					console.log("switch defaulted")
 					return [false,false]
 			}
 		})();
 		
-		// abort if no input
+		// abort if no input or power is NaN
 		if(!biasTokens) {return}
+		if (isNaN(+biasPower)) { return }
 
 		console.log("values",biasTokens,biasPower)
 
 		const modBias = logitBias.bias;
 		
-		// abort if power isn't a number
-		if (isNaN(+biasPower)) { return }
+		
 		// delete entry if power 0 or empty
 		if (biasPower == 0 || biasPower == "" && logitBias[biasTokens]) {
 			console.log("delete",biasTokens)
@@ -2234,14 +2235,67 @@ export function App() {
 				}
 			}
 		}));
-
-		if (!isNaN(index)) {
-			toggleModal("bias");
-			toggleModal("bias");
-		}
+		//console.log("temp",logitBiasTemp)
+		// if (!isNaN(index)) {
+		// 	repopLogitBiasModal()
+		// }
 	};
 
-	const logitBiasSearch = async (value) => {
+	const updateLogitBiasTemp = (() => {
+		const tempArray = logitBiasSorted.map((string, index) =>  ({
+			value: string,
+			strings: logitBias.bias[string].strings,
+			power: logitBias.bias[string].power
+		}));
+		setLogitBiasTemp({
+			positive: tempArray.filter(item => item.power > 0),
+			negative: tempArray.filter(item => item.power < 0)
+		});
+	});
+
+	// const handleBiasTempChange = ((key,index,value) => {
+	// 	console.log("cur temp",logitBiasTemp)
+	// 	console.log("update temp",key, index, value)
+	// 	setLogitBiasTemp((prevLogitBiasTemp) => {
+	// 		const updatedTemp = prevLogitBiasTemp;
+	// 		updatedTemp[index][key] = String(value);
+	// 		return updatedTemp;
+	// 	})
+	// 	console.log("up temp",logitBiasTemp[index])
+	// })
+	const handleBiasTempChange = (posneg,key, index, value) => {
+		setLogitBiasTemp((prevLogitBiasTemp) => {
+			const rest = { ...prevLogitBiasTemp };
+			const updatedTemp = [ ...prevLogitBiasTemp[posneg] ];
+			 
+			updatedTemp[index] = {
+				...updatedTemp[index],
+				[key]: value,
+			};
+			return {
+				...rest,
+				[posneg]: updatedTemp
+			};
+		});
+		console.log("up temp",logitBiasTemp[index])
+	};
+
+	// const handleWorldInfoChange = (key,index,value) => {
+	// 	setWorldInfo((prevWorldInfo) => {
+	// 		const updatedEntries = [...prevWorldInfo.entries];
+	// 		const updatedEntry = key == "keys"
+	// 			? { ...updatedEntries[index], [key]: value.split(/(?<!\\), ?/) }
+	// 			: { ...updatedEntries[index], [key]: value };
+	// 		updatedEntries[index] = updatedEntry;
+
+	// 		return {
+	// 			...prevWorldInfo,
+	// 			entries: updatedEntries,
+	// 		};
+	// 	});
+	// }
+
+	const logitBiasSearch = (value) => {
 		const filteredList = value ? Object.keys(logitBias.bias).filter(key => key.startsWith(value)) : []
 		const sorted = logitBiasSorted;
 		setLogitBiasSearchList(filteredList)
@@ -2259,11 +2313,21 @@ export function App() {
 		setLogitBiasSorted(resultArray)
 	}, [logitBias]);
 
-
+	// const repopLogitBiasModal = (() => {
+	// 	try {
+	// 		const lbModalInputs = document.querySelectorAll(".lb-modal-power, .lb-modal-stringInput");
+	// 		lbModalInputs.forEach( input => {
+	// 			input.value = input.defaultValue;
+	// 		});
+	// 	}
+	// 	catch {
+	// 		return
+	// 	}
+	// });
 
 
 	const debugLogitBias = useMemo(() => {
-		console.log(logitBias)
+		console.log("logit bias",logitBias)
 	}, [logitBias]);
 
 	const debugLogitBiasSearch = useMemo(() => {
@@ -3158,7 +3222,7 @@ export function App() {
 							<button
 								className="textAreaSettings"
 								disabled=${!!cancel}
-								onClick=${() => toggleModal("bias")}>
+								onClick=${() => {updateLogitBiasTemp(); toggleModal("bias")}}>
 								<svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="-1 -5 8 7" xmlns="http://www.w3.org/2000/svg"><path d="M0 0 3-3C3-4 3-5 5-5L4-4 5-3 6-4C6-2 5-2 4-2L1 1C0 2-1 1 0 0"></path></svg>
 							</button>
 						</label>
@@ -3296,48 +3360,49 @@ export function App() {
 			</div>
 		</${Modal}>
 
-		<${Modal} isOpen=${modalState.bias} onClose=${() => closeModal("bias")}
+		<${Modal} isOpen=${modalState.bias} onClose=${() => {closeModal("bias")}}
 		title="Logit Bias"
 		description="Make certain tokens more or less likely to be generated. Values range from -100 to 100.
 		-100 is a ban, +100 means the model will only generate that token. 0 is neutral.
 		Currently only works on the first token of multi-token phrases/words.
 		
 		Different models might tokenize words differently. Always Re-Tokenize when switching models!">
-			
 		${modalState.bias 
-			&& logitBiasSorted.length > 0
 			&& html`
 			<div class="lb-modal-biasList" >
-				<div class="overflow-container lb-modal-grid-column" id="lb-modal-positive">
-					${ logitBiasSorted.map((string, index) => {
-		
-							return !logitBias.bias[string] || logitBias.bias[string].power < 0 ? null : html`
-								<div class="lb-modal-entry lb-modal-grid-row" key=${index}>
+				${ Object.keys(logitBiasTemp).map((key) => {
+					return html`
 
-									<${InputBox} label="Bias" classList="lb-modal-power"
-										type="number" max=100 min=-100 step="1"
-										id="lb-modal-power-${index}"
-										readOnly=${!!cancel}
-										onValueChange=${doNothing}
-										defaultValue=${logitBias.bias[string].power}/>
-									<label className="InputBox">
-										Token
-									<input label="Token" type="text" class="lb-modal-stringInput"
-										readOnly=${!!cancel} 
-										defaultValue="${string}" 
-										id="lb-modal-input-${index}"/>
-									</label>
-									<div class="lb-modal-tokenized">
-										[${logitBias.bias[string].strings.join("|")}] (${logitBias.bias[string].ids.length})
-									</div>
-									<button disabled=${!!cancel} class="hbox-button lb-modal-button" onClick=${() => logitBiasAdd(index,"positive",string)}>+</button>
-									<hr/>
-								</div>`
+					<div class="overflow-container lb-modal-grid-column" id="lb-modal-${key}">
+					${ logitBiasTemp[key].map((bias, index) => {
+						return html`
+						<div class="lb-modal-entry lb-modal-grid-row" key=${index}>
 
-					}
-					)}
+							<${InputBox} label="Bias" class="lb-modal-power"
+								type="number" max=100 min=-100 step="1"
+								id="lb-modal-power-${index}"
+								readOnly=${!!cancel}
+								onValueChange=${(value) => handleBiasTempChange(key,"power", index, value) }
+								value=${bias.power}/>
+							<label className="InputBox">
+								Token
+							<input label="Token" type="text" class="lb-modal-stringInput"
+								readOnly=${!!cancel} 
+								onInput=${(e) => handleBiasTempChange(key,"value", index, e.target.value) }
+								value=${bias.value}
+								id="lb-modal-input-${index}"/>
+							</label>
+							<div class="lb-modal-tokenized">
+								[${bias.strings.join("|")}] (${bias.strings.length})
+							</div>
+							<button disabled=${!!cancel} class="hbox-button lb-modal-button" onClick=${() => logitBiasAdd(index,"positive",bias.value)}>+</button>
+							<hr/>
+						</div>
 
+					`})}
 				</div>
+				`})}
+				
 			</div>`}
 
 		</${Modal}>

--- a/mikupad.html
+++ b/mikupad.html
@@ -2202,11 +2202,6 @@ export function App() {
 			setLastError("Error: Bias is NaN")
 			return
 		}
-		//biasPower = Number(biasPower)
-
-
-		//biasPower = (endpointAPI == 0 && Number(biasPower) < -99) ? false : biasPower;
-		// don't know what format kobold wants for ban
 
 
 		const modBias = logitBias.bias;	
@@ -3516,7 +3511,7 @@ export function App() {
 						<div class="lb-modal-entry lb-modal-grid-row" key=${index}>
 
 							<${InputBox} label="Bias" class="lb-modal-power"
-								type="enumber" inputmode="numeric" max=100 min=-100 step=1
+								type="enumber" max=100 min=-100 step=1
 								id="lb-modal-power-${index}"
 								readOnly=${!!cancel}
 								onValueChange=${(value) => {console.log(value); handleBiasTempChange(key,"power", index, value)} }

--- a/mikupad.html
+++ b/mikupad.html
@@ -1516,7 +1516,7 @@ function InputBox({ label, tooltip, tooltipSize, value, type, datalist, onValueC
 		<label className="InputBox ${tooltip ? 'tooltip' : ''}">
 			${label}
 			<input
-				type=${type || 'text'}
+				type=${ (type === "enumber") ? "number" : (type === "" ? "text" : type) }
 				list="${datalist ? label : ''}"
 				value=${value}
 				size="1"
@@ -2151,19 +2151,22 @@ export function App() {
 
 	//- Logit Bias --//
 	const [logitBias, setLogitBias] = useSessionState('logitBias', defaultPresets.logitBias);
+	const [logitBiasParam, setLogitBiasParam] = useState({});
 	const [logitBiasTemp, setLogitBiasTemp] = useState([]);
 	const [logitBiasSearchList, setLogitBiasSearchList] = useState([]);
 	const [logitBiasSorted, setLogitBiasSorted] = useState([]);
 	const [logitBiasSearchState, setLogitBiasSearchState] = useState(false);
-	const [logitBiasInput, setLogitBiasInput] = useState({power:2,string:"string"});
+	const [logitBiasInput, setLogitBiasInput] = useState({power:"2",string:"string"});
 
 	const handleLogitBiasInput = (key,value) => {
+		console.log(key, value)
 		setLogitBiasInput((prevLogitBiasInput) => {
-			const rest = { ...prevLogitBiasInput }
-			rest[key] = value;
-			console.log(rest)
-			return { ...rest };
+			return {
+				...prevLogitBiasInput,
+				[key]: value
+			}
 		});
+		console.log(logitBiasInput)
 
 	}
 
@@ -2199,27 +2202,64 @@ export function App() {
 		const ac = new AbortController();
 		console.log("input","."+biasTokens+".",biasPower)
 
-		const tokens = await getTokens({
+		setLastError(undefined)
+		try {
+			const tokens = await getTokens({
 				endpoint,
 				endpointAPI,
 				...(endpointAPI == 3 || endpointAPI == 0 ? { endpointAPIKey } : {}),
 				content: `${biasTokens}`,
 				signal: ac.signal,
-		})
-		console.log("add",tokens)
-
-		setLogitBias((prevLogitBias) => ({
-			...prevLogitBias,
-			bias: {
-				...modBias,
-				[biasTokens]: {
-					ids: [ ...tokens.ids ],
-					strings: [ ...tokens.str ],
-					power: biasPower
+			})
+			console.log("add",tokens)
+			setLogitBias((prevLogitBias) => ({
+				...prevLogitBias,
+				bias: {
+					...modBias,
+					[biasTokens]: {
+						ids: [ ...tokens.ids ],
+						strings: [ ...tokens.str ],
+						power: biasPower
+					}
+				}
+			}));
+		}
+		catch(e) {
+			if (e.name !== 'AbortError') {
+				reportError(e);
+				const errStr = e.toString();
+				if ((endpointAPI == 3 || endpointAPI == 0) && errStr.includes("401")) {
+					setLastError("Error: Rejected API Key");
+					setRejectedAPIKey(true);
+				} else if (endpointAPI == 3 && errStr.includes("429")) {
+					setLastError("Error: Insufficient Quota");
+				} else {
+					setLastError(errStr);
 				}
 			}
-		}));
+			return
+		}
 	};
+
+	const updateLogitBiasParam = useEffect(() => {
+		console.log("endpoint",endpointAPI)
+		if (endpoint == 0) {
+			// const param = logitBias.bias.map((entry, index) => {
+			// 	return [Number(entry.ids),Number(entry.power)];
+			// })	
+			
+
+		}
+		const param = [];
+		Object.keys(logitBias.bias).forEach(entry => {
+			console.log("help me",logitBias.bias[entry])
+			param.push([Number(logitBias.bias[entry].ids[0]),Number(logitBias.bias[entry].power)]);
+		})
+		console.log("params",param)
+		setLogitBiasParam(param)
+
+	}, [logitBias, endpointAPI]);
+
 
 	function updateLogitBiasTemp() {
 		const tempArray = logitBiasSorted.map((string, index) =>  ({
@@ -2553,6 +2593,10 @@ export function App() {
 					repeat_last_n: repeatLastN,
 					penalize_nl: penalizeNl,
 					ignore_eos: ignoreEos,
+				} : {}),
+				// not sure if I need the openaiPresets here
+				...(!openaiPresets || [0,2].includes(endpointAPI) && logitBias.bias.length > 0 ? {
+					logit_bias: logitBiasParam, // [[39,-20],[37934,-20]], //
 				} : {}),
 				presence_penalty: presencePenalty,
 				frequency_penalty: frequencyPenalty,
@@ -3183,9 +3227,10 @@ export function App() {
 					<div className="hbox-flex logitBiasContainer">
 						<div class="small-inputBox">
 							<${InputBox} label="Bias" classList="logitBiasPower-container"
-								type="number" max=100 min=-100 step=1
+								type="enumber"  max=100 min=-100 step=1
+								pattern='^-?[0-9]*$'
 								readOnly=${!!cancel}
-								onValueChange=${(e) => {handleLogitBiasInput("power",e)} }
+								onValueChange=${(value) => { console.log("aa",value);handleLogitBiasInput("power",value)} }
 								value=${logitBiasInput.power} 
 								id="logitBiasPower"/>
 						</div>
@@ -3193,7 +3238,7 @@ export function App() {
 							Token
 						<input label="Token" type="text" id="logitBiasTokens-container"
 							readOnly=${!!cancel} 
-							onInput=${(e) => {logitBiasSearch(e.target.value);handleLogitBiasInput("tokens",e.target.value)} }
+							onInput=${(e) => {logitBiasSearch(e.target.value); handleLogitBiasInput("string",e.target.value)} }
 							onFocus=${(e) => {logitBiasSearch(e.target.value); setLogitBiasSearchState(true)} }
 							onBlur=${() => setLogitBiasSearchState(false)}
 							value=${logitBiasInput.string} 
@@ -3378,7 +3423,7 @@ export function App() {
 						<div class="lb-modal-entry lb-modal-grid-row" key=${index}>
 
 							<${InputBox} label="Bias" class="lb-modal-power"
-								type="number" max=100 min=-100 step=1
+								type="enumber" inputmode="numeric" max=100 min=-100 step=1
 								id="lb-modal-power-${index}"
 								readOnly=${!!cancel}
 								onValueChange=${(value) => handleBiasTempChange(key,"power", index, value) }

--- a/mikupad.html
+++ b/mikupad.html
@@ -1045,6 +1045,7 @@ export async function getTokens({ endpoint, endpointAPI, endpointAPIKey, signal,
 	// returns a json object in the format of:
 	// { ids:[ array of token ids ], str:[ array of detokenized ids ] }
 	// example: { ids:[9288,4731],str:["test"," string"] }
+	endpoint = normalizeEndpoint(endpoint);
 	switch (endpointAPI) {
 		case 0: // llama.cpp
 			return await llamaCppTokenize({ endpoint, endpointAPIKey, signal, ...options });
@@ -2846,7 +2847,7 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 					ignore_eos: ignoreEos,
 				} : {}),
 				...(Object.keys(logitBias.bias).length > 0 ? {
-					logit_bias: logitBiasParam, // [[" The",false]], // [[39,-20],[37934,-20]], // { 415: 100 }, //
+					logit_bias: logitBiasParam,
 				} : {}),
 				presence_penalty: presencePenalty,
 				frequency_penalty: frequencyPenalty,

--- a/mikupad.html
+++ b/mikupad.html
@@ -1085,7 +1085,6 @@ export async function getTokenCount({ endpoint, endpointAPI, endpointAPIKey, sig
 
 export async function getTokens({ endpoint, endpointAPI, endpointAPIKey, signal, ...options }) {
 	// currently only implemented for llama.cpp and koboldcpp
-	// to implement other APIs, make a function that takes an input of a string and
 	// returns a json object in the format of:
 	// { ids:[ array of token ids ], str:[ array of detokenized ids ] }
 	// example: { ids:[9288,4731],str:["test"," string"] }
@@ -1290,12 +1289,13 @@ async function koboldCppTokenCount({ endpoint, proxyEndpoint, signal, ...options
 	return value;
 }
 
-async function koboldCppTokenize({ endpoint, signal, ...options }) {
+async function koboldCppTokenize({ endpoint, proxyEndpoint, signal, ...options }) {
 	console.log("kcpp",options.content)
 	const res = await fetch(new URL('/api/extra/tokencount', endpoint), {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json',
+			...(proxyEndpoint ? { 'X-Real-URL': endpoint } : {})
 		},
 		body: JSON.stringify({
 			prompt: options.content
@@ -1307,8 +1307,6 @@ async function koboldCppTokenize({ endpoint, signal, ...options }) {
 	const { ids } = await res.json();
 	console.log(ids)
 	ids.shift() // kobold automatically adds a token, so we need to remove it
-	// at this point I think kobold just automatically adds a space to the front of
-	// requests, which fucks up the token IDs for things at the beginning of a sentence.
 	console.log("shift",ids)
 	return {ids:ids,str:""};
 	
@@ -2450,15 +2448,38 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 		console.log("input","."+biasString+".",biasPower)
 		console.log("replace","."+biasString.replace(/\\n/g, '\n')+".")
 		try {
-			const tokens = await getTokens({
-				endpoint,
-				endpointAPI,
-				...(endpointAPI == 3 || endpointAPI == 0 ? { endpointAPIKey } : {}),
-				content: `${biasString}`.replace(/\\n/g,'\n'),
-				signal: ac.signal,
-				...(isMikupadEndpoint ? { proxyEndpoint: sessionStorage.proxyEndpoint } : {})
-			});
+			// if the string is a comma separated list of numbers wrapped in /
+			var tokens
+			const isTokenIds = biasString.match(/^(?<!\\)\/(\s*\d+\s*,?\s*)+(?<!\\)\/$/g)
+			if ( isTokenIds != null ) {
+				// split by , and use it as token ids directly
+				tokens = {
+					ids: isTokenIds[0].replaceAll("/","").split(",").map( item => Number(item.trim()) ),
+					str: ""
+				} 
+				console.log("token ids RAW!!!", tokens.ids)
+			}
+			// else process like normal
+			else {
+				// KNOWN ISSUE: some models automatically prepend a space to any tokenization input.
+				// to work around this, I'm prepending the input with a "|", then shifting the output
+				// array by one to remove the " |" token. I know this is an absolute hack, but this is
+				// the best I could come up with.
+				tokens = await getTokens({
+					endpoint,
+					endpointAPI,
+					...(endpointAPI == 3 || endpointAPI == 0 ? { endpointAPIKey } : {}),
+					content: `|${biasString}`.replace(/\\n/g,'\n'),
+					signal: ac.signal,
+					...(isMikupadEndpoint ? { proxyEndpoint: sessionStorage.proxyEndpoint } : {})
+				});
+			}
+			tokens.ids.shift()
+			if ( Array.isArray(tokens.str) ) {
+				tokens.str.shift()
+			}
 			console.log("add",tokens)
+			//console.log("shift",[ ...tokens.ids ],[ ...tokens.ids ].shift())
 			setLogitBias((prevLogitBias) => ({
 				...prevLogitBias,
 				bias: {
@@ -2537,7 +2558,7 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 			value: string,
 			valueBack: string,
 			strings: logitBias.bias[string].strings,
-			tokens: logitBias.bias[string].ids.length,
+			tokens: logitBias.bias[string].ids,
 			power: logitBias.bias[string].power
 		}));
 		setLogitBiasTemp({
@@ -3664,13 +3685,21 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 				${(endpointAPI == 0 || endpointAPI == 2) && html`
 					<div className="hbox-flex logitBiasContainer">
 						<div class="small-inputBox">
-							<${InputBox} label="Bias" classList="logitBiasPower-container"
+							<${InputBox} label="Bias" className="logitBiasPower-container"
 								type="enumber"  max=100 min=-100 step=1
 								readOnly=${!!cancel}
 								onValueChange=${(value) => { handleLogitBiasInput("power",value)} }
 								value=${logitBiasInput.power} 
 								id="logitBiasPower"/>
 						</div>
+						<${InputBox} label="Token (string or /IDs/)" type="text"
+							tooltip="aaaaaaaaa"
+							readOnly=${!!cancel}
+							value=${logitBiasInput.string}
+							onInput=${(e) => {logitBiasSearch(e.target.value); handleLogitBiasInput("string",e.target.value)} }
+							onFocus=${(e) => {logitBiasSearch(e.target.value); setLogitBiasSearchState(true)} }
+							onBlur=${() => setLogitBiasSearchState(false)}
+							/>
 						<label className="InputBox">
 							Token
 						<input label="Token" type="text" id="logitBiasTokens-container"
@@ -3848,7 +3877,9 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 		description="Make certain tokens more or less likely to be generated. 
 		Currently only works on the first token of multi-token phrases/words.
 		
-		Different models might tokenize words differently. Always Re-Tokenize when switching models!">
+		Some models prepend spaces to any input sent to their detokenizer. If your bias doesn't appear to be working, try inputting the correct token IDs manually in a comma separated list, wrapped in '/'. Example: /382,1449,1802/
+
+		Different models might tokenize words differently. Always Re-Tokenize your biases when switching models by pressing the '+' button again for every entry.">
 		${modalState.bias 
 			&& html`
 					<div className="hbox-flex logitBiasContainer">
@@ -3858,7 +3889,7 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 								Retokenize
 						</button>
 						<div class="small-inputBox">
-							<${InputBox} label="Bias" classList="logitBiasPower-container"
+							<${InputBox} label="Bias" className="logitBiasPower-container"
 								type="enumber"  max=100 min=-100 step=1
 								readOnly=${!!cancel}
 								onValueChange=${(value) => { handleLogitBiasInput("power",value)} }
@@ -3902,9 +3933,9 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 									id="lb-modal-input-${index}"/>
 							</label>
 							<div class="lb-modal-tokenized">
-								${endpointAPI == 0
+								${endpointAPI == 0 && bias.strings != ""
 									? "["+bias.strings.join("|")+"] "
-									: "["+bias.value+"]" } (${bias.tokens} tokens)
+									: "["+bias.tokens+"]" } (${bias.tokens.length} tokens)
 								
 							</div>
 							<button disabled=${!!cancel} class="hbox-button lb-modal-button" onClick=${() => logitBiasAdd(bias.power, bias.value, bias.valueBack)}>+</button>


### PR DESCRIPTION
UI and logic for biasing single tokens. If a multi-token string is biased, it will currently only bias the first token.
I'll do phrase biasing in a new PR once this mess is done, because this is large enough as is.

This is still very much work in progress, but I think I need some help.

* It definitely does do something for both kobold and llama, but I can't make sense of the ranges at all.
The [llama server example](https://github.com/ggerganov/llama.cpp/blob/master/examples/server/README.md) just mentions + and -1, which didn't feel like it was doing much. (banning by setting the bias value to `false` works though)
  And kobold says its [implementation is compatible with the openAI implementation](https://github.com/LostRuins/koboldcpp/releases/tag/v1.54), which should be [this](https://platform.openai.com/docs/api-reference/chat/create#chat-create-logit_bias), but tokens I set to -100 were still showing up, so I'm confused.

* The `logitBiasRetokenize` function I added to quickly re-tokenize all strings when switching model seems to update random entries and I can't for the life of me figure out why.

* I couldn't find any useful info on what api endpoints are available for ooga, so didn't implement that for the moment.

* The modal definitely needs a dedicated delete button, but I really don't know where a good place for it would be.

Any input is appreciated.