### PR TITLE
Export to plaintext

### DIFF
--- a/mikupad.html
+++ b/mikupad.html
@@ -2018,6 +2018,18 @@ export function App({ sessionStorage, useSessionState }) {
 		}));
 	};
 
+	const exportPadText = () => {
+		const textBlob = new Blob([promptArea.current.value], {type: 'text/plain;charset=utf-8'});
+		const textURL = URL.createObjectURL(textBlob);
+		var element = document.createElement('a');
+		element.setAttribute('href', textURL);
+		element.setAttribute('download', `${sessionStorage.getProperty('name') || 'default'}.txt`);
+		document.body.appendChild(element);
+		element.click();
+		URL.revokeObjectURL(textURL);
+		document.body.removeChild(element);
+	};
+
 	const promptText = useMemo(() => joinPrompt(promptChunks), [promptChunks]);
 
 	// compute separately as I imagine this can get expensive
@@ -2953,6 +2965,9 @@ export function App({ sessionStorage, useSessionState }) {
 						{ name: 'Show on hover while holding CTRL', value: 1 },
 						{ name: 'Don\'t show', value: -1 },
 					]}/>
+				<div style=${{ display: 'flex', justifyContent: 'flex-start' }}>
+					<button onClick=${exportPadText}>Export prompt to plaintext</button>
+				</div>
 			</div>
 		</${Modal}>
 


### PR DESCRIPTION
Added a button in the settings modal dialog to allow to export the current text of the prompt area:

![image](https://github.com/lmg-anon/mikupad/assets/136095681/217e68d1-dc29-4733-891e-cde56859e5f5)

The name of the file is the name of the current session in .txt format. Nothing else is exported, only the text that has been co-written with the AI:

![image](https://github.com/lmg-anon/mikupad/assets/136095681/b652c469-f8af-47cb-86f9-68e0b86097c4)

![image](https://github.com/lmg-anon/mikupad/assets/136095681/7c48f405-45bb-49b1-ac13-f55319786826)

I've used a blob after checking out with chatGPT because the text could be potentially very long. To be honest, I don't know if we'd run into other issues first as the text grew larger. I know that for example NovelAI doesn't load all the text necessarily.
