### PR TITLE
Show session name in window title

### DIFF
--- a/mikupad.html
+++ b/mikupad.html
@@ -2274,6 +2274,15 @@ export function App({ sessionStorage, useSessionState }) {
 		}
 	}
 
+	function setTitleToSession() {
+		const sessionName = sessionStorage.getProperty('name');
+		document.title = sessionName ? 'mikupad - ' + sessionName : 'mikupad';
+	}
+
+	useEffect(() => {
+		setTitleToSession();
+	}, [sessionStorage]);
+
 	useEffect(() => {
 		if (triggerPredict) {
 			predict();
@@ -2649,6 +2658,7 @@ export function App({ sessionStorage, useSessionState }) {
 		redoStack.current = [];
 		undoStack.current = [];
 		setUndoHovered(false);
+		setTitleToSession();
 	}
 
 	const probs = useMemo(() =>


### PR DESCRIPTION
Sessions are similar to stories in NovelAI. For example, I keep in one of the sessions lorebook information about a novel I'm writing. However, sometimes it's hard to tell which session I am on, and it can lead to overwriting information.

I think that adding the session name after the title can be very helpful:

![image](https://github.com/lmg-anon/mikupad/assets/136095681/e56c9e1a-e4bc-4ff5-a592-308fc3a9288a)

![image](https://github.com/lmg-anon/mikupad/assets/136095681/80bf8bf1-a303-4334-abd7-1d7d1dfc07b2)

Personally I'd put the session name first and mikupad after that (this is what NovelAI does) but for now I append it after it.