### PR TITLE
Add a "Selenized" color scheme and width adjustment option in prefs

### DIFF
--- a/mikupad.html
+++ b/mikupad.html
@@ -2326,6 +2326,7 @@ export function App({ sessionStorage, useSessionState }) {
 		document.documentElement.classList.remove('serif-dark');
 		document.documentElement.classList.remove('monospace-dark');
 		document.documentElement.classList.remove('nockoffAI');
+		document.documentElement.classList.remove('selenized');
 		switch (theme) {
 		case 1:
 			document.documentElement.classList.add('serif-dark');
@@ -2335,6 +2336,9 @@ export function App({ sessionStorage, useSessionState }) {
 			break;
 		case 3:
 			document.documentElement.classList.add('nockoffAI');
+			break;
+		case 4:
+			document.documentElement.classList.add('selenized');
 			break;
 		}
 	}, [theme]);

--- a/mikupad.html
+++ b/mikupad.html
@@ -195,7 +195,7 @@ body {
 #prompt-container {
 	position: relative;
 	font-size: 1.125rem;
-	max-width: 36em;
+	max-width: 35em; /* Default display value is set by onLoad() and modified by the modal buttons! */
 	margin-right: auto;
 	margin-left: auto;
 	flex: 1;
@@ -204,8 +204,8 @@ body {
 }
 @media (min-width: calc(40.5em + 250px)) {
 	body.attachSidebar #prompt-container {
-		min-width: 36em;
-		max-width: 36em;
+		min-width: 35em;
+		max-width: 35em;
 	}
 }
 
@@ -411,9 +411,6 @@ html.nockoffAI #probs {
 	display: flex;
 	flex-direction: column;
 }
-html.monospace-dark .modal {
-	background: #282833;
-}
 html.nockoffAI .modal {
 	background: var(--color-sidebar);
 	color:var(--color-base-50);
@@ -447,6 +444,22 @@ html.selenized .modal {
 	font-size: 150%;
 	font-weight:bold;
 	margin-bottom: .25em;
+}
+
+.modal-width-adjustment {
+	margin-top: 20px;
+}
+
+.modal-width-adjustment button {
+	font-family: monospace;
+	background: #FF00FF;
+}
+
+#modal-width-readout {
+	width: 3em;
+	text-align: center;
+	margin: 0 auto;
+	font-family: monospace;
 }
 
 hr {
@@ -1210,6 +1223,7 @@ function openaiConvertOptions(options, isOpenAI) {
 		options.dynamic_temperature = true;
 		options.dynatemp_low = Math.max(0, options.temperature - options.dynatemp_range);
 		options.dynatemp_high = Math.max(0, options.temperature + options.dynatemp_range);
+		delete options.dynatemp_range;
 	}
 	if (!isOpenAI && options.temperature === 0) {
 		// oobabooga specific.
@@ -1579,6 +1593,24 @@ function Sessions({ sessionStorage, onSessionChange, disabled }) {
 		</div>`;
 }
 
+function onLoad() {
+	// Any other general task we want to do when the page is loaded.
+	setTimeout(() => {
+		try {
+			document.getElementById("prompt-container").style.maxWidth = "36em";
+			// You can't actually get the width from the element unless you do some
+			// stupid workaround like "get the computed width in pixels, get the
+			// font size, do math on pixels, and convert to em". Instead, we'll just
+			// manually set it to be "36em" so it can be interacted with by the modal.
+
+			// document.getElementsByClassName("modal-width-readout")[0].value = "36";
+		} catch(e) {
+			reportError(e);
+		}
+	}, 1000);
+}
+
+
 class SessionStorage {
 	constructor(defaultPresets) {
 		this.dbName = 'MikuPad';
@@ -1843,7 +1875,7 @@ const defaultPresets = {
 	maxPredictTokens: -1,
 	temperature: 0.7,
 	dynaTempRange: 0,
-	dynaTempExp: 1,
+	dynaTempExp: 0,
 	repeatPenalty: 1.1,
 	repeatLastN: 256,
 	penalizeNl: false,
@@ -1956,6 +1988,7 @@ export function App({ sessionStorage, useSessionState }) {
 	const [preserveCursorPosition, setPreserveCursorPosition] = usePersistentState('preserveCursorPosition', true);
 	const [darkMode, _] = usePersistentState('darkMode', false); // legacy
 	const [theme, setTheme] = usePersistentState('theme', darkMode ? 1 : 0);
+	// const [boxWidth, setBoxWidth] = usePersistentState('boxWidth', boxWidth);
 	const [endpoint, setEndpoint] = useSessionState('endpoint', defaultPresets.endpoint);
 	const [endpointAPI, setEndpointAPI] = useSessionState('endpointAPI', defaultPresets.endpointAPI);
 	const [endpointAPIKey, setEndpointAPIKey] = useSessionState('endpointAPIKey', defaultPresets.endpointAPIKey);
@@ -2337,6 +2370,18 @@ export function App({ sessionStorage, useSessionState }) {
 		if (didUndo) {
 			setTriggerPredict(true);
 		}
+	}
+
+
+	function adjustWidth(adjustment) {
+
+		var width = document.getElementById("prompt-container").style.maxWidth.replace("em", "").trim();
+		width = String(parseInt(width) + parseInt(adjustment))
+		if (width < 1){
+			width = 1;
+		}
+		document.getElementById("prompt-container").style.maxWidth = width + "em";
+		document.getElementById("modal-width-readout").value = width
 	}
 
 	useEffect(() => {
@@ -2836,13 +2881,14 @@ export function App({ sessionStorage, useSessionState }) {
 				<${InputBox} label="Temperature" type="number" step="0.01"
 					readOnly=${!!cancel} value=${temperature} onValueChange=${setTemperature}/>
 				${(!openaiPresets || endpointAPI != 3) && html`
-					<div className="hbox">
-						<${InputBox} label="DynaTemp Range" type="number" step="0.01"
-							readOnly=${!!cancel} value=${dynaTempRange} onValueChange=${setDynaTempRange}/>
-						${(endpointAPI != 2) && html`
-							<${InputBox} label="DynaTemp Exp" type="number" step="0.01"
-								readOnly=${!!cancel} value=${dynaTempExp} onValueChange=${setDynaTempExp}/>`}
-					</div>
+					${endpointAPI != 0 && html`
+						<div className="hbox">
+							<${InputBox} label="DynaTemp Range" type="number" step="0.01"
+								readOnly=${!!cancel} value=${dynaTempRange} onValueChange=${setDynaTempRange}/>
+							${endpointAPI != 2 && html`
+								<${InputBox} label="DynaTemp Exp" type="number" step="0.01"
+									readOnly=${!!cancel} value=${dynaTempExp} onValueChange=${setDynaTempExp}/>`}
+						</div>`}
 					<div className="hbox">
 						<${InputBox} label="Repeat penalty" type="number" step="0.01"
 							readOnly=${!!cancel} value=${repeatPenalty} onValueChange=${setRepeatPenalty}/>
@@ -3023,6 +3069,14 @@ export function App({ sessionStorage, useSessionState }) {
 						{ name: 'Show on hover while holding CTRL', value: 1 },
 						{ name: 'Don\'t show', value: -1 },
 					]}/>
+				<div className="modal-width-adjustment">
+					<span>Box width: </span>
+					<button onClick=${() => adjustWidth(-5)}>⟪</button>
+					<button onClick=${() => adjustWidth(-1)}>⟨</button>
+					<input type="text" value="35" id="modal-width-readout" readOnly />
+					<button onClick=${() => adjustWidth( 1)}>〉</button>
+					<button onClick=${() => adjustWidth( 5)}>⟫</button>
+				</div>
 			</div>
 		</${Modal}>
 
@@ -3216,6 +3270,7 @@ export function App({ sessionStorage, useSessionState }) {
 async function main() {
 	const sessionStorage = new SessionStorage(defaultPresets);
 	await sessionStorage.init();
+	onLoad();
 
 	createRoot(document.body).render(html`
 		<${App}

--- a/mikupad.html
+++ b/mikupad.html
@@ -106,6 +106,42 @@ html.nockoffAI {
 html.nockoffAI body {
 	background: var(--color-prompt-area)
 }
+html.selenized {
+	---color-bg-dark: #103C48;
+	--color-bg: #103C48;
+
+	--color-text: #CAD8D9;
+	--color-base-0: #CAD8D9;
+	--color-base-10: color-mix(in oklch, var(--color-base-100) 90%, var(--color-base-0));
+	--color-base-20: color-mix(in oklch, var(--color-base-100) 80%, var(--color-base-0));
+	--color-base-30: color-mix(in oklch, var(--color-base-100) 70%, var(--color-base-0));
+	--color-base-40: color-mix(in oklch, var(--color-base-100) 60%, var(--color-base-0));
+	--color-base-50: color-mix(in oklch, var(--color-base-100) 50%, var(--color-base-0));
+	--color-base-60: color-mix(in oklch, var(--color-base-100) 40%, var(--color-base-0));
+	--color-base-70: color-mix(in oklch, var(--color-base-100) 30%, var(--color-base-0));
+	--color-base-80: color-mix(in oklch, var(--color-base-100) 20%, var(--color-base-0));
+	--color-base-90: color-mix(in oklch, var(--color-base-100) 10%, var(--color-base-0));
+	--color-base-100: #72898F;
+	--color-dark: var(--color-base-100);
+	--color-light: #fff;
+	--color-input: #0e0f21;
+	--color-sidebar: var(--color-base-100);
+	--color-prompt-area: #191b31;
+	--color-hover: #13152c;
+	--color-button: #22253f;
+	--color-disabled: #161833;
+	--color-button-hover: #282b44;
+
+	--token-prob-box: #4a4a4a;
+
+	font-family: "Source Sans Pro", "Helvetica Neue", sans-serif;
+	font-size: 15.5px;
+
+	accent-color: var(--color-base-30);
+	background: var(--color-bg-dark);
+	color: var(--color-base-0);
+	color-scheme: dark;
+}
 
 html.monospace-dark {
 	---color-bg-dark: #282833;
@@ -2705,6 +2741,7 @@ export function App({ sessionStorage, useSessionState }) {
 					{ name: 'Serif Dark', value: 1 },
 					{ name: 'Monospace Dark', value: 2 },
 					{ name: 'nockoffAI', value: 3 },
+					{ name: 'Selenized', value: 4 },
 				]}/>
 			<div class="horz-separator"/>
 			<${CollapsibleGroup} label="Sessions">

--- a/mikupad.html
+++ b/mikupad.html
@@ -9,7 +9,7 @@
   -- You should have received a copy of the CC0 legalcode along with this
   -- work.  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
   -->
-<title>mikupad</title>
+<title>mikupad!</title>
 <script type="importmap">
 {
 	"imports": {

--- a/mikupad.html
+++ b/mikupad.html
@@ -9,7 +9,7 @@
   -- You should have received a copy of the CC0 legalcode along with this
   -- work.  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
   -->
-<title>mikupad!</title>
+<title>mikupad</title>
 <script type="importmap">
 {
 	"imports": {
@@ -23,152 +23,160 @@
 <style>
 
 html {
-	--color-miku: #009bb3;
-	--color-base-0: oklch(0.20 0.02 60);
-	--color-base-10: color-mix(in oklch, var(--color-base-100) 10%, var(--color-base-0));
-	--color-base-20: color-mix(in oklch, var(--color-base-100) 20%, var(--color-base-0));
-	--color-base-30: color-mix(in oklch, var(--color-base-100) 30%, var(--color-base-0));
-	--color-base-40: color-mix(in oklch, var(--color-base-100) 40%, var(--color-base-0));
-	--color-base-50: color-mix(in oklch, var(--color-base-100) 50%, var(--color-base-0));
-	--color-base-60: color-mix(in oklch, var(--color-base-100) 60%, var(--color-base-0));
-	--color-base-70: color-mix(in oklch, var(--color-base-100) 70%, var(--color-base-0));
-	--color-base-80: color-mix(in oklch, var(--color-base-100) 80%, var(--color-base-0));
-	--color-base-90: color-mix(in oklch, var(--color-base-100) 90%, var(--color-base-0));
-	--color-base-100: oklch(0.95 0.04 70);
-	--color-dark: var(--color-base-0);
-	--color-light: var(--color-base-100);
+	--color-miku:         #009bb3;
+	--color-base-0:       oklch(0.20 0.02 60);
+	--color-base-10:      color-mix(in oklch, var(--color-base-100) 10%, var(--color-base-0));
+	--color-base-20:      color-mix(in oklch, var(--color-base-100) 20%, var(--color-base-0));
+	--color-base-30:      color-mix(in oklch, var(--color-base-100) 30%, var(--color-base-0));
+	--color-base-40:      color-mix(in oklch, var(--color-base-100) 40%, var(--color-base-0));
+	--color-base-50:      color-mix(in oklch, var(--color-base-100) 50%, var(--color-base-0));
+	--color-base-60:      color-mix(in oklch, var(--color-base-100) 60%, var(--color-base-0));
+	--color-base-70:      color-mix(in oklch, var(--color-base-100) 70%, var(--color-base-0));
+	--color-base-80:      color-mix(in oklch, var(--color-base-100) 80%, var(--color-base-0));
+	--color-base-90:      color-mix(in oklch, var(--color-base-100) 90%, var(--color-base-0));
+	--color-base-100:     oklch(0.95 0.04 70);
+	--color-dark:         var(--color-base-0);
+	--color-light:        var(--color-base-100);
 
-	font-family: serif;
-	font-size: 16px;
-	min-height: 100%;
-	display: flex;
-	flex-direction: column;
+	font-family:          serif;
+	font-size:            16px;
+	min-height:           100%;
+	display:              flex;
+	flex-direction:       column;
 
-	accent-color: var(--color-base-30);
-	background: var(--color-base-20);
-	color: var(--color-base-0);
+	accent-color:         var(--color-base-30);
+	background:           var(--color-base-20);
+	color:                var(--color-base-0);
 }
 
 html.serif-dark {
-	--color-base-0: oklch(0.95 0.04 30);
-	--color-base-10: color-mix(in oklch, var(--color-base-100) 10%, var(--color-base-0));
-	--color-base-20: color-mix(in oklch, var(--color-base-100) 80%, var(--color-base-0));
-	--color-base-30: color-mix(in oklch, var(--color-base-100) 70%, var(--color-base-0));
-	--color-base-40: color-mix(in oklch, var(--color-base-100) 60%, var(--color-base-0));
-	--color-base-50: color-mix(in oklch, var(--color-base-100) 50%, var(--color-base-0));
-	--color-base-60: color-mix(in oklch, var(--color-base-100) 40%, var(--color-base-0));
-	--color-base-70: color-mix(in oklch, var(--color-base-100) 30%, var(--color-base-0));
-	--color-base-80: color-mix(in oklch, var(--color-base-100) 20%, var(--color-base-0));
-	--color-base-90: color-mix(in oklch, var(--color-base-100) 10%, var(--color-base-0));
-	--color-base-100: oklch(0.20 0.02 30);
-	--color-dark: var(--color-base-100);
-	--color-light: var(--color-base-0);
+	--color-base-0:       oklch(0.95 0.04 30);
+	--color-base-10:      color-mix(in oklch, var(--color-base-100) 10%, var(--color-base-0));
+	--color-base-20:      color-mix(in oklch, var(--color-base-100) 80%, var(--color-base-0));
+	--color-base-30:      color-mix(in oklch, var(--color-base-100) 70%, var(--color-base-0));
+	--color-base-40:      color-mix(in oklch, var(--color-base-100) 60%, var(--color-base-0));
+	--color-base-50:      color-mix(in oklch, var(--color-base-100) 50%, var(--color-base-0));
+	--color-base-60:      color-mix(in oklch, var(--color-base-100) 40%, var(--color-base-0));
+	--color-base-70:      color-mix(in oklch, var(--color-base-100) 30%, var(--color-base-0));
+	--color-base-80:      color-mix(in oklch, var(--color-base-100) 20%, var(--color-base-0));
+	--color-base-90:      color-mix(in oklch, var(--color-base-100) 10%, var(--color-base-0));
+	--color-base-100:     oklch(0.20 0.02 30);
+	--color-dark:         var(--color-base-100);
+	--color-light:        var(--color-base-0);
 
-	color-scheme: dark;
+	color-scheme:         dark;
 }
 
 html.nockoffAI {
-	---color-bg-dark: #191b31;
-	--color-bg: #191b31;
+	---color-bg-dark:     #191b31;
+	--color-bg:           #191b31;
 
-	--color-text: #fff;
-	--color-base-0: #fff;
-	--color-base-10: color-mix(in oklch, var(--color-base-100) 90%, var(--color-base-0));
-	--color-base-20: color-mix(in oklch, var(--color-base-100) 80%, var(--color-base-0));
-	--color-base-30: color-mix(in oklch, var(--color-base-100) 70%, var(--color-base-0));
-	--color-base-40: color-mix(in oklch, var(--color-base-100) 60%, var(--color-base-0));
-	--color-base-50: color-mix(in oklch, var(--color-base-100) 50%, var(--color-base-0));
-	--color-base-60: color-mix(in oklch, var(--color-base-100) 40%, var(--color-base-0));
-	--color-base-70: color-mix(in oklch, var(--color-base-100) 30%, var(--color-base-0));
-	--color-base-80: color-mix(in oklch, var(--color-base-100) 20%, var(--color-base-0));
-	--color-base-90: color-mix(in oklch, var(--color-base-100) 10%, var(--color-base-0));
-	--color-base-100: #13152c;
-	--color-dark: var(--color-base-100);
-	--color-light: #fff;
-	--color-input: #0e0f21;
-	--color-sidebar: var(--color-base-100);
-	--color-prompt-area: #191b31;
-	--color-hover: #13152c;
-	--color-button: #22253f;
-	--color-disabled: #161833;
+	--color-text:         #fff;
+	--color-base-0:       #fff;
+	--color-base-10:      color-mix(in oklch, var(--color-base-100) 90%, var(--color-base-0));
+	--color-base-20:      color-mix(in oklch, var(--color-base-100) 80%, var(--color-base-0));
+	--color-base-30:      color-mix(in oklch, var(--color-base-100) 70%, var(--color-base-0));
+	--color-base-40:      color-mix(in oklch, var(--color-base-100) 60%, var(--color-base-0));
+	--color-base-50:      color-mix(in oklch, var(--color-base-100) 50%, var(--color-base-0));
+	--color-base-60:      color-mix(in oklch, var(--color-base-100) 40%, var(--color-base-0));
+	--color-base-70:      color-mix(in oklch, var(--color-base-100) 30%, var(--color-base-0));
+	--color-base-80:      color-mix(in oklch, var(--color-base-100) 20%, var(--color-base-0));
+	--color-base-90:      color-mix(in oklch, var(--color-base-100) 10%, var(--color-base-0));
+	--color-base-100:     #13152c;
+	--color-dark:         var(--color-base-100);
+	--color-light:        #fff;
+	--color-input:        #0e0f21;
+	--color-sidebar:      var(--color-base-100);
+	--color-prompt-area:  #191b31;
+	--color-hover:        #13152c;
+	--color-button:       #22253f;
+	--color-disabled:     #161833;
 	--color-button-hover: #282b44;
 
-	--token-prob-box: #4a4a4a;
+	--token-prob-box:     #4a4a4a;
 
-	font-family: "Source Sans Pro", "Helvetica Neue", sans-serif;
-	font-size: 15.5px;
+	font-family:          "Source Sans Pro", "Helvetica Neue", sans-serif;
+	font-size:            15.5px;
 
-	accent-color: var(--color-base-30);
-	background: var(--color-bg-dark);
-	color: var(--color-base-0);
-	color-scheme: dark;
+	accent-color:          var(--color-base-30);
+	background:            var(--color-bg-dark);
+	color:                 var(--color-base-0);
+	color-scheme:          dark;
 }
 html.nockoffAI body {
-	background: var(--color-prompt-area)
+	background:            var(--color-prompt-area)
 }
 html.selenized {
-	---color-bg-dark: #103C48;
-	--color-bg: #103C48;
+	---color-bg-dark:     #103C48;
+	--color-bg:           #103C48;
+	--color-text:         #CAD8D9;
+	--color-base-0:       #CAD8D9;
+	--color-base-10:      color-mix(in oklch, var(--color-base-100) 10%, var(--color-base-0));
+	--color-base-20:      color-mix(in oklch, var(--color-base-100) 20%, var(--color-base-0));
+	--color-base-30:      color-mix(in oklch, var(--color-base-100) 30%, var(--color-base-0));
+	--color-base-40:      color-mix(in oklch, var(--color-base-100) 40%, var(--color-base-0));
+	--color-base-50:      color-mix(in oklch, var(--color-base-100) 50%, var(--color-base-0));
+	--color-base-60:      color-mix(in oklch, var(--color-base-100) 60%, var(--color-base-0));
+	--color-base-70:      color-mix(in oklch, var(--color-base-100) 70%, var(--color-base-0));
+	--color-base-80:      color-mix(in oklch, var(--color-base-100) 80%, var(--color-base-0));
+	--color-base-90:      color-mix(in oklch, var(--color-base-100) 90%, var(--color-base-0));
+	--color-base-100:     #103C48;
+	--color-base-150:     #081e24;
+	--color-dark:         var(--color-base-100);
+	--color-light:        #CAD8D9;
+	--color-input:        #FA5750;
+	--color-sidebar:      var(--color-base-100);
+	--color-prompt-area:  #CAD8D9;
+	--color-hover:        #4695F7;
+	--color-button:       #75B938;
+	--color-disabled:     #72898F;
+	--color-button-hover: #DBB32D;
 
-	--color-text: #CAD8D9;
-	--color-base-0: #CAD8D9;
-	--color-base-10: color-mix(in oklch, var(--color-base-100) 90%, var(--color-base-0));
-	--color-base-20: color-mix(in oklch, var(--color-base-100) 80%, var(--color-base-0));
-	--color-base-30: color-mix(in oklch, var(--color-base-100) 70%, var(--color-base-0));
-	--color-base-40: color-mix(in oklch, var(--color-base-100) 60%, var(--color-base-0));
-	--color-base-50: color-mix(in oklch, var(--color-base-100) 50%, var(--color-base-0));
-	--color-base-60: color-mix(in oklch, var(--color-base-100) 40%, var(--color-base-0));
-	--color-base-70: color-mix(in oklch, var(--color-base-100) 30%, var(--color-base-0));
-	--color-base-80: color-mix(in oklch, var(--color-base-100) 20%, var(--color-base-0));
-	--color-base-90: color-mix(in oklch, var(--color-base-100) 10%, var(--color-base-0));
-	--color-base-100: #72898F;
-	--color-dark: var(--color-base-100);
-	--color-light: #fff;
-	--color-input: #0e0f21;
-	--color-sidebar: var(--color-base-100);
-	--color-prompt-area: #191b31;
-	--color-hover: #13152c;
-	--color-button: #22253f;
-	--color-disabled: #161833;
-	--color-button-hover: #282b44;
+	--token-prob-box:     #FF665C;
 
-	--token-prob-box: #4a4a4a;
+	font-family:           "Source Sans Pro", "Helvetica Neue", sans-serif;
+	font-size:             15.5px;
 
-	font-family: "Source Sans Pro", "Helvetica Neue", sans-serif;
-	font-size: 15.5px;
+	accent-color:          var(--color-base-90);
+	background:            var(--color-bg-dark);
+	color:                 var(--color-base-0);
+	color-scheme:          dark;
+}
 
-	accent-color: var(--color-base-30);
-	background: var(--color-bg-dark);
-	color: var(--color-base-0);
-	color-scheme: dark;
+html.selenized body {
+	background:            var(--color-base-150)
+}
+
+html.selenized #sidebar {
+	background:            var(--color-base-100)
 }
 
 html.monospace-dark {
-	---color-bg-dark: #282833;
-	--color-bg: #202020;
-	--color-text: #bababa;
-	--color-base-0: oklch(77.65% 0.0752 285.22);
-	--color-base-10: color-mix(in oklch, var(--color-base-100) 90%, var(--color-base-0));
-	--color-base-20: color-mix(in oklch, var(--color-base-100) 80%, var(--color-base-0));
-	--color-base-30: color-mix(in oklch, var(--color-base-100) 70%, var(--color-base-0));
-	--color-base-40: color-mix(in oklch, var(--color-base-100) 60%, var(--color-base-0));
-	--color-base-50: color-mix(in oklch, var(--color-base-100) 50%, var(--color-base-0));
-	--color-base-60: color-mix(in oklch, var(--color-base-100) 40%, var(--color-base-0));
-	--color-base-70: color-mix(in oklch, var(--color-base-100) 30%, var(--color-base-0));
-	--color-base-80: color-mix(in oklch, var(--color-base-100) 20%, var(--color-base-0));
-	--color-base-90: color-mix(in oklch, var(--color-base-100) 10%, var(--color-base-0));
-	--color-base-100: oklch(24.28% 0.015 285.22);
-	--color-dark: var(--color-base-100);
-	--color-light: var(--color-base-0);
-	--token-prob-box: #4a4a4a;
+	---color-bg-dark:     #282833;
+	--color-bg:           #202020;
+	--color-text:         #bababa;
+	--color-base-0:       oklch(77.65% 0.0752 285.22);
+	--color-base-10:      color-mix(in oklch, var(--color-base-100) 90%, var(--color-base-0));
+	--color-base-20:      color-mix(in oklch, var(--color-base-100) 80%, var(--color-base-0));
+	--color-base-30:      color-mix(in oklch, var(--color-base-100) 70%, var(--color-base-0));
+	--color-base-40:      color-mix(in oklch, var(--color-base-100) 60%, var(--color-base-0));
+	--color-base-50:      color-mix(in oklch, var(--color-base-100) 50%, var(--color-base-0));
+	--color-base-60:      color-mix(in oklch, var(--color-base-100) 40%, var(--color-base-0));
+	--color-base-70:      color-mix(in oklch, var(--color-base-100) 30%, var(--color-base-0));
+	--color-base-80:      color-mix(in oklch, var(--color-base-100) 20%, var(--color-base-0));
+	--color-base-90:      color-mix(in oklch, var(--color-base-100) 10%, var(--color-base-0));
+	--color-base-100:     oklch(24.28% 0.015 285.22);
+	--color-dark:         var(--color-base-100);
+	--color-light:        var(--color-base-0);
+	--token-prob-box:     #4a4a4a;
 
-	font-family: monospace;
-	font-size: 15px;
+	font-family:           monospace;
+	font-size:             15px;
 
-	accent-color: var(--color-base-30);
-	background: var(--color-bg-dark);
-	color: var(--color-base-0);
-	color-scheme: dark;
+	accent-color:          var(--color-base-30);
+	background:            var(--color-bg-dark);
+	color:                 var(--color-base-0);
+	color-scheme:          dark;
 }
 
 body {
@@ -414,6 +422,11 @@ html.nockoffAI  #context-order-desc,
 html.nockoffAI .modal-desc {
 	color:var(--color-base-80);
 }
+
+html.selenized .modal {
+	background:var(--color-base-100);
+}
+
 .modal-content {
 	overflow-y: auto;
 }
@@ -571,6 +584,22 @@ html.nockoffAI #sidebar {
 	color: inherit;
 	background: var(--color-base-30);
 	flex: none;
+}
+
+html.selenized .InputBox > input,
+html.selenized .SelectBox > select,
+html.selenized .TextArea > textarea,
+html.selenized .collapsible-header,
+html.selenized button {
+	background: var(--color-base-90);
+}
+
+html.selenized button:hover {
+	background: var(--color-base-70);
+}
+
+html.selenized button:disabled {
+	background: var(--color-base-60);
 }
 
 html.monospace-dark .InputBox > input, html.monospace-dark .SelectBox > select,


### PR DESCRIPTION
This adds an additional color scheme, [Selenized](https://github.com/jan-warchol/selenized) (which is essentially [Solarized](https://en.wikipedia.org/wiki/Solarized) with some contrast enhancements). It also formats some of the whitespace in the properties for color schemes, which I found useful when going through and modifying this one, and would probably be useful for the rest as well.

Also adds prefs option to change width of the text box from default of 35em