### PR TITLE
Support for Instruct / prompt format templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,16 @@
 
 ## Features
 
-* **Multiple Backends**: Multiple backends are supported, namely **llamacpp**, **legacy oobabooga**, **koboldcpp**, and any other backend with **openai-compatible** APIs. You can seamlessly switch between these backends to get different text generation experiences.
-  * As of 10/10/2023 (commit [4aabff3](https://github.com/oobabooga/text-generation-webui/commit/4aabff3728e00ee2a4afa5e6ee8079bab0523dbd)), **oobabooga** uses a openai-compatible API, so make sure you use it instead of the legacy API.
+* **Multiple Backends**: Multiple backends are supported, namely **llama.cpp**, **koboldcpp**, and any other backend with **OpenAI compatible** APIs. You can seamlessly switch between these backends to get different text generation experiences.
 * **Session Persistence**: Your text generation sessions are automatically saved and restored. This means you can work on your text in multiple sittings and continue right where you left off. Import and export your sessions to share your creative work or switch devices effortlessly.
+* **Persistent Context**:
+  * **Memory**: Seamlessly inject a text of your choice at the beginning of the context.
+  * **Author's Note**: Seamlessly inject a text of your choice at the end of the context, with adjustable depth.
+  * **World Info**: Dynamically include extra information in the context, triggered by specific keywords.
 * **Prediction Undo/Redo**: It's possible to undo and redo predictions, making it easy to experiment and fine-tune your generated text until it's just right.
 * **Token Probability** *(llamacpp/openai backend)*: When you hover over a token in the generated text, a list will show at most 10 tokens with their probabilities. This information can be a valuable aid in refining your text. Moreover, you can click on another token's probability to restart text generation from that point.
   * If you're using oobabooga, make sure to use an _HF sampler for this feature to function properly.
-* **Dark Mode Switch**: Customize your environment to suit your preferences with a convenient dark mode switch.
+* **Themes**: Customize your environment by choosing from a variety of themes.
 
 ## Getting Started
 

--- a/mikupad.html
+++ b/mikupad.html
@@ -1137,6 +1137,12 @@ function openaiConvertOptions(options, isOpenAI) {
 	if (isOpenAI && options.n_probs > 5) {
 		options.n_probs = 5;
 	}
+	if ("dynatemp_range" in options && options.dynatemp_range !== 0) {
+		// oobabooga specific.
+		options.dynatemp_low = Math.max(0, options.temperature - options.dynatemp_range);
+		options.dynatemp_high = Math.max(0, options.temperature + options.dynatemp_range);
+		delete options.dynatemp_range;
+	}
 	swapOption("n_ctx", "max_context_length");
 	swapOption("n_predict", "max_tokens");
 	swapOption("n_probs", "logprobs");
@@ -1663,6 +1669,8 @@ const defaultPresets = {
 	seed: -1,
 	maxPredictTokens: -1,
 	temperature: 0.7,
+	dynaTempRange: 0,
+	dynaTempExp: 0,
 	repeatPenalty: 1.1,
 	repeatLastN: 256,
 	penalizeNl: false,
@@ -1790,6 +1798,8 @@ export function App() {
 	const [seed, setSeed] = useSessionState('seed', defaultPresets.seed);
 	const [maxPredictTokens, setMaxPredictTokens] = useSessionState('maxPredictTokens', defaultPresets.maxPredictTokens);
 	const [temperature, setTemperature] = useSessionState('temperature', defaultPresets.temperature);
+	const [dynaTempRange, setDynaTempRange] = useSessionState('dynaTempRange', defaultPresets.dynaTempRange);
+	const [dynaTempExp, setDynaTempExp] = useSessionState('dynaTempExp', defaultPresets.dynaTempMax);
 	const [repeatPenalty, setRepeatPenalty] = useSessionState('repeatPenalty', defaultPresets.repeatPenalty);
 	const [repeatLastN, setRepeatLastN] = useSessionState('repeatLastN', defaultPresets.repeatLastN);
 	const [penalizeNl, setPenalizeNl] = useSessionState('penalizeNl', defaultPresets.penalizeNl);
@@ -2078,6 +2088,8 @@ export function App() {
 				...(seed != -1 ? { seed } : {}),
 				temperature,
 				...(!openaiPresets || endpointAPI != 3 ? {
+					dynatemp_range: dynaTempRange,
+					dynatemp_exponent: dynaTempExp,
 					repeat_penalty: repeatPenalty,
 					repeat_last_n: repeatLastN,
 					penalize_nl: penalizeNl,
@@ -2612,6 +2624,14 @@ export function App() {
 				<${InputBox} label="Temperature" type="number" step="0.01"
 					readOnly=${!!cancel} value=${temperature} onValueChange=${setTemperature}/>
 				${(!openaiPresets || endpointAPI != 3) && html`
+					${endpointAPI != 0 && html`
+						<div className="hbox">
+							<${InputBox} label="DynaTemp Range" type="number" step="0.01"
+								readOnly=${!!cancel} value=${dynaTempRange} onValueChange=${setDynaTempRange}/>
+							${endpointAPI != 2 && html`
+								<${InputBox} label="DynaTemp Exp" type="number" step="0.01"
+									readOnly=${!!cancel} value=${dynaTempExp} onValueChange=${setDynaTempExp}/>`}
+						</div>`}
 					<div className="hbox">
 						<${InputBox} label="Repeat penalty" type="number" step="0.01"
 							readOnly=${!!cancel} value=${repeatPenalty} onValueChange=${setRepeatPenalty}/>

--- a/mikupad.html
+++ b/mikupad.html
@@ -1698,6 +1698,14 @@ function Templates({ templateStorage, onSessionChange, disabled }) {
 	const [isRenaming, setIsRenaming] = useState(false);
 	const [isCreating, setIsCreating] = useState(false);
 
+
+	useEffect(() => {
+		templateStorage.onchange = () => setVersion(v => v + 1);
+		return () => {
+			sessionStorage.onchange = null;
+		};
+	}, []);
+
 	const renameSession = (sessionId) => {
 		if (renameSessionName) {
 			templateStorage.renameSession(sessionId, renameSessionName);
@@ -1721,9 +1729,9 @@ function Templates({ templateStorage, onSessionChange, disabled }) {
 		}
 	};
 
-	templateStorage.templates.clear();
-	templateStorage.templates.addTemplate('Mixtral', '[INST]', '[/INST]');
-	templateStorage.templates.addTemplate('Alpaca', '### Instruction:', '### Response:');
+	templateStorage.clear();
+	templateStorage.addTemplate('Mixtral', '[INST]', '[/INST]');
+	templateStorage.addTemplate('Alpaca', '### Instruction:', '### Response:');
 	
 	const importSession = () => {
 		const fileInput = document.createElement("input");
@@ -1751,7 +1759,7 @@ function Templates({ templateStorage, onSessionChange, disabled }) {
 
 	const exportSession = () => {
 		var element = document.createElement('a');
-		const sessionObj = { ...templateStorage.sessions[templateStorage.selectedSession] };
+		const sessionObj = { ...templateStorage.sessions[templateStorage.selectedSessionId] };
 		for (const [key, value] of Object.entries(sessionObj)) {
 			// This is done for compatibility with localStorage export files.
 			sessionObj[key] = JSON.stringify(value);
@@ -1788,7 +1796,7 @@ function Templates({ templateStorage, onSessionChange, disabled }) {
 		<div className="Sessions ${disabled ? 'disabled' : ''}">
 			<ul>
 				${isCreating && html`
-					<li key=-1>
+					<li key=-1}>
 						<a className="Session">
 							<div>
 								<label>Instruct:</label>
@@ -1817,31 +1825,31 @@ function Templates({ templateStorage, onSessionChange, disabled }) {
 						</a>
 					</li>
 				`}
-				${[...templateStorage.templates.templates.entries()].map(([sessionId, { name, prefix, suffix }]) => html`
-					<li>
-						<a className="Session ${templateStorage.selectedSession == sessionId ? 'selected' : ''}"
-							onClick=${() => switchSession(sessionId)}>
-							${isRenaming === sessionId ? html`
+				${[...templateStorage.templates.entries()].map(([templateId, { name, prefix, suffix }]) => html`
+					<li key=${templateId}>
+						<a className="Session ${templateStorage.selectedTemplateId == templateId ? 'selected' : ''}"
+							onClick=${() => templateStorage.switchTemplate(templateId)}>
+							${isRenaming === templateId ? html`
 								<input
 									type="text"
 									value=${name}
 									onChange=${(e) => setRenameSessionName(e.target.value)}
-									onKeyDown=${(e) => handleKeyDown(sessionId, e.key)}
+									onKeyDown=${(e) => handleKeyDown(templateId, e.key)}
 									onClick=${(e) => e.stopPropagation()}
 									autoFocus
 								/>
 								<div className="flex-separator"></div>
-								<button onClick=${(e) => (renameSession(sessionId), e.stopImmediatePropagation())}>${confirmSvg}</button>
+								<button onClick=${(e) => (renameSession(templateId), e.stopImmediatePropagation())}>${confirmSvg}</button>
 								<button onClick=${(e) => (setIsRenaming(false), e.stopImmediatePropagation())}>${cancelSvg}</button>
 							` : html`
 								${name}
 								<div className="flex-separator"></div>
 								<button
-									onClick=${(e) => (startRenameSession(sessionId, name), e.stopPropagation())}>
+									onClick=${(e) => (startRenameSession(templateId, name), e.stopPropagation())}>
 									${renameSvg}
 								</button>
 								<button
-									onClick=${(e) => (deleteSession(sessionId), e.stopPropagation())}>
+									onClick=${(e) => (deleteSession(templateId), e.stopPropagation())}>
 									${trashSvg}
 								</button>
 							`}
@@ -1862,11 +1870,14 @@ class TemplateCollection {
 	constructor() {
 		this.templates = new Map();
 		this.nextId = 1;
+		this.selectedTemplateId = 1;
+		this.onchange = null;
 	}
 
 	addTemplate(name, prefix, suffix) {
 		const id = this.nextId++;
 		this.templates.set(id, { name, prefix, suffix });
+		this.selectedTemplateId = id;
 		return id;
 	}
 
@@ -1876,6 +1887,11 @@ class TemplateCollection {
 
 	clear() {
 		this.templates.clear();
+	}
+
+	switchTemplate(id) {
+		this.selectedTemplateId = id;
+		this.onchange?.();
 	}
 }
 
@@ -2846,7 +2862,7 @@ export function App() {
 					onSessionChange=${onSessionChange}/>
 			</${CollapsibleGroup}>					
 			<${CollapsibleGroup} label="Instruct Templates">
-				<${Templates} templateStorage=${{ templates : templateStorage}}
+				<${Templates} templateStorage=${ templateStorage}
 					disabled=${!!cancel}
 					onSessionChange=${onSessionChange} />
 			</${CollapsibleGroup}>

--- a/mikupad.html
+++ b/mikupad.html
@@ -849,7 +849,7 @@ html.monospace-dark .horz-separator {
 </style>
 <script type="module">
 
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState, useCallback } from 'react';
 import { createRoot } from 'react-dom/client';
 import { html } from 'htm/react';
 import { SVResizeObserver } from 'scrollview-resize';
@@ -1267,7 +1267,8 @@ function CollapsibleGroup({ label, expanded, children }) {
 	useEffect(() => {
 		setContentHeight(contentArea.current.scrollHeight);
 		const observer = new SVResizeObserver(() => {
-			setContentHeight(contentArea.current.scrollHeight);
+			if (contentArea?.current)
+				setContentHeight(contentArea.current.scrollHeight);
 		});
 		observer.observe(contentArea.current);
 		return () => observer.disconnect();
@@ -1763,6 +1764,7 @@ function Templates({ templateStorage, onSessionChange, disabled, promptArea, onI
 	const [version, setVersion] = useState(0);
 	const [newPrefix, setNewPrefix] = useState('');
 	const [newSuffix, setNewSuffix] = useState('');
+	const [newName, setNewName] = useState('');
 	const [renameSessionName, setRenameSessionName] = useState('');
 	const [isRenaming, setIsRenaming] = useState(false);
 	const [isCreating, setIsCreating] = useState(false);
@@ -1795,19 +1797,21 @@ function Templates({ templateStorage, onSessionChange, disabled, promptArea, onI
 		}
 	};
 
-	const deleteSession = (sessionId) => {
-		templateStorage.deleteSession(sessionId);
+	const deleteTemplate = (templateId) => {
+		templateStorage.removeTemplate(templateId);
 	};
 
 	const startCreateTemplate = () => {
+		setNewName('');
 		setNewPrefix('');
 		setNewSuffix('');
 		setIsCreating(true);
 	};
 
 	const createTemplate = () => {
-		if (newPrefix || newSuffix) {
-			templateStorage.templates.addTemplate(newPrefix, newSuffix);
+		if (newName && (newPrefix || newSuffix)) {
+			templateStorage.addTemplate(newName, newPrefix, newSuffix);
+			setIsCreating(false);
 		}
 	};
 	
@@ -1839,7 +1843,6 @@ function Templates({ templateStorage, onSessionChange, disabled, promptArea, onI
 		var element = document.createElement('a');
 		const sessionObj = { ...templateStorage.sessions[templateStorage.selectedSessionId] };
 		for (const [key, value] of Object.entries(sessionObj)) {
-			// This is done for compatibility with localStorage export files.
 			sessionObj[key] = JSON.stringify(value);
 		}
 		element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(JSON.stringify(sessionObj)));
@@ -1852,9 +1855,7 @@ function Templates({ templateStorage, onSessionChange, disabled, promptArea, onI
 
 	function handleKeyDown(sessionId, key) {
 		if (event.key === 'Enter') {
-			if (isCreating)
-				createTemplate();
-			else if (isRenaming)
+			if (isRenaming)
 				renameSession(sessionId);
 		} else if (event.key === 'Escape') {
 			if (isCreating)
@@ -1936,22 +1937,30 @@ function Templates({ templateStorage, onSessionChange, disabled, promptArea, onI
 			<ul>
 				${isCreating && html`
 					<li key=-1}>
-						<a className="Session">
+						<a className="Session" style=${{ display: 'flex', flexDirection: 'column' }}>
 							<div>
-								<label>Instruct:</label>
+								<label>Template name:</label>
 								<input
 									type="text"
-									value=${newPrefix}
-									onChange=${(e) => setNewPrefix(e.target.value)}
+									value=${newName}
+									onChange=${(e) => setNewName(e.target.value)}
 									onKeyDown=${(e) => handleKeyDown(undefined, e.key)}
 									onClick=${(e) => e.stopPropagation()}
 									autoFocus
 								/>
 							</div>
 							<div>
+								<label>Instruct:</label>
+								<textarea
+									value=${newPrefix}
+									onChange=${(e) => setNewPrefix(e.target.value)}
+									onKeyDown=${(e) => handleKeyDown(undefined, e.key)}
+									onClick=${(e) => e.stopPropagation()}
+								/>
+							</div>
+							<div>
 								<label>Response:</label>
-								<input
-									type="text"
+								<textarea
 									value=${newSuffix}
 									onChange=${(e) => setNewSuffix(e.target.value)}
 									onKeyDown=${(e) => handleKeyDown(undefined, e.key)}
@@ -1959,8 +1968,10 @@ function Templates({ templateStorage, onSessionChange, disabled, promptArea, onI
 								/>
 							</div>
 							<div className="flex-separator"></div>
-							<button onClick=${(e) => (createTemplate(), e.stopImmediatePropagation?.())}>${confirmSvg}</button>
-							<button onClick=${(e) => (setIsCreating(false), e.stopImmediatePropagation?.())}>${cancelSvg}</button>
+							<div style=${{ display: 'flex', flexDirection: 'row' }}>
+								<button onClick=${(e) => (createTemplate(), e.stopImmediatePropagation?.())}>${confirmSvg}</button>
+								<button onClick=${(e) => (setIsCreating(false), e.stopImmediatePropagation?.())}>${cancelSvg}</button>
+							</div>
 						</a>
 					</li>
 				`}
@@ -1988,7 +1999,7 @@ function Templates({ templateStorage, onSessionChange, disabled, promptArea, onI
 									${renameSvg}
 								</button>
 								<button
-									onClick=${(e) => (deleteSession(templateId), e.stopPropagation())}>
+									onClick=${(e) => (deleteTemplate(templateId), e.stopPropagation())}>
 									${trashSvg}
 								</button>
 							`}
@@ -2007,15 +2018,25 @@ function Templates({ templateStorage, onSessionChange, disabled, promptArea, onI
 
 
 class TemplateCollection {
-	constructor() {
+	constructor(changeListener = null, initialState = null) {
 		this.templates = new Map();
 		this.nextId = 1;
 		this.selectedTemplateId = 1;
-		this.onchange = null;
-		if (this.templates.size === 0)
-		{
+		this.changeListener = changeListener;
+
+		if (initialState) {
+			this.templates = initialState.templates;
+			this.nextId = initialState.nextId;
+			this.selectedTemplateId = initialState.selectedTemplateId;
+		} else {
 			this.addTemplate('Mixtral', '[INT]', '[/INT]');
 			this.addTemplate('Alpaca', '### Instruction:\n', '### Response:\n');
+		}
+	}
+
+	notifyChange() {
+		if (this.changeListener) {
+			this.changeListener(this);
 		}
 	}
 
@@ -2023,24 +2044,37 @@ class TemplateCollection {
 		const id = this.nextId++;
 		this.templates.set(id, { name, prefix, suffix });
 		this.selectedTemplateId = id;
+		this.notifyChange();
 		return id;
 	}
 
 	removeTemplate(id) {
 		this.templates.delete(id);
+		this.onchange?.();
+		this.notifyChange();
 	}
 
 	clear() {
 		this.templates.clear();
+		this.notifyChange();
 	}
 
 	switchTemplate(id) {
 		this.selectedTemplateId = id;
 		this.onchange?.();
+		this.notifyChange();
 	}
 
 	getCurrentTemplate() {
 		return this.templates.get(this.selectedTemplateId) || null;
+	}
+
+	setChangeListener(changeListener) {
+		this.changeListener = changeListener;
+	}
+
+	removeChangeListener(listener) {
+		this.changeListener = null;
 	}
 }
 
@@ -2159,8 +2193,60 @@ function usePersistentState(name, initialState) {
 	return [value, updateState];
 }
 
+
+function serializeTemplateCollection(collection) {
+	const templatesArray = [...collection.templates.entries()].map(([id, {name, prefix, suffix}]) => ({id, name, prefix, suffix}));
+	return JSON.stringify({
+		templates: templatesArray,
+		nextId: collection.nextId,
+		selectedTemplateId: collection.selectedTemplateId,
+	});
+}
+
+function deserializeTemplateCollection(serialized) {
+	const parsed = JSON.parse(serialized);
+	const collection = new TemplateCollection();
+	collection.templates.clear();
+	collection.nextId = parsed.nextId;
+	collection.selectedTemplateId = parsed.selectedTemplateId;
+	parsed.templates.forEach(({id, name, prefix, suffix}) => {
+		collection.templates.set(id, {name, prefix, suffix});
+		collection.nextId = Math.max(collection.nextId, id + 1);
+	});
+	return collection;
+}
+
+function usePersistentTemplateCollection(name, initialState) {
+	const handleChangeRef = useRef(null);
+	handleChangeRef.current = (newState) => {
+		setTemplateStorage(newState);
+		localStorage.setItem(name, serializeTemplateCollection(newState));
+	};
+	const [templateStorage, setTemplateStorage] = useState(() => {
+		const init = () => {
+		try {
+			const item = localStorage.getItem(name);
+			return item ? deserializeTemplateCollection(item, handleChangeRef.current) : new TemplateCollection(handleChangeRef.current);
+		} catch (e) {
+			console.error(e);
+			return new TemplateCollection(handleChangeRef.current);
+		}
+		};
+		return init();
+	});
+
+	useEffect(() => {
+		templateStorage.setChangeListener(handleChangeRef.current);
+		return () => {
+		templateStorage.removeChangeListener(handleChangeRef.current);
+		};
+	}, [templateStorage]);
+
+	return [templateStorage, setTemplateStorage];
+}
+
 export function App({ sessionStorage, useSessionState }) {
-	const [templateStorage, setTemplateStorage] = usePersistentState('templateStorage', new TemplateCollection());
+	const [templateStorage, setTemplateStorage] = usePersistentTemplateCollection('templateStorage', new TemplateCollection());
 	const promptArea = useRef();
 	const promptOverlay = useRef();
 	const undoStack = useRef([]);

--- a/mikupad.html
+++ b/mikupad.html
@@ -2858,7 +2858,6 @@ export function App({ sessionStorage, useSessionState }) {
 			case 'false:false:true:y':
 				if (cancel || !redo()) return;
 				break;
-				
 			default:
 				keyState.current = e;
 				return;

--- a/mikupad.html
+++ b/mikupad.html
@@ -1811,7 +1811,26 @@ function Templates({ templateStorage, onSessionChange, disabled, promptArea, onI
 		const prefix = currentTemplate.prefix || '';
 		const suffix = currentTemplate.suffix || '';
 
-		const lineBreakBeforePrefix = textBefore ? '\n\n' : '';
+		const countLineBreaks = (text) => {
+			let count = 0;
+			for (let i = text.length - 1; i >= 0; i--) {
+				if (text[i] === '\n') {
+					count++;
+				} else {
+					break;
+				}
+			}
+			return count;
+    	};
+
+		const existingLineBreaks = countLineBreaks(textBefore);
+    	let lineBreakBeforePrefix = '';
+		if (textBefore.length > 0) {
+			if (existingLineBreaks < 2) {
+				lineBreakBeforePrefix = '\n'.repeat(2 - existingLineBreaks);
+			}
+		}
+
 		const lineBreakAfterPrefix = '\n';
 		const lineBreakBeforeSuffix = '\n\n';
 		const lineBreakAfterSuffix = '\n';
@@ -1824,10 +1843,15 @@ function Templates({ templateStorage, onSessionChange, disabled, promptArea, onI
 
 		elem.value = finalText;
 
-		const newCursorPos = startPos 
+		let newCursorPos;
+		if (selectedText.length === 0) {
+			newCursorPos = startPos + lineBreakBeforePrefix.length + prefix.length + lineBreakAfterPrefix.length;
+		} else {
+			newCursorPos = startPos 
 							+ lineBreakBeforePrefix.length + prefix.length + lineBreakAfterPrefix.length 
 							+ selectedText.length 
 							+ lineBreakBeforeSuffix.length + suffix.length + lineBreakAfterSuffix.length;
+    	}
 		elem.setSelectionRange(newCursorPos, newCursorPos);
 		onInput({ target: elem });
 	}

--- a/mikupad.html
+++ b/mikupad.html
@@ -2035,6 +2035,7 @@ class TemplateCollection {
 		} else {
 			this.addTemplate('Mixtral', '[INT]', '[/INT]');
 			this.addTemplate('Alpaca', '### Instruction:\n', '### Response:\n');
+			this.addTemplate('ChatLM', '<|im_start|>user\n', '<|im_end|>\n<|im_start|\n');
 		}
 	}
 

--- a/mikupad.html
+++ b/mikupad.html
@@ -1799,7 +1799,7 @@ export function App() {
 	const [maxPredictTokens, setMaxPredictTokens] = useSessionState('maxPredictTokens', defaultPresets.maxPredictTokens);
 	const [temperature, setTemperature] = useSessionState('temperature', defaultPresets.temperature);
 	const [dynaTempRange, setDynaTempRange] = useSessionState('dynaTempRange', defaultPresets.dynaTempRange);
-	const [dynaTempExp, setDynaTempExp] = useSessionState('dynaTempExp', defaultPresets.dynaTempMax);
+	const [dynaTempExp, setDynaTempExp] = useSessionState('dynaTempExp', defaultPresets.dynaTempExp);
 	const [repeatPenalty, setRepeatPenalty] = useSessionState('repeatPenalty', defaultPresets.repeatPenalty);
 	const [repeatLastN, setRepeatLastN] = useSessionState('repeatLastN', defaultPresets.repeatLastN);
 	const [penalizeNl, setPenalizeNl] = useSessionState('penalizeNl', defaultPresets.penalizeNl);

--- a/mikupad.html
+++ b/mikupad.html
@@ -1672,8 +1672,8 @@ class SessionStorage {
 function Templates({ templateStorage, onSessionChange, disabled }) {
 	
 	const [version, setVersion] = useState(0);
-	const [newInstruct, setNewInstruct] = useState('');
-	const [newResponse, setNewResponse] = useState('');
+	const [newPrefix, setNewPrefix] = useState('');
+	const [newSuffix, setNewSuffix] = useState('');
 	const [renameSessionName, setRenameSessionName] = useState('');
 	const [isRenaming, setIsRenaming] = useState(false);
 	const [isCreating, setIsCreating] = useState(false);
@@ -1690,17 +1690,21 @@ function Templates({ templateStorage, onSessionChange, disabled }) {
 	};
 
 	const startCreateTemplate = () => {
-		setNewInstruct('');
-		setNewResponse('');
+		setNewPrefix('');
+		setNewSuffix('');
 		setIsCreating(true);
 	};
 
 	const createTemplate = () => {
-		if (newInstruct || newResponse) {
-			// TODO: add element to templates array with the values, preserve in storage
+		if (newPrefix || newSuffix) {
+			templateStorage.templates.addTemplate(newPrefix, newSuffix);
 		}
 	};
 
+	templateStorage.templates.clear();
+	templateStorage.templates.addTemplate('Mixtral', '[INST]', '[/INST]');
+	templateStorage.templates.addTemplate('Alpaca', '### Instruction:', '### Response:');
+	
 	const importSession = () => {
 		const fileInput = document.createElement("input");
 		fileInput.type = 'file';
@@ -1770,8 +1774,8 @@ function Templates({ templateStorage, onSessionChange, disabled }) {
 								<label>Instruct:</label>
 								<input
 									type="text"
-									value=${newInstruct}
-									onChange=${(e) => setNewInstruct(e.target.value)}
+									value=${newPrefix}
+									onChange=${(e) => setNewPrefix(e.target.value)}
 									onKeyDown=${(e) => handleKeyDown(undefined, e.key)}
 									onClick=${(e) => e.stopPropagation()}
 									autoFocus
@@ -1781,8 +1785,8 @@ function Templates({ templateStorage, onSessionChange, disabled }) {
 								<label>Response:</label>
 								<input
 									type="text"
-									value=${newResponse}
-									onChange=${(e) => setNewResponse(e.target.value)}
+									value=${newSuffix}
+									onChange=${(e) => setNewSuffix(e.target.value)}
 									onKeyDown=${(e) => handleKeyDown(undefined, e.key)}
 									onClick=${(e) => e.stopPropagation()}
 								/>
@@ -1793,14 +1797,14 @@ function Templates({ templateStorage, onSessionChange, disabled }) {
 						</a>
 					</li>
 				`}
-				${templateStorage.templates.reverse().map(([instruction, response]) => html`
-					<li key=${sessionId}>
+				${[...templateStorage.templates.templates.entries()].map(([sessionId, { name, prefix, suffix }]) => html`
+					<li>
 						<a className="Session ${templateStorage.selectedSession == sessionId ? 'selected' : ''}"
 							onClick=${() => switchSession(sessionId)}>
 							${isRenaming === sessionId ? html`
 								<input
 									type="text"
-									value=${renameSessionName}
+									value=${name}
 									onChange=${(e) => setRenameSessionName(e.target.value)}
 									onKeyDown=${(e) => handleKeyDown(sessionId, e.key)}
 									onClick=${(e) => e.stopPropagation()}
@@ -1810,10 +1814,10 @@ function Templates({ templateStorage, onSessionChange, disabled }) {
 								<button onClick=${(e) => (renameSession(sessionId), e.stopImmediatePropagation())}>${confirmSvg}</button>
 								<button onClick=${(e) => (setIsRenaming(false), e.stopImmediatePropagation())}>${cancelSvg}</button>
 							` : html`
-								${session.name}
+								${name}
 								<div className="flex-separator"></div>
 								<button
-									onClick=${(e) => (startRenameSession(sessionId, session.name), e.stopPropagation())}>
+									onClick=${(e) => (startRenameSession(sessionId, name), e.stopPropagation())}>
 									${renameSvg}
 								</button>
 								<button
@@ -1832,6 +1836,29 @@ function Templates({ templateStorage, onSessionChange, disabled }) {
 			</div>
 		</div>`;
 }
+
+
+class TemplateCollection {
+	constructor() {
+		this.templates = new Map();
+		this.nextId = 1;
+	}
+
+	addTemplate(name, prefix, suffix) {
+		const id = this.nextId++;
+		this.templates.set(id, { name, prefix, suffix });
+		return id;
+	}
+
+	removeTemplate(id) {
+		this.templates.delete(id);
+	}
+
+	clear() {
+		this.templates.clear();
+	}
+}
+
 
 
 const defaultPrompt = `[INST] <<SYS>>
@@ -1957,6 +1984,7 @@ function usePersistentState(name, initialState) {
 
 export function App() {
 	const [sessionStorage, useSessionState] = useSessionStorage(defaultPresets);
+	const [templateStorage, setTemplateStorage] = usePersistentState('templateStorage', new TemplateCollection());
 	const promptArea = useRef();
 	const promptOverlay = useRef();
 	const undoStack = useRef([]);
@@ -2798,7 +2826,7 @@ export function App() {
 					onSessionChange=${onSessionChange}/>
 			</${CollapsibleGroup}>					
 			<${CollapsibleGroup} label="Instruct Templates">
-				<${Templates} templateStorage=${{ templates : []}}
+				<${Templates} templateStorage=${{ templates : templateStorage}}
 					disabled=${!!cancel}
 					onSessionChange=${onSessionChange} />
 			</${CollapsibleGroup}>

--- a/mikupad.html
+++ b/mikupad.html
@@ -2575,7 +2575,7 @@ export function App() {
 					disabled=${!!cancel}
 					onSessionChange=${onSessionChange}/>
 			</${CollapsibleGroup}>
-			<${CollapsibleGroup} label="Presets" expanded>
+			<${CollapsibleGroup} label="Parameters" expanded>
 				<${InputBox} label="Server"
 					className="${isMixedContent() ? 'mixed-content' : ''}"
 					tooltip="${isMixedContent() ? 'This URL might be blocked due to mixed content. If the prediction fails, download mikupad.html and run it locally.' : ''}"
@@ -2606,9 +2606,7 @@ export function App() {
 						datalist=${openaiModels}
 						readOnly=${!!cancel}
 						value=${endpointModel}
-						onValueChange=${setEndpointModel}/>
-					<${Checkbox} label="Full OpenAI compliance"
-						disabled=${!!cancel} value=${openaiPresets} onValueChange=${setOpenaiPresets}/>`}
+						onValueChange=${setEndpointModel}/>`}
 				<${InputBox} label="Seed (-1 = random)" type="text" inputmode="numeric"
 					readOnly=${!!cancel} value=${seed} onValueChange=${setSeed}/>
 				<${InputBox} tooltip="Currently not accurate to the token count, it will be used as an estimate." label="Max Context Length" type="text" inputmode="numeric"
@@ -2621,6 +2619,11 @@ export function App() {
 					readOnly=${!!cancel}
 					value=${stoppingStrings}
 					onValueChange=${setStoppingStrings}/>
+			</${CollapsibleGroup}>
+			<${CollapsibleGroup} label="Sampling" expanded>
+				${endpointAPI == 3 && html`
+					<${Checkbox} label="Full OpenAI compliance"
+						disabled=${!!cancel} value=${openaiPresets} onValueChange=${setOpenaiPresets}/>`}
 				<${InputBox} label="Temperature" type="number" step="0.01"
 					readOnly=${!!cancel} value=${temperature} onValueChange=${setTemperature}/>
 				${(!openaiPresets || endpointAPI != 3) && html`
@@ -2674,6 +2677,9 @@ export function App() {
 									readOnly=${!!cancel} value=${topK} onValueChange=${setTopK}/>`}
 							<${InputBox} label="Top P" type="number" step="0.01"
 								readOnly=${!!cancel} value=${topP} onValueChange=${setTopP}/>
+							${(!openaiPresets || endpointAPI != 3) && html`
+								<${InputBox} label="Min P" type="number" step="0.01"
+									readOnly=${!!cancel} value=${minP} onValueChange=${setMinP}/>`}
 						</div>
 						${(!openaiPresets || endpointAPI != 3) && html`
 							<div className="hbox">
@@ -2681,10 +2687,6 @@ export function App() {
 									readOnly=${!!cancel} value=${typicalP} onValueChange=${setTypicalP}/>
 								<${InputBox} label="TFS z" type="number" step="0.01"
 									readOnly=${!!cancel} value=${tfsZ} onValueChange=${setTfsZ}/>
-							</div>
-							<div className="hbox">
-								<${InputBox} label="Min P" type="number" step="0.01"
-									readOnly=${!!cancel} value=${minP} onValueChange=${setMinP}/>
 							</div>`}
 					`}
 				`}

--- a/mikupad.html
+++ b/mikupad.html
@@ -1759,7 +1759,7 @@ class SessionStorage {
 }
 
 
-function Templates({ templateStorage, onSessionChange, disabled, promptArea, onInput }) {
+function Templates({ templateStorage, disabled, promptArea, onInput, setTemplateStorage }) {
 	
 	const [version, setVersion] = useState(0);
 	const [newPrefix, setNewPrefix] = useState('');
@@ -1784,11 +1784,10 @@ function Templates({ templateStorage, onSessionChange, disabled, promptArea, onI
 	});
 
 	useEffect(() => {
-		templateStorage.onchange = () => setVersion(v => v + 1);
-		return () => {
-			sessionStorage.onchange = null;
-		};
-	}, []);
+	templateStorage.onchange = () => setVersion(v => v + 1);
+	return () => {
+		templateStorage.onchange = null;
+	};}, [templateStorage]);
 
 	const modifyTemplate = (templateId) => {
 		if (newName && (newPrefix || newSuffix)) {
@@ -1829,7 +1828,7 @@ function Templates({ templateStorage, onSessionChange, disabled, promptArea, onI
 		}
 	};
 
-	const importSession = () => {
+	const importTemplate = () => {
 		const fileInput = document.createElement("input");
 		fileInput.type = 'file';
 		fileInput.style.display = 'none';
@@ -1845,22 +1844,19 @@ function Templates({ templateStorage, onSessionChange, disabled, promptArea, onI
 			reader.readAsText(file);
 		};
 		fileInput.func = (text) => {
-			const newId = templateStorage.createSessionFromObject(JSON.parse(text));
-			templateStorage.switchSession(newId);
+			const newStorage = deserializeTemplateCollection(text);
+		    setTemplateStorage(newStorage);
 		};
 		document.body.appendChild(fileInput);
 		fileInput.click();
 		document.body.removeChild(fileInput);
 	};
 
-	const exportSession = () => {
+	const exportTemplate = () => {
 		var element = document.createElement('a');
-		const sessionObj = { ...templateStorage.sessions[templateStorage.selectedSessionId] };
-		for (const [key, value] of Object.entries(sessionObj)) {
-			sessionObj[key] = JSON.stringify(value);
-		}
-		element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(JSON.stringify(sessionObj)));
-		element.setAttribute('download', `${templateStorage.getProperty('name')}.json`);
+		const serializedJson = serializeTemplateCollection(templateStorage)
+		element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(serializedJson));
+		element.setAttribute('download', `instruct templates.json`);
 		element.style.display = 'none';
 		document.body.appendChild(element);
 		element.click();
@@ -2015,8 +2011,8 @@ function Templates({ templateStorage, onSessionChange, disabled, promptArea, onI
 			</ul>
 			<div className="vbox">
 				<button disabled=${disabled} onClick=${startCreateTemplate}>Create</button>
-				<button disabled=${disabled} onClick=${importSession}>Import</button>
-				<button disabled=${disabled} onClick=${exportSession}>Export</button>
+				<button disabled=${disabled} onClick=${importTemplate}>Import</button>
+				<button disabled=${disabled} onClick=${exportTemplate}>Export</button>
 				<button disabled=${disabled} onClick=${insertTemplate}>Insert</button>
 			</div>
 		</div>`;
@@ -3113,8 +3109,8 @@ export function App({ sessionStorage, useSessionState }) {
 				<${Templates} templateStorage=${ templateStorage}
 					promptArea=${promptArea}
 					disabled=${!!cancel}
-					onSessionChange=${onSessionChange},
-					onInput=${onInput} />
+					onInput=${onInput},
+					setTemplateStorage=${setTemplateStorage} />
 			</${CollapsibleGroup}>
 			<${CollapsibleGroup} label="Parameters" expanded>
 				<${InputBox} label="Server"

--- a/mikupad.html
+++ b/mikupad.html
@@ -1765,8 +1765,8 @@ function Templates({ templateStorage, onSessionChange, disabled, promptArea, onI
 	const [newPrefix, setNewPrefix] = useState('');
 	const [newSuffix, setNewSuffix] = useState('');
 	const [newName, setNewName] = useState('');
-	const [renameSessionName, setRenameSessionName] = useState('');
-	const [isRenaming, setIsRenaming] = useState(false);
+	const [isModifying, setIsModifying] = useState(false);
+	const [modifyingTemplateId, setModifyingTemplateId] = useState(null);
 	const [isCreating, setIsCreating] = useState(false);
 
 	useEffect(() => {
@@ -1790,10 +1790,10 @@ function Templates({ templateStorage, onSessionChange, disabled, promptArea, onI
 		};
 	}, []);
 
-	const renameSession = (sessionId) => {
-		if (renameSessionName) {
-			templateStorage.renameSession(sessionId, renameSessionName);
-			setIsRenaming(false);
+	const modifyTemplate = (templateId) => {
+		if (newName && (newPrefix || newSuffix)) {
+			templateStorage.modifyTemplate(templateId, newName, newPrefix, newSuffix);
+			setIsModifying(false);
 		}
 	};
 
@@ -1808,13 +1808,27 @@ function Templates({ templateStorage, onSessionChange, disabled, promptArea, onI
 		setIsCreating(true);
 	};
 
+	const startModifyingTemplate = (templateId) => {
+		const template = templateStorage.getTemplate(templateId);
+		setNewName(template.name);
+		setNewPrefix(template.prefix);
+		setNewSuffix(template.suffix);
+		setModifyingTemplateId(templateId);
+		setIsModifying(true);
+	};
+
 	const createTemplate = () => {
-		if (newName && (newPrefix || newSuffix)) {
+		if (isCreating && newName && (newPrefix || newSuffix)) {
 			templateStorage.addTemplate(newName, newPrefix, newSuffix);
 			setIsCreating(false);
 		}
+		else if (isModifying && newName && (newPrefix || newSuffix)) {
+			templateStorage.modifyTemplate(modifyingTemplateId, newName, newPrefix, newSuffix);
+			setIsModifying(false);
+			setModifyingTemplateId(null);
+		}
 	};
-	
+
 	const importSession = () => {
 		const fileInput = document.createElement("input");
 		fileInput.type = 'file';
@@ -1854,15 +1868,19 @@ function Templates({ templateStorage, onSessionChange, disabled, promptArea, onI
 	};
 
 	function handleKeyDown(sessionId, key) {
-		if (event.key === 'Enter') {
-			if (isRenaming)
-				renameSession(sessionId);
-		} else if (event.key === 'Escape') {
+		if (event.key === 'Escape') {
 			if (isCreating)
 				setIsCreating(false);
-			else if (isRenaming)
-				setIsRenaming(false);
+			else if (isModifying)
+				setIsModifying(false);
 		}
+	}
+
+	const cancelCreationScreen = () => {
+		if (isCreating)
+			setIsCreating(false);
+		else if (isModifying)
+			setIsModifying(false);
 	}
 
 	function insertTemplate() {
@@ -1935,7 +1953,7 @@ function Templates({ templateStorage, onSessionChange, disabled, promptArea, onI
 	return html`
 		<div className="Sessions ${disabled ? 'disabled' : ''}">
 			<ul>
-				${isCreating && html`
+				${(isCreating || isModifying) && html`
 					<li key=-1}>
 						<a className="Session" style=${{ display: 'flex', flexDirection: 'column' }}>
 							<div>
@@ -1970,7 +1988,7 @@ function Templates({ templateStorage, onSessionChange, disabled, promptArea, onI
 							<div className="flex-separator"></div>
 							<div style=${{ display: 'flex', flexDirection: 'row' }}>
 								<button onClick=${(e) => (createTemplate(), e.stopImmediatePropagation?.())}>${confirmSvg}</button>
-								<button onClick=${(e) => (setIsCreating(false), e.stopImmediatePropagation?.())}>${cancelSvg}</button>
+								<button onClick=${(e) => (cancelCreationScreen(), e.stopImmediatePropagation?.())}>${cancelSvg}</button>
 							</div>
 						</a>
 					</li>
@@ -1979,23 +1997,11 @@ function Templates({ templateStorage, onSessionChange, disabled, promptArea, onI
 					<li key=${templateId}>
 						<a className="Session ${templateStorage.selectedTemplateId == templateId ? 'selected' : ''}"
 							onClick=${() => templateStorage.switchTemplate(templateId)}>
-							${isRenaming === templateId ? html`
-								<input
-									type="text"
-									value=${name}
-									onChange=${(e) => setRenameSessionName(e.target.value)}
-									onKeyDown=${(e) => handleKeyDown(templateId, e.key)}
-									onClick=${(e) => e.stopPropagation()},
-									autoFocus
-								/>
-								<div className="flex-separator"></div>
-								<button onClick=${(e) => (renameSession(templateId), e.stopImmediatePropagation())}>${confirmSvg}</button>
-								<button onClick=${(e) => (setIsRenaming(false), e.stopImmediatePropagation())}>${cancelSvg}</button>
-							` : html`
+							${html`
 								${name}
 								<div className="flex-separator"></div>
 								<button
-									onClick=${(e) => (startRenameSession(templateId, name), e.stopPropagation())}>
+									onClick=${(e) => (startModifyingTemplate(templateId), e.stopPropagation())}>
 									${renameSvg}
 								</button>
 								<button
@@ -2069,12 +2075,25 @@ class TemplateCollection {
 		return this.templates.get(this.selectedTemplateId) || null;
 	}
 
+	getTemplate(templateId) {
+		return this.templates.get(templateId) || null;
+	}
+
 	setChangeListener(changeListener) {
 		this.changeListener = changeListener;
 	}
 
 	removeChangeListener(listener) {
 		this.changeListener = null;
+	}
+
+	modifyTemplate(modifyingTemplateId, newName, newPrefix, newSuffix) {
+		const template = this.getTemplate(modifyingTemplateId);
+		template.name = newName;
+		template.prefix = newPrefix;
+		template.suffix = newSuffix;
+		this.onchange?.();
+		this.notifyChange();
 	}
 }
 
@@ -2217,29 +2236,33 @@ function deserializeTemplateCollection(serialized) {
 }
 
 function usePersistentTemplateCollection(name, initialState) {
-	const handleChangeRef = useRef(null);
-	handleChangeRef.current = (newState) => {
-		setTemplateStorage(newState);
-		localStorage.setItem(name, serializeTemplateCollection(newState));
-	};
+	const handleChangeRef = useRef(() => {});
+
 	const [templateStorage, setTemplateStorage] = useState(() => {
 		const init = () => {
-		try {
-			const item = localStorage.getItem(name);
-			return item ? deserializeTemplateCollection(item, handleChangeRef.current) : new TemplateCollection(handleChangeRef.current);
-		} catch (e) {
-			console.error(e);
-			return new TemplateCollection(handleChangeRef.current);
-		}
+			try {
+				const item = localStorage.getItem(name);
+				return item ? deserializeTemplateCollection(item) : new TemplateCollection();
+			} catch (e) {
+				console.error(e);
+				return new TemplateCollection();
+			}
 		};
 		return init();
 	});
 
+	handleChangeRef.current = (newState) => {
+		setTemplateStorage(newState);
+		localStorage.setItem(name, serializeTemplateCollection(newState));
+	};
+
 	useEffect(() => {
-		templateStorage.setChangeListener(handleChangeRef.current);
-		return () => {
-		templateStorage.removeChangeListener(handleChangeRef.current);
-		};
+		if (templateStorage.setChangeListener && templateStorage.removeChangeListener) {
+			templateStorage.setChangeListener(handleChangeRef.current);
+			return () => {
+				templateStorage.removeChangeListener(handleChangeRef.current);
+			};
+		}
 	}, [templateStorage]);
 
 	return [templateStorage, setTemplateStorage];

--- a/mikupad.html
+++ b/mikupad.html
@@ -2012,10 +2012,10 @@ function Templates({ templateStorage, disabled, promptArea, onInput, setTemplate
 				`)}
 			</ul>
 			<div className="vbox">
-				<button disabled=${disabled} onClick=${startCreateTemplate}>Create</button>
-				<button disabled=${disabled} onClick=${importTemplate}>Import</button>
-				<button disabled=${disabled} onClick=${exportTemplate}>Export</button>
-				<button disabled=${disabled} onClick=${insertTemplate}>Insert</button>
+				<button disabled=${disabled} title="Add a new template" onClick=${startCreateTemplate}>Create</button>
+				<button disabled=${disabled} title="Import templates from a JSON file" onClick=${importTemplate}>Import</button>
+				<button disabled=${disabled} title="Export all your templates to a JSON file" onClick=${exportTemplate}>Export</button>
+				<button disabled=${disabled} title="Insert the template at the cursor position (Ctrl + Insert)" onClick=${insertTemplate}>Insert</button>
 			</div>
 		</div>`;
 }
@@ -2858,6 +2858,7 @@ export function App({ sessionStorage, useSessionState }) {
 			case 'false:false:true:y':
 				if (cancel || !redo()) return;
 				break;
+				
 			default:
 				keyState.current = e;
 				return;

--- a/mikupad.html
+++ b/mikupad.html
@@ -1704,7 +1704,7 @@ function Templates({ templateStorage, onSessionChange, disabled, promptArea, onI
 				event.preventDefault();
 				insertTemplate();
 			}
-    	};
+		};
 
 		document.addEventListener('keydown', onKeyDown);
 		return () => {
@@ -1821,10 +1821,10 @@ function Templates({ templateStorage, onSessionChange, disabled, promptArea, onI
 				}
 			}
 			return count;
-    	};
+		};
 
 		const existingLineBreaks = countLineBreaks(textBefore);
-    	let lineBreakBeforePrefix = '';
+		let lineBreakBeforePrefix = '';
 		if (textBefore.length > 0) {
 			if (existingLineBreaks < 2) {
 				lineBreakBeforePrefix = '\n'.repeat(2 - existingLineBreaks);
@@ -1851,7 +1851,7 @@ function Templates({ templateStorage, onSessionChange, disabled, promptArea, onI
 							+ lineBreakBeforePrefix.length + prefix.length + lineBreakAfterPrefix.length 
 							+ selectedText.length 
 							+ lineBreakBeforeSuffix.length + suffix.length + lineBreakAfterSuffix.length;
-    	}
+		}
 		elem.setSelectionRange(newCursorPos, newCursorPos);
 		onInput({ target: elem });
 	}
@@ -1946,7 +1946,7 @@ class TemplateCollection {
 		if (this.templates.size === 0)
 		{
 			this.addTemplate('Mixtral', '[INT]', '[/INT]');
-			this.addTemplate('Alpaca', '### instruct:\n', '### response:\n');
+			this.addTemplate('Alpaca', '### Instruction:\n', '### Response:\n');
 		}
 	}
 

--- a/mikupad.html
+++ b/mikupad.html
@@ -1689,7 +1689,7 @@ class SessionStorage {
 }
 
 
-function Templates({ templateStorage, onSessionChange, disabled }) {
+function Templates({ templateStorage, onSessionChange, disabled, promptArea, onInput }) {
 	
 	const [version, setVersion] = useState(0);
 	const [newPrefix, setNewPrefix] = useState('');
@@ -1698,6 +1698,19 @@ function Templates({ templateStorage, onSessionChange, disabled }) {
 	const [isRenaming, setIsRenaming] = useState(false);
 	const [isCreating, setIsCreating] = useState(false);
 
+	useEffect(() => {
+    	const onKeyDown = (event) => {
+			if (event.ctrlKey && event.key === 'Insert') {
+				event.preventDefault();
+				insertTemplate();
+			}
+    	};
+
+		document.addEventListener('keydown', onKeyDown);
+		return () => {
+			document.removeEventListener('keydown', onKeyDown);
+		};
+	});
 
 	useEffect(() => {
 		templateStorage.onchange = () => setVersion(v => v + 1);
@@ -1728,10 +1741,6 @@ function Templates({ templateStorage, onSessionChange, disabled }) {
 			templateStorage.templates.addTemplate(newPrefix, newSuffix);
 		}
 	};
-
-	templateStorage.clear();
-	templateStorage.addTemplate('Mixtral', '[INST]', '[/INST]');
-	templateStorage.addTemplate('Alpaca', '### Instruction:', '### Response:');
 	
 	const importSession = () => {
 		const fileInput = document.createElement("input");
@@ -1786,6 +1795,43 @@ function Templates({ templateStorage, onSessionChange, disabled }) {
 		}
 	}
 
+	function insertTemplate() {
+		const currentTemplate = templateStorage.getCurrentTemplate();
+		if (!currentTemplate) return;
+
+		const elem = promptArea.current;
+		if (!elem) return;
+
+		const startPos = elem.selectionStart;
+		const endPos = elem.selectionEnd;
+		const textBefore = elem.value.substring(0, startPos) || '';
+		const textAfter = elem.value.substring(endPos);
+		const selectedText = elem.value.substring(startPos, endPos);
+
+		const prefix = currentTemplate.prefix || '';
+		const suffix = currentTemplate.suffix || '';
+
+		const lineBreakBeforePrefix = textBefore ? '\n\n' : '';
+		const lineBreakAfterPrefix = '\n';
+		const lineBreakBeforeSuffix = '\n\n';
+		const lineBreakAfterSuffix = '\n';
+
+		const finalText = textBefore 
+						+ lineBreakBeforePrefix + prefix + lineBreakAfterPrefix
+						+ selectedText 
+						+ lineBreakBeforeSuffix + suffix + lineBreakAfterSuffix
+						+ textAfter;
+
+		elem.value = finalText;
+
+		const newCursorPos = startPos 
+							+ lineBreakBeforePrefix.length + prefix.length + lineBreakAfterPrefix.length 
+							+ selectedText.length 
+							+ lineBreakBeforeSuffix.length + suffix.length + lineBreakAfterSuffix.length;
+		elem.setSelectionRange(newCursorPos, newCursorPos);
+		onInput({ target: elem });
+	}
+
 	const trashSvg = html`<svg fill="var(--color-light)" width="16" height="16" viewBox="0 0 490.646 490.646"><path d="m399.179 67.285-74.794.033L324.356 0 166.214.066l.029 67.318-74.802.033.025 62.914h307.739l-.026-63.046zM198.28 32.11l94.03-.041.017 35.262-94.03.041-.017-35.262zM91.465 490.646h307.739V146.359H91.465v344.287zm225.996-297.274h16.028v250.259h-16.028V193.372zm-80.14 0h16.028v250.259h-16.028V193.372zm-80.141 0h16.028v250.259H157.18V193.372z"/></svg>`;
 	const renameSvg = html`<svg fill="var(--color-light)" width="16" height="16" viewBox="0 0 512 448"><path style=${{ fillOpacity: 1, stroke: 'none', strokeWidth: 30, strokeLinecap: 'round', strokeMiterlimit: 4, strokeDasharray: 'none', strokeOpacity: 1 }} d="M0 96v256h320v-32H32V128h288V96H0zM416 96v32h64v192h-64v32h96V96h-96z" /><path style=${{ fillOpacity: 1, stroke: 'none', strokeWidth: 30, strokeLinecap: 'round', strokeMiterlimit: 4, strokeDasharray: 'none', strokeOpacity: 1 }} d="M352 636.362h32v384h-32z" transform="matrix(1, 0, 0, 1, 0, -604.3619995117188)" /><path style=${{ fillOpacity: 1, stroke: 'none', strokeWidth: 30, strokeLinecap: 'round', strokeMiterlimit: 4, strokeDasharray: 'none', strokeOpacity: 1 }} transform="matrix(0, 1, -1, 0, 0, -604.3619995117188)" d="M1020.362-448h32v64h-32zM1020.362-352h32v64h-32zM604.362-448h32v64h-32zM604.362-352h32v64h-32zM764.362-288h128v224h-128z" /></svg>`;
 
@@ -1835,7 +1881,7 @@ function Templates({ templateStorage, onSessionChange, disabled }) {
 									value=${name}
 									onChange=${(e) => setRenameSessionName(e.target.value)}
 									onKeyDown=${(e) => handleKeyDown(templateId, e.key)}
-									onClick=${(e) => e.stopPropagation()}
+									onClick=${(e) => e.stopPropagation()},
 									autoFocus
 								/>
 								<div className="flex-separator"></div>
@@ -1861,6 +1907,7 @@ function Templates({ templateStorage, onSessionChange, disabled }) {
 				<button disabled=${disabled} onClick=${startCreateTemplate}>Create</button>
 				<button disabled=${disabled} onClick=${importSession}>Import</button>
 				<button disabled=${disabled} onClick=${exportSession}>Export</button>
+				<button disabled=${disabled} onClick=${insertTemplate}>Insert</button>
 			</div>
 		</div>`;
 }
@@ -1872,6 +1919,11 @@ class TemplateCollection {
 		this.nextId = 1;
 		this.selectedTemplateId = 1;
 		this.onchange = null;
+		if (this.templates.size === 0)
+		{
+			this.addTemplate('Mixtral', '[INT]', '[/INT]');
+			this.addTemplate('Alpaca', '### instruct:\n', '### response:\n');
+		}
 	}
 
 	addTemplate(name, prefix, suffix) {
@@ -1893,8 +1945,11 @@ class TemplateCollection {
 		this.selectedTemplateId = id;
 		this.onchange?.();
 	}
-}
 
+	getCurrentTemplate() {
+		return this.templates.get(this.selectedTemplateId) || null;
+	}
+}
 
 
 const defaultPrompt = `[INST] <<SYS>>
@@ -2611,7 +2666,6 @@ export function App() {
 			case 'false:false:true:y':
 				if (cancel || !redo()) return;
 				break;
-
 			default:
 				keyState.current = e;
 				return;
@@ -2863,8 +2917,10 @@ export function App() {
 			</${CollapsibleGroup}>					
 			<${CollapsibleGroup} label="Instruct Templates">
 				<${Templates} templateStorage=${ templateStorage}
+					promptArea=${promptArea}
 					disabled=${!!cancel}
-					onSessionChange=${onSessionChange} />
+					onSessionChange=${onSessionChange},
+					onInput=${onInput} />
 			</${CollapsibleGroup}>
 			<${CollapsibleGroup} label="Parameters" expanded>
 				<${InputBox} label="Server"

--- a/mikupad.html
+++ b/mikupad.html
@@ -1651,6 +1651,172 @@ class SessionStorage {
 	}
 }
 
+
+function Templates({ templateStorage, onSessionChange, disabled }) {
+	
+	const [version, setVersion] = useState(0);
+	const [newInstruct, setNewInstruct] = useState('');
+	const [newResponse, setNewResponse] = useState('');
+	const [renameSessionName, setRenameSessionName] = useState('');
+	const [isRenaming, setIsRenaming] = useState(false);
+	const [isCreating, setIsCreating] = useState(false);
+
+	const renameSession = (sessionId) => {
+		if (renameSessionName) {
+			templateStorage.renameSession(sessionId, renameSessionName);
+			setIsRenaming(false);
+		}
+	};
+
+	const deleteSession = (sessionId) => {
+		templateStorage.deleteSession(sessionId);
+	};
+
+	const startCreateTemplate = () => {
+		setNewInstruct('');
+		setNewResponse('');
+		setIsCreating(true);
+	};
+
+	const createTemplate = () => {
+		if (newInstruct || newResponse) {
+			// TODO: add element to templates array with the values, preserve in storage
+		}
+	};
+
+	const importSession = () => {
+		const fileInput = document.createElement("input");
+		fileInput.type = 'file';
+		fileInput.style.display = 'none';
+		fileInput.onchange = (e) => {
+			const file = e.target.files[0];
+			if (!file)
+				return;
+			const reader = new FileReader();
+			reader.onload = (e) => {
+				const contents = e.target.result;
+				fileInput.func(contents);
+			}
+			reader.readAsText(file);
+		};
+		fileInput.func = (text) => {
+			const newId = templateStorage.createSessionFromObject(JSON.parse(text));
+			templateStorage.switchSession(newId);
+		};
+		document.body.appendChild(fileInput);
+		fileInput.click();
+		document.body.removeChild(fileInput);
+	};
+
+	const exportSession = () => {
+		var element = document.createElement('a');
+		const sessionObj = { ...templateStorage.sessions[templateStorage.selectedSession] };
+		for (const [key, value] of Object.entries(sessionObj)) {
+			// This is done for compatibility with localStorage export files.
+			sessionObj[key] = JSON.stringify(value);
+		}
+		element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(JSON.stringify(sessionObj)));
+		element.setAttribute('download', `${templateStorage.getProperty('name')}.json`);
+		element.style.display = 'none';
+		document.body.appendChild(element);
+		element.click();
+		document.body.removeChild(element);
+	};
+
+	function handleKeyDown(sessionId, key) {
+		if (event.key === 'Enter') {
+			if (isCreating)
+				createTemplate();
+			else if (isRenaming)
+				renameSession(sessionId);
+		} else if (event.key === 'Escape') {
+			if (isCreating)
+				setIsCreating(false);
+			else if (isRenaming)
+				setIsRenaming(false);
+		}
+	}
+
+	const trashSvg = html`<svg fill="var(--color-light)" width="16" height="16" viewBox="0 0 490.646 490.646"><path d="m399.179 67.285-74.794.033L324.356 0 166.214.066l.029 67.318-74.802.033.025 62.914h307.739l-.026-63.046zM198.28 32.11l94.03-.041.017 35.262-94.03.041-.017-35.262zM91.465 490.646h307.739V146.359H91.465v344.287zm225.996-297.274h16.028v250.259h-16.028V193.372zm-80.14 0h16.028v250.259h-16.028V193.372zm-80.141 0h16.028v250.259H157.18V193.372z"/></svg>`;
+	const renameSvg = html`<svg fill="var(--color-light)" width="16" height="16" viewBox="0 0 512 448"><path style=${{ fillOpacity: 1, stroke: 'none', strokeWidth: 30, strokeLinecap: 'round', strokeMiterlimit: 4, strokeDasharray: 'none', strokeOpacity: 1 }} d="M0 96v256h320v-32H32V128h288V96H0zM416 96v32h64v192h-64v32h96V96h-96z" /><path style=${{ fillOpacity: 1, stroke: 'none', strokeWidth: 30, strokeLinecap: 'round', strokeMiterlimit: 4, strokeDasharray: 'none', strokeOpacity: 1 }} d="M352 636.362h32v384h-32z" transform="matrix(1, 0, 0, 1, 0, -604.3619995117188)" /><path style=${{ fillOpacity: 1, stroke: 'none', strokeWidth: 30, strokeLinecap: 'round', strokeMiterlimit: 4, strokeDasharray: 'none', strokeOpacity: 1 }} transform="matrix(0, 1, -1, 0, 0, -604.3619995117188)" d="M1020.362-448h32v64h-32zM1020.362-352h32v64h-32zM604.362-448h32v64h-32zM604.362-352h32v64h-32zM764.362-288h128v224h-128z" /></svg>`;
+
+	const confirmSvg = html`<svg width="16" height="16" viewBox="0 0 128 128"><circle cx="64" cy="64" r="64" fill="var(--color-dark)"/><path d="M54.3 97.2 24.8 67.7c-.4-.4-.4-1 0-1.4l8.5-8.5c.4-.4 1-.4 1.4 0L55 78.1l38.2-38.2c.4-.4 1-.4 1.4 0l8.5 8.5c.4.4.4 1 0 1.4L55.7 97.2c-.4.4-1 .4-1.4 0z" fill="var(--color-light)"/></svg>`;
+	const cancelSvg = html`<svg width="16" height="16" viewBox="0 0 128 128"><circle cx="64" cy="64" r="64" fill="var(--color-dark)"/><path d="M100.3 90.4 73.9 64l26.3-26.4c.4-.4.4-1 0-1.4l-8.5-8.5c-.4-.4-1-.4-1.4 0L64 54.1 37.7 27.8c-.4-.4-1-.4-1.4 0l-8.5 8.5c-.4.4-.4 1 0 1.4L54 64 27.7 90.3c-.4.4-.4 1 0 1.4l8.5 8.5c.4.4 1.1.4 1.4 0L64 73.9l26.3 26.3c.4.4 1.1.4 1.5.1l8.5-8.5c.4-.4.4-1 0-1.4z" fill="var(--color-light)"/></svg>`;
+
+	return html`
+		<div className="Sessions ${disabled ? 'disabled' : ''}">
+			<ul>
+				${isCreating && html`
+					<li key=-1>
+						<a className="Session">
+							<div>
+								<label>Instruct:</label>
+								<input
+									type="text"
+									value=${newInstruct}
+									onChange=${(e) => setNewInstruct(e.target.value)}
+									onKeyDown=${(e) => handleKeyDown(undefined, e.key)}
+									onClick=${(e) => e.stopPropagation()}
+									autoFocus
+								/>
+							</div>
+							<div>
+								<label>Response:</label>
+								<input
+									type="text"
+									value=${newResponse}
+									onChange=${(e) => setNewResponse(e.target.value)}
+									onKeyDown=${(e) => handleKeyDown(undefined, e.key)}
+									onClick=${(e) => e.stopPropagation()}
+								/>
+							</div>
+							<div className="flex-separator"></div>
+							<button onClick=${(e) => (createTemplate(), e.stopImmediatePropagation?.())}>${confirmSvg}</button>
+							<button onClick=${(e) => (setIsCreating(false), e.stopImmediatePropagation?.())}>${cancelSvg}</button>
+						</a>
+					</li>
+				`}
+				${templateStorage.templates.reverse().map(([instruction, response]) => html`
+					<li key=${sessionId}>
+						<a className="Session ${templateStorage.selectedSession == sessionId ? 'selected' : ''}"
+							onClick=${() => switchSession(sessionId)}>
+							${isRenaming === sessionId ? html`
+								<input
+									type="text"
+									value=${renameSessionName}
+									onChange=${(e) => setRenameSessionName(e.target.value)}
+									onKeyDown=${(e) => handleKeyDown(sessionId, e.key)}
+									onClick=${(e) => e.stopPropagation()}
+									autoFocus
+								/>
+								<div className="flex-separator"></div>
+								<button onClick=${(e) => (renameSession(sessionId), e.stopImmediatePropagation())}>${confirmSvg}</button>
+								<button onClick=${(e) => (setIsRenaming(false), e.stopImmediatePropagation())}>${cancelSvg}</button>
+							` : html`
+								${session.name}
+								<div className="flex-separator"></div>
+								<button
+									onClick=${(e) => (startRenameSession(sessionId, session.name), e.stopPropagation())}>
+									${renameSvg}
+								</button>
+								<button
+									onClick=${(e) => (deleteSession(sessionId), e.stopPropagation())}>
+									${trashSvg}
+								</button>
+							`}
+						</a>
+					</li>
+				`)}
+			</ul>
+			<div className="vbox">
+				<button disabled=${disabled} onClick=${startCreateTemplate}>Create</button>
+				<button disabled=${disabled} onClick=${importSession}>Import</button>
+				<button disabled=${disabled} onClick=${exportSession}>Export</button>
+			</div>
+		</div>`;
+}
+
+
 const defaultPrompt = `[INST] <<SYS>>
 You are a talented writing assistant. Always respond by incorporating the instructions into expertly written prose that is highly detailed, evocative, vivid and engaging.
 <</SYS>>
@@ -2601,6 +2767,11 @@ export function App() {
 				<${Sessions} sessionStorage=${sessionStorage}
 					disabled=${!!cancel}
 					onSessionChange=${onSessionChange}/>
+			</${CollapsibleGroup}>					
+			<${CollapsibleGroup} label="Instruct Templates">
+				<${Templates} templateStorage=${{ templates : []}}
+					disabled=${!!cancel}
+					onSessionChange=${onSessionChange} />
 			</${CollapsibleGroup}>
 			<${CollapsibleGroup} label="Parameters" expanded>
 				<${InputBox} label="Server"

--- a/mikupad.html
+++ b/mikupad.html
@@ -852,7 +852,7 @@ html.monospace-dark .horz-separator {
 </style>
 <script type="module">
 
-import { useEffect, useLayoutEffect, useMemo, useRef, useState, useCallback } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { html } from 'htm/react';
 import { SVResizeObserver } from 'scrollview-resize';


### PR DESCRIPTION
Personally, I mix a pure "notebook" mode with prompt templates, which helps with finetuned models such as Mixtral - even for pure instruction (not complete) mode, I find an interface like Mikupad to be much better than a typical chat UI, as it allows me to edit and steer the replies of the AI very easily.

A chat-instruction finetune still works on continuous text. The AI doesn't see a conversation, just text with a special format - in other words, LLMs are actually always in complete mode! What changes is the illusion of it being a chat. So by having prompts (a prefix before the user prompt and a suffix after it that marks the start of the AI's turn) we can avoid typing all the instruct tags if we want to use them (some like ChatLM are quite hard to remember and type).

The interface is based on the sessions, with the addition of the "Insert" button (Control + Insert) that will insert the currently selected template into the text:

![image](https://github.com/lmg-anon/mikupad/assets/136095681/f680ac6a-2920-4eab-8a41-b8f5ac35221d)

Creating a template needs a name, and a suffix or a prefix (one can be missing, since I suppose there are templates like that). It allows line breaks, since in fact many templates need them:

![image](https://github.com/lmg-anon/mikupad/assets/136095681/6f5720cf-911c-4d41-bccc-f7746f09a30d)

Then, when the user inserts the template, it will be inserted around the current selection:

1. If no selection is there, it will insert the template at the cursor position and then position the cursor inside the template so the user can start writing right away
2. If there is a selection, it will prepend the prefix before the selection and append the suffix after the selection, basically turning something into an instruction.

![image](https://github.com/lmg-anon/mikupad/assets/136095681/da5c1262-4508-467f-ba60-2ca68ea4384e)

![image](https://github.com/lmg-anon/mikupad/assets/136095681/dda60907-c22b-4f15-9c5c-3fa72135b7bd)

I have supported exporting and importing JSON files, and the templates themselves are stored in the local storage, and are not part of the sessions. I have included by default the ones I use the most: alpaca, mixtral and ChatLM, but the idea is the user can create any. There is no support for system prompt templates as some, like ChatLM, have, since it's not clear where the user would include them, and personally I'd put them in the memory.


Other areas of future improvement are:

1. Having an option to auto insert as a stopping string the start of the user's turn (prefix) - oftentimes the AI may start writing your own turn
2. An option to clean up instructions, so it would delete from the text area everything that is inside prompts, plus the prompt itself - at least this is something I miss from NovelAI, where my text becomes full of left-over prompts