### PR TITLE
Add support for a basic session server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+server/web-session-storage.db
 package-lock.json
 project/mikupad.html
 mikupad_compiled.html

--- a/mikupad.html
+++ b/mikupad.html
@@ -1776,14 +1776,15 @@ class SessionStorage {
 }
 
 class WebSessionStorage extends SessionStorage {
-	constructor(defaultPresets) {
+	constructor(defaultPresets, sessionEndpoint) {
 		super(defaultPresets);
+		this.sessionEndpoint = sessionEndpoint;
 	}
 
 	async openDatabase() {
 		return async (route, options) => {
 			try {
-				return await fetch(new URL(route, "http://127.0.0.1:3000/"), {
+				return await fetch(new URL(route, this.sessionEndpoint), {
 					method: 'POST',
 					headers: {
 						'Content-Type': 'application/json',
@@ -1794,7 +1795,7 @@ class WebSessionStorage extends SessionStorage {
 				});
 			} catch (e) {
 				reportError(e);
-				return { ok: false, status: -1 };
+				return { ok: false, status: e.toString() };
 			}
 		};
 	}
@@ -2801,7 +2802,7 @@ export function App({ sessionStorageRef }) {
 			const cancelThis = () => ac.abort();
 			setCancel(() => cancelThis);
 
-			const sessionStorage = new WebSessionStorage(defaultPresets);
+			const sessionStorage = new WebSessionStorage(defaultPresets, sessionEndpoint);
 			sessionStorage.dependents = sessionStorageRef.sessionStorage.dependents;
 			sessionStorage.onchange = sessionStorageRef.sessionStorage.onchange;
 			sessionStorage.onsessionchange = sessionStorageRef.sessionStorage.onsessionchange;

--- a/mikupad.html
+++ b/mikupad.html
@@ -2397,7 +2397,7 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 			// restart right away (???)
 			let cancelled = false;
 			setCancel(() => () => cancelled = true);
-			await new Promise(resolve => setTimeout(resolve, 1000));
+			await new Promise(resolve => setTimeout(resolve, 500));
 			if (cancelled)
 				return;
 		}

--- a/mikupad.html
+++ b/mikupad.html
@@ -1807,7 +1807,7 @@ class WebSessionStorage extends SessionStorage {
 				if (res.status == 404) {
 					resolve(undefined);
 				} else {
-					reject();
+					reject(res.status);
 				}
 				return;
 			}
@@ -1821,7 +1821,7 @@ class WebSessionStorage extends SessionStorage {
 		return new Promise(async (resolve, reject) => {
 			const res = await db("/save", { data, key });
 			if (!res.ok) {
-				reject();
+				reject(res.status);
 				return;
 			}
 			const { result } = await res.json();
@@ -1833,7 +1833,7 @@ class WebSessionStorage extends SessionStorage {
 		return new Promise(async (resolve, reject) => {
 			const res = await db("/sessions");
 			if (!res.ok) {
-				reject();
+				reject(res.status);
 				return;
 			}
 			const { result } = await res.json();
@@ -1865,7 +1865,7 @@ class WebSessionStorage extends SessionStorage {
 		return new Promise(async (resolve, reject) => {
 			const res = await db("/delete", { sessionId });
 			if (!res.ok) {
-				reject();
+				reject(res.status);
 				return;
 			}
 			
@@ -2020,6 +2020,7 @@ export function App({ sessionStorageRef }) {
 	const [sessionEndpoint, setSessionEndpoint] = usePersistentState('sessionEndpoint', '');
 	const [sessionEndpointConnecting, setSessionEndpointConnecting] = useState(false);
 	const [sessionEndpointConnected, setSessionEndpointConnected] = useState(false);
+	const [sessionEndpointError, setSessionEndpointError] = useState(undefined);
 	const [endpoint, setEndpoint] = useSessionState('endpoint', defaultPresets.endpoint);
 	const [endpointAPI, setEndpointAPI] = useSessionState('endpointAPI', defaultPresets.endpointAPI);
 	const [endpointAPIKey, setEndpointAPIKey] = useSessionState('endpointAPIKey', defaultPresets.endpointAPIKey);
@@ -2795,6 +2796,8 @@ export function App({ sessionStorageRef }) {
 	}
 
 	async function toggleSessionServer() {
+		setSessionEndpointError(undefined);
+		
 		if (!sessionEndpointConnected) {
 			setSessionEndpointConnecting(true);
 
@@ -2809,6 +2812,7 @@ export function App({ sessionStorageRef }) {
 			try {
 				await sessionStorage.init();
 			} catch (e) {
+				setSessionEndpointError(e);
 				setCancel(null);
 				setSessionEndpointConnecting(false);
 				return;
@@ -2901,8 +2905,9 @@ export function App({ sessionStorageRef }) {
 			<div class="horz-separator"/>
 			<${CollapsibleGroup} label="Sessions">
 				<${InputBox} label="Session Server"
-					className="${isMixedContent() ? 'mixed-content' : ''}"
-					tooltip="${isMixedContent() ? 'This URL might be blocked due to mixed content. If the connection fails, download mikupad.html and run it locally.' : ''}"
+					className="${sessionEndpointError ? 'rejected' : (isMixedContent() ? 'mixed-content' : '')}"
+					tooltip="${sessionEndpointError ? sessionEndpointError : (isMixedContent() ? 'This URL might be blocked due to mixed content. If the connection fails, download mikupad.html and run it locally.' : '')}"
+					tooltipSize="short"
 					readOnly=${!!cancel}
 					value=${sessionEndpoint}
 					onValueChange=${setSessionEndpoint}>

--- a/mikupad.html
+++ b/mikupad.html
@@ -503,12 +503,22 @@ html.nockoffAI #sidebar {
 	color: var(--color-base-50);
 }
 
+.flex1 {
+	flex: 1;
+}
+
 .hbox {
 	flex: none;
 	display: grid;
 	grid: auto / auto-flow minmax(min-content, 1fr);
 	gap: 8px;
 }
+.hbox-flex {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+}
+
 .vbox {
 	flex: none;
 	display: grid;
@@ -524,7 +534,7 @@ html.nockoffAI #sidebar {
 	font-size: 0.75rem;
 	padding: 0 8px;
 }
-.InputBox > input, .SelectBox > select, .TextArea > textarea {
+.InputBox > div > input, .SelectBox > select, .TextArea > textarea {
 	appearance: none;
 	border: none;
 	outline: none;
@@ -537,33 +547,32 @@ html.nockoffAI #sidebar {
 	border-radius: 2px;
 	color: inherit;
 	background: var(--color-base-30);
-	flex: none;
 }
 
-html.monospace-dark .InputBox > input, html.monospace-dark .SelectBox > select,
-html.nockoffAI .InputBox > input, html.nockoffAI .SelectBox > select {
+html.monospace-dark .InputBox > div > input, html.monospace-dark .SelectBox > select,
+html.nockoffAI .InputBox > div > input, html.nockoffAI .SelectBox > select {
 	color: var(--color-light);
 }
 
-.InputBox > input:read-only {
+.InputBox > div > input:read-only {
 	background: var(--color-base-60);
 }
-html.monospace-dark .InputBox > input:read-only {
+html.monospace-dark .InputBox > div > input:read-only {
 	background: var(--color-base-30);
 }
-html.nockoffAI .InputBox > input:read-only {
+html.nockoffAI .InputBox > div > input:read-only {
 	background: var(--color-disabled);
 }
 html.nockoffAI .SelectBox > select,
 html.nockoffAI .collapsible-header,
-html.nockoffAI .InputBox > input {
+html.nockoffAI .InputBox > div > input {
 	background: var(--color-input);
 }
 html.nockoffAI .horz-separator {
 	border-top: 3px dotted color-mix(in oklch, var(--color-base-100) 90%, var(--color-light));
 }
 
-.InputBox > input:focus-visible {
+.InputBox > div > input:focus-visible {
 	outline: 1px solid var(--color-base-0);
 }
 .SelectBox > select:disabled {
@@ -581,11 +590,18 @@ html.nockoffAI .SelectBox > select:disabled {
   	bottom: .08em;
 }
 
-.InputBox > input.mixed-content {
+.InputBox > div > input.mixed-content {
 	outline: 1px solid yellow;
 }
-.InputBox > input.rejected {
+.InputBox > div > input.rejected {
 	outline: 1px solid #ff3131;
+}
+
+.InputBox > div > button {
+	margin-left: 4px;
+	padding: 4px;
+	line-height: 0;
+	margin-right: -8px;
 }
 
 .tooltip {
@@ -1199,27 +1215,31 @@ async function openaiOobaAbortCompletion({ endpoint }) {
 	}
 }
 
-function InputBox({ label, tooltip, tooltipSize, value, type, datalist, onValueChange, ...props }) {
+function InputBox({ label, className, tooltip, tooltipSize, value, type, datalist, onValueChange, children, ...props }) {
 	return html`
 		<label className="InputBox ${tooltip ? 'tooltip' : ''}">
 			${label}
-			<input
-				type=${type || 'text'}
-				list="${datalist ? label : ''}"
-				value=${value}
-				size="1"
-				onChange=${({ target }) => {
-					let value = type === 'number' ? target.valueAsNumber : target.value;
-					if (props.inputmode === 'numeric') {
-						props.pattern = '^-?[0-9]*$';
-						if (value && !isNaN(+value))
-							value = +target.value;
-					}
-					if (props.pattern && !new RegExp(props.pattern).test(value))
-						return;
-					onValueChange(value);
-				}}
-				...${props}/>
+			<div className="${children ? 'hbox-flex' : ''}">
+				<input
+					className="flex1 ${className}"
+					type=${type || 'text'}
+					list="${datalist ? label : ''}"
+					value=${value}
+					size="1"
+					onChange=${({ target }) => {
+						let value = type === 'number' ? target.valueAsNumber : target.value;
+						if (props.inputmode === 'numeric') {
+							props.pattern = '^-?[0-9]*$';
+							if (value && !isNaN(+value))
+								value = +target.value;
+						}
+						if (props.pattern && !new RegExp(props.pattern).test(value))
+							return;
+						onValueChange(value);
+					}}
+					...${props}/>
+				${children}
+			</div>
 			${datalist && html`
 				<datalist id="${label}">
 					${datalist.map(opt => html`
@@ -1530,15 +1550,11 @@ class SessionStorage {
 	}
 
 	async init() {
-		try {
-			const db = await this.openDatabase();
-			this.nextId = (await this.loadFromDatabase(db, 'nextSessionId')) || 0;
-			this.selectedSession = (await this.loadFromDatabase(db, 'selectedSessionId')) || 0;
-			await this.loadSessions(db);
-			this.saveTimer = setInterval(async () => await this.saveTimerHandler(), 500);
-		} catch (e) {
-			reportError(e);
-		}
+		const db = await this.openDatabase();
+		this.nextId = (await this.loadFromDatabase(db, 'nextSessionId')) || 0;
+		this.selectedSession = (await this.loadFromDatabase(db, 'selectedSessionId')) || 0;
+		await this.loadSessions(db);
+		this.saveTimer = setInterval(async () => await this.saveTimerHandler(), 500);
 	}
 
 	async openDatabase() {
@@ -1759,6 +1775,114 @@ class SessionStorage {
 	}
 }
 
+class WebSessionStorage extends SessionStorage {
+	constructor(defaultPresets) {
+		super(defaultPresets);
+	}
+
+	async openDatabase() {
+		return async (route, options) => {
+			try {
+				return await fetch(new URL(route, "http://127.0.0.1:3000/"), {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						//'Authorization': `Bearer ${endpointAPIKey}`,
+					},
+					body: JSON.stringify(options),
+					//signal,
+				});
+			} catch (e) {
+				reportError(e);
+				return { ok: false, status: -1 };
+			}
+		};
+	}
+
+	async loadFromDatabase(db, key) {
+		return new Promise(async (resolve, reject) => {
+			const res = await db("/load", { key });
+			if (!res.ok) {
+				if (res.status == 404) {
+					resolve(undefined);
+				} else {
+					reject();
+				}
+				return;
+			}
+			const { result } = await res.json();
+			resolve(result);
+		});
+	}
+
+	async saveToDatabase(key, data) {
+		const db = await this.openDatabase();
+		return new Promise(async (resolve, reject) => {
+			const res = await db("/save", { data, key });
+			if (!res.ok) {
+				reject();
+				return;
+			}
+			const { result } = await res.json();
+			resolve(result);
+		});
+	}
+
+	async loadSessions(db) {
+		return new Promise(async (resolve, reject) => {
+			const res = await db("/sessions");
+			if (!res.ok) {
+				reject();
+				return;
+			}
+			const { result } = await res.json();
+			const sessions = result;
+
+			for (const [key, value] of Object.entries(sessions)) {
+				if (key !== 'nextSessionId' && key !== 'selectedSessionId') {
+					this.sessions[key] = value;
+				}
+			}
+
+			if (Object.keys(this.sessions).length === 0) {
+				if (!await this.migrateSessions()) {
+					await this.createSession('MikuPad #1');
+				}
+			}
+
+			await this.switchSession(this.selectedSession);
+			resolve();
+		});
+	}
+
+	async deleteSession(sessionId) {
+		if (Object.keys(this.sessions).length === 1)
+			return;
+		if (!window.confirm("Are you sure you want to delete this session? This action can't be undone."))
+			return;
+		const db = await this.openDatabase();
+		return new Promise(async (resolve, reject) => {
+			const res = await db("/delete", { sessionId });
+			if (!res.ok) {
+				reject();
+				return;
+			}
+			
+			// Select another session if the current was deleted
+			if (sessionId == this.selectedSession) {
+				const sessionIds = Object.keys(this.sessions).map(x => +x);
+				const sessionIdx = sessionIds.indexOf(sessionId);
+				const newSessionId = sessionIds[sessionIdx - 1] ?? sessionIds[sessionIdx + 1];
+				await this.switchSession(+newSessionId)
+			}
+
+			delete this.sessions[sessionId];
+			this.onchange?.();
+			resolve();
+		});
+	}
+}
+
 const defaultPrompt = `[INST] <<SYS>>
 You are a talented writing assistant. Always respond by incorporating the instructions into expertly written prose that is highly detailed, evocative, vivid and engaging.
 <</SYS>>
@@ -1873,7 +1997,8 @@ function usePersistentState(name, initialState) {
 	return [value, updateState];
 }
 
-export function App({ sessionStorage, useSessionState }) {
+export function App({ sessionStorageRef }) {
+	const { sessionStorage, useSessionState } = sessionStorageRef;
 	const promptArea = useRef();
 	const promptOverlay = useRef();
 	const undoStack = useRef([]);
@@ -1891,6 +2016,9 @@ export function App({ sessionStorage, useSessionState }) {
 	const [preserveCursorPosition, setPreserveCursorPosition] = usePersistentState('preserveCursorPosition', true);
 	const [darkMode, _] = usePersistentState('darkMode', false); // legacy
 	const [theme, setTheme] = usePersistentState('theme', darkMode ? 1 : 0);
+	const [sessionEndpoint, setSessionEndpoint] = usePersistentState('sessionEndpoint', '');
+	const [sessionEndpointConnecting, setSessionEndpointConnecting] = useState(false);
+	const [sessionEndpointConnected, setSessionEndpointConnected] = useState(false);
 	const [endpoint, setEndpoint] = useSessionState('endpoint', defaultPresets.endpoint);
 	const [endpointAPI, setEndpointAPI] = useSessionState('endpointAPI', defaultPresets.endpointAPI);
 	const [endpointAPIKey, setEndpointAPIKey] = useSessionState('endpointAPIKey', defaultPresets.endpointAPIKey);
@@ -2665,6 +2793,45 @@ export function App({ sessionStorage, useSessionState }) {
 		return isHttps && (url.protocol !== 'https:' && url.protocol !== 'wss:');
 	}
 
+	async function toggleSessionServer() {
+		if (!sessionEndpointConnected) {
+			setSessionEndpointConnecting(true);
+
+			const ac = new AbortController();
+			const cancelThis = () => ac.abort();
+			setCancel(() => cancelThis);
+
+			const sessionStorage = new WebSessionStorage(defaultPresets);
+			sessionStorage.dependents = sessionStorageRef.sessionStorage.dependents;
+			sessionStorage.onchange = sessionStorageRef.sessionStorage.onchange;
+			sessionStorage.onsessionchange = sessionStorageRef.sessionStorage.onsessionchange;
+			try {
+				await sessionStorage.init();
+			} catch (e) {
+				setCancel(null);
+				setSessionEndpointConnecting(false);
+				return;
+			}
+			sessionStorageRef.setSessionStorage(sessionStorage);
+
+			setCancel(null);
+			setSessionEndpointConnecting(false);
+			setSessionEndpointConnected(true);
+		} else {
+			setSessionEndpointConnecting(true);
+
+			const sessionStorage = new SessionStorage(defaultPresets);
+			sessionStorage.dependents = sessionStorageRef.sessionStorage.dependents;
+			sessionStorage.onchange = sessionStorageRef.sessionStorage.onchange;
+			sessionStorage.onsessionchange = sessionStorageRef.sessionStorage.onsessionchange;
+			await sessionStorage.init();
+			sessionStorageRef.setSessionStorage(sessionStorage);
+
+			setSessionEndpointConnecting(false);
+			setSessionEndpointConnected(false);
+		}
+	}
+
 	function onSessionChange() {
 		// TODO: Store the undo/redo in the session.
 		redoStack.current = [];
@@ -2732,6 +2899,19 @@ export function App({ sessionStorage, useSessionState }) {
 				]}/>
 			<div class="horz-separator"/>
 			<${CollapsibleGroup} label="Sessions">
+				<${InputBox} label="Session Server"
+					className="${isMixedContent() ? 'mixed-content' : ''}"
+					tooltip="${isMixedContent() ? 'This URL might be blocked due to mixed content. If the connection fails, download mikupad.html and run it locally.' : ''}"
+					readOnly=${!!cancel}
+					value=${sessionEndpoint}
+					onValueChange=${setSessionEndpoint}>
+					<button
+						className="${sessionEndpointConnecting ? 'processing' : ''}"
+						disabled=${!!cancel}
+						onClick=${toggleSessionServer}>
+						<svg fill="${sessionEndpointConnected ? 'limegreen' : 'var(--color-light)'}" width="16" height="16" viewBox="0 0 135 135"><path d="M 68.589358,96.528086 86.974134,78.143309 c 1.561999,-1.561998 1.561999,-4.094855 0,-5.656854 -1.561999,-1.561999 -4.094855,-1.561999 -5.656854,0 L 62.932504,90.871232 44.547727,72.486455 62.932504,54.101679 c 1.561999,-1.561999 1.561999,-4.094856 0,-5.656854 -1.561999,-1.561999 -4.094856,-1.561999 -5.656854,0 L 38.890873,66.829601 32.526912,60.46564 21.213204,71.779348 C 10.950256,82.042296 9.6788776,97.889973 17.396241,109.53744 L 0,126.93368 8.4852813,135.41896 25.881523,118.02272 c 11.647463,7.71736 27.49514,6.44598 37.758088,-3.81697 l 11.313708,-11.3137 -6.363961,-6.363964 z"/><path d="m 102.89204,74.953321 11.31372,-11.313712 c 10.26295,-10.262948 11.53433,-26.110625 3.81696,-37.758088 L 135.41896,8.48528 126.93368,0 109.53744,17.396239 C 97.889972,9.67888 82.042292,10.95025 71.779342,21.213202 l -11.3137,11.313708 c 41.502088,41.502087 0.33001,0.330023 42.426398,42.426411 z"/></svg>
+					</button>
+				</${InputBox}>
 				<${Sessions} sessionStorage=${sessionStorage}
 					disabled=${!!cancel}
 					onSessionChange=${onSessionChange}/>
@@ -2907,14 +3087,14 @@ export function App({ sessionStorage, useSessionState }) {
 			<div className="buttons">
 				<button
 					title="Run next prediction (Ctrl + Enter)"
-					className=${cancel ? (predictStartTokens === tokens ? 'processing' : 'completing') : ''}
+					className=${cancel && !sessionEndpointConnecting ? (predictStartTokens === tokens ? 'processing' : 'completing') : ''}
 					disabled=${!!cancel || stoppingStringsError}
 					onClick=${() => predict()}>
 					Predict
 				</button>
 				<button
 					title="Cancel prediction (Escape)"
-					disabled=${!cancel}
+					disabled=${!cancel || sessionEndpointConnecting}
 					onClick=${cancel}>
 					Cancel
 				</button>
@@ -3172,10 +3352,17 @@ async function main() {
 	const sessionStorage = new SessionStorage(defaultPresets);
 	await sessionStorage.init();
 
-	createRoot(document.body).render(html`
-		<${App}
-			sessionStorage=${sessionStorage}
-			useSessionState=${(name, initialState) => useSessionState(sessionStorage, name, initialState)}/>`);
+	const sessionStorageRef = {
+		sessionStorage: sessionStorage,
+		setSessionStorage: (sessionStorage) => {
+			sessionStorageRef.sessionStorage = sessionStorage;
+			sessionStorageRef.useSessionState = (name, initialState) => useSessionState(sessionStorage, name, initialState);
+		},
+		useSessionState: (name, initialState) => useSessionState(sessionStorage, name, initialState),
+	};
+
+	const root = createRoot(document.body);
+	root.render(html`<${App} sessionStorageRef=${sessionStorageRef}/>`);
 }
 
 main();

--- a/mikupad.html
+++ b/mikupad.html
@@ -856,6 +856,23 @@ html.monospace-dark .Session.selected {
 	margin-right: 5%;
 }
 
+#error-bar {
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	min-height: 0;
+
+	background-color: #4E3534;
+	color: #FF8080;
+	text-align: center;
+	box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+#error-bar div {
+	padding: 10px;
+}
+
 .flex-separator {
 	margin-left: auto;
 }
@@ -933,12 +950,12 @@ export async function* completion({ endpoint, endpointAPI, endpointAPIKey, signa
 	}
 }
 
-export async function abortCompletion({ endpoint, endpointAPI }) {
+export async function abortCompletion({ endpoint, endpointAPI, ...options }) {
 	switch (endpointAPI) {
 		case 2: // koboldcpp
-			return await koboldCppAbortCompletion({ endpoint });
+			return await koboldCppAbortCompletion({ endpoint, ...options });
 		case 3: // openai (ooba)
-			return await openaiOobaAbortCompletion({ endpoint });
+			return await openaiOobaAbortCompletion({ endpoint, ...options });
 	}
 }
 
@@ -991,12 +1008,13 @@ async function* parseEventStream(eventStream) {
 	}
 }
 
-async function llamaCppTokenCount({ endpoint, endpointAPIKey, signal, ...options }) {
-	const res = await fetch(new URL('/tokenize', endpoint), {
+async function llamaCppTokenCount({ endpoint, endpointAPIKey, realEndpoint, signal, ...options }) {
+	const res = await fetch(`${endpoint}/tokenize`, {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json',
 			...(endpointAPIKey ? { 'Authorization': `Bearer ${endpointAPIKey}` } : {}),
+			...(realEndpoint ? { 'X-Real-URL': realEndpoint } : {})
 		},
 		body: JSON.stringify(options),
 		signal,
@@ -1007,12 +1025,13 @@ async function llamaCppTokenCount({ endpoint, endpointAPIKey, signal, ...options
 	return tokens.length + 1; // + 1 for BOS, I guess.
 }
 
-async function* llamaCppCompletion({ endpoint, endpointAPIKey, signal, ...options }) {
-	const res = await fetch(new URL('/completion', endpoint), {
+async function* llamaCppCompletion({ endpoint, endpointAPIKey, realEndpoint, signal, ...options }) {
+	const res = await fetch(`${endpoint}/completion`, {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json',
 			...(endpointAPIKey ? { 'Authorization': `Bearer ${endpointAPIKey}` } : {}),
+			...(realEndpoint ? { 'X-Real-URL': realEndpoint } : {})
 		},
 		body: JSON.stringify({
 			...options,
@@ -1026,11 +1045,24 @@ async function* llamaCppCompletion({ endpoint, endpointAPIKey, signal, ...option
 	return yield* await parseEventStream(res.body);
 }
 
-async function koboldCppTokenCount({ endpoint, signal, ...options }) {
-	const res = await fetch(new URL('/api/extra/tokencount', endpoint), {
+function koboldFixEndpoint(endpoint) {
+	if (endpoint === undefined)
+		return undefined;
+	const url = new URL(endpoint.trim());
+	if (url.pathname.endsWith("/api")) {
+		url.pathname = url.pathname.replace("/api", "");
+	}
+	return url.toString();
+}
+
+async function koboldCppTokenCount({ endpoint, realEndpoint, signal, ...options }) {
+	endpoint = koboldFixEndpoint(endpoint);
+	realEndpoint = koboldFixEndpoint(realEndpoint);
+	const res = await fetch(`${endpoint}/api/extra/tokencount`, {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json',
+			...(realEndpoint ? { 'X-Real-URL': realEndpoint } : {})
 		},
 		body: JSON.stringify({
 			prompt: options.content
@@ -1065,11 +1097,14 @@ function koboldCppConvertOptions(options) {
 	return options;
 }
 
-async function* koboldCppCompletion({ endpoint, signal, ...options }) {
-	const res = await fetch(new URL('/api/extra/generate/stream', endpoint), {
+async function* koboldCppCompletion({ endpoint, realEndpoint, signal, ...options }) {
+	endpoint = koboldFixEndpoint(endpoint);
+	realEndpoint = koboldFixEndpoint(realEndpoint);
+	const res = await fetch(`${endpoint}/api/extra/generate/stream`, {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json',
+			...(realEndpoint ? { 'X-Real-URL': realEndpoint } : {})
 		},
 		body: JSON.stringify({
 			...koboldCppConvertOptions(options),
@@ -1084,19 +1119,41 @@ async function* koboldCppCompletion({ endpoint, signal, ...options }) {
 	}
 }
 
-async function koboldCppAbortCompletion({ endpoint }) {
-	await fetch(new URL('/api/extra/abort', endpoint), {
-		method: 'POST',
-	});
+async function koboldCppAbortCompletion({ endpoint, realEndpoint, ...options }) {
+	try {
+		endpoint = koboldFixEndpoint(endpoint);
+		realEndpoint = koboldFixEndpoint(realEndpoint);
+		await fetch(`${endpoint}/api/extra/abort`, {
+			method: 'POST',
+			headers: {
+				...(realEndpoint ? { 'X-Real-URL': realEndpoint } : {})
+			},
+		});
+	} catch (e) {
+		reportError(e);
+	}
 }
 
-async function openaiAphroditeTokenCount({ endpoint, endpointAPIKey, signal, ...options }) {
+function openaiFixEndpoint(endpoint) {
+	if (endpoint === undefined)
+		return undefined;
+	const url = new URL(endpoint.trim());
+	if (url.pathname.endsWith("/v1")) {
+		url.pathname = url.pathname.replace("/v1", "");
+	}
+	return url.toString();
+}
+
+async function openaiAphroditeTokenCount({ endpoint, endpointAPIKey, realEndpoint, signal, ...options }) {
 	try {
-		const res = await fetch(new URL('/v1/token/encode', endpoint), {
+		endpoint = openaiFixEndpoint(endpoint);
+		realEndpoint = openaiFixEndpoint(realEndpoint);
+		const res = await fetch(`${endpoint}/v1/token/encode`, {
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',
 				'Authorization': `Bearer ${endpointAPIKey}`,
+				...(realEndpoint ? { 'X-Real-URL': realEndpoint } : {})
 			},
 			body: JSON.stringify({
 				prompt: options.content
@@ -1113,12 +1170,15 @@ async function openaiAphroditeTokenCount({ endpoint, endpointAPIKey, signal, ...
 	}
 }
 
-async function openaiOobaTokenCount({ endpoint, signal, ...options }) {
+async function openaiOobaTokenCount({ endpoint, realEndpoint, signal, ...options }) {
 	try {
-		const res = await fetch(new URL('/v1/internal/token-count', endpoint), {
+		endpoint = openaiFixEndpoint(endpoint);
+		realEndpoint = openaiFixEndpoint(realEndpoint);
+		const res = await fetch(`${endpoint}/v1/internal/token-count`, {
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',
+				...(realEndpoint ? { 'X-Real-URL': realEndpoint } : {})
 			},
 			body: JSON.stringify({
 				text: options.content
@@ -1135,13 +1195,16 @@ async function openaiOobaTokenCount({ endpoint, signal, ...options }) {
 	}
 }
 
-async function openaiTabbyTokenCount({ endpoint, endpointAPIKey, signal, ...options }) {
+async function openaiTabbyTokenCount({ endpoint, endpointAPIKey, realEndpoint, signal, ...options }) {
 	try {
-		const res = await fetch(new URL('/v1/token/encode', endpoint), {
+		endpoint = openaiFixEndpoint(endpoint);
+		realEndpoint = openaiFixEndpoint(realEndpoint);
+		const res = await fetch(`${endpoint}/v1/token/encode`, {
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',
 				'Authorization': `Bearer ${endpointAPIKey}`,
+				...(realEndpoint ? { 'X-Real-URL': realEndpoint } : {})
 			},
 			body: JSON.stringify({
 				text: options.content
@@ -1158,12 +1221,15 @@ async function openaiTabbyTokenCount({ endpoint, endpointAPIKey, signal, ...opti
 	}
 }
 
-async function openaiModels({ endpoint, endpointAPIKey, signal, ...options }) {
-	const res = await fetch(new URL('/v1/models', endpoint), {
+async function openaiModels({ endpoint, endpointAPIKey, realEndpoint, signal, ...options }) {
+	endpoint = openaiFixEndpoint(endpoint);
+	realEndpoint = openaiFixEndpoint(realEndpoint);
+	const res = await fetch(`${endpoint}/v1/models`, {
 		method: 'GET',
 		headers: {
 			'Content-Type': 'application/json',
 			'Authorization': `Bearer ${endpointAPIKey}`,
+			...(realEndpoint ? { 'X-Real-URL': realEndpoint } : {})
 		},
 		signal,
 	});
@@ -1207,12 +1273,15 @@ function openaiConvertOptions(options, isOpenAI) {
 	return options;
 }
 
-async function* openaiCompletion({ endpoint, endpointAPIKey, signal, ...options }) {
-	const res = await fetch(new URL('/v1/completions', endpoint), {
+async function* openaiCompletion({ endpoint, endpointAPIKey, realEndpoint, signal, ...options }) {
+	endpoint = openaiFixEndpoint(endpoint);
+	realEndpoint = openaiFixEndpoint(realEndpoint);
+	const res = await fetch(`${endpoint}/v1/completions`, {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json',
 			'Authorization': `Bearer ${endpointAPIKey}`,
+			...(realEndpoint ? { 'X-Real-URL': realEndpoint } : {})
 		},
 		body: JSON.stringify({
 			...openaiConvertOptions(options, endpoint.toLowerCase().includes("openai.com")),
@@ -1235,10 +1304,15 @@ async function* openaiCompletion({ endpoint, endpointAPIKey, signal, ...options 
 	}
 }
 
-async function openaiOobaAbortCompletion({ endpoint }) {
+async function openaiOobaAbortCompletion({ endpoint, realEndpoint, ...options }) {
+	endpoint = openaiFixEndpoint(endpoint);
+	realEndpoint = openaiFixEndpoint(realEndpoint);
 	try {
-		await fetch(new URL('/v1/internal/stop-generation', endpoint), {
+		await fetch(`${endpoint}/v1/internal/stop-generation`, {
 			method: 'POST',
+			headers: {
+				...(realEndpoint ? { 'X-Real-URL': realEndpoint } : {})
+			},
 		});
 	} catch (e) {
 		reportError(e);
@@ -1383,7 +1457,7 @@ function CollapsibleGroup({ label, expanded, children }) {
 		`;
 	}
 
-function Sessions({ sessionStorage, onSessionChange, disabled }) {
+function Sessions({ sessionStorage, onSessionChange, onSessionError, disabled }) {
 	const [version, setVersion] = useState(0);
 	const [newSessionName, setNewSessionName] = useState('');
 	const [renameSessionName, setRenameSessionName] = useState('');
@@ -1393,9 +1467,11 @@ function Sessions({ sessionStorage, onSessionChange, disabled }) {
 	useEffect(() => {
 		sessionStorage.onchange = () => setVersion(v => v + 1);
 		sessionStorage.onsessionchange = onSessionChange;
+		sessionStorage.onerror = onSessionError;
 		return () => {
 			sessionStorage.onchange = null;
 			sessionStorage.onsessionchange = null;
+			sessionStorage.onerror = null;
 		};
 	}, []);
 
@@ -1577,6 +1653,7 @@ class SessionStorage {
 		this.sessionTemplate = { ...defaultPresets };
 		this.onchange = null;
 		this.onsessionchange = null;
+		this.onerror = null;
 	}
 
 	async init() {
@@ -1591,7 +1668,10 @@ class SessionStorage {
 		return new Promise((resolve, reject) => {
 			const openRequest = indexedDB.open(this.dbName);
 
-			openRequest.onerror = () => reject(openRequest.error);
+			openRequest.onerror = () => {
+				this.onerror?.(openRequest.error);
+				reject(openRequest.error);
+			};
 			openRequest.onsuccess = () => resolve(openRequest.result);
 			openRequest.onupgradeneeded = (event) => {
 				const db = event.target.result;
@@ -1621,8 +1701,12 @@ class SessionStorage {
 	}
 
 	async saveTimerHandler() {
+		const sessions = [];
 		while (this.saveQueue.length) {
-			const sessionId = this.saveQueue.pop();
+			sessions.push(this.saveQueue.pop());
+		}
+
+		for (const sessionId of sessions) {
 			if (!this.sessions[sessionId])
 				continue;
 			await this.saveToDatabase(sessionId, this.sessions[sessionId]);
@@ -1818,12 +1902,11 @@ class WebSessionStorage extends SessionStorage {
 					method: 'POST',
 					headers: {
 						'Content-Type': 'application/json',
-						//'Authorization': `Bearer ${endpointAPIKey}`,
 					},
 					body: JSON.stringify(options),
-					//signal,
 				});
 			} catch (e) {
+				this.onerror?.(e);
 				reportError(e);
 				return { ok: false, status: e.toString() };
 			}
@@ -2028,14 +2111,14 @@ function usePersistentState(name, initialState) {
 	return [value, updateState];
 }
 
-export function App({ sessionStorageRef }) {
-	const { sessionStorage, useSessionState } = sessionStorageRef;
+export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 	const promptArea = useRef();
 	const promptOverlay = useRef();
 	const undoStack = useRef([]);
 	const redoStack = useRef([]);
 	const probsDelayTimer = useRef();
 	const keyState = useRef({});
+	const sessionReconnectTimer = useRef();
 	const [currentPromptChunk, setCurrentPromptChunk] = useState(undefined);
 	const [undoHovered, setUndoHovered] = useState(false);
 	const [showProbs, setShowProbs] = useState(true);
@@ -2047,9 +2130,7 @@ export function App({ sessionStorageRef }) {
 	const [preserveCursorPosition, setPreserveCursorPosition] = usePersistentState('preserveCursorPosition', true);
 	const [darkMode, _] = usePersistentState('darkMode', false); // legacy
 	const [theme, setTheme] = usePersistentState('theme', darkMode ? 1 : 0);
-	const [sessionEndpoint, setSessionEndpoint] = usePersistentState('sessionEndpoint', '');
 	const [sessionEndpointConnecting, setSessionEndpointConnecting] = useState(false);
-	const [sessionEndpointConnected, setSessionEndpointConnected] = useState(false);
 	const [sessionEndpointError, setSessionEndpointError] = useState(undefined);
 	const [endpoint, setEndpoint] = useSessionState('endpoint', defaultPresets.endpoint);
 	const [endpointAPI, setEndpointAPI] = useSessionState('endpointAPI', defaultPresets.endpointAPI);
@@ -2316,14 +2397,18 @@ export function App({ sessionStorageRef }) {
 			// restart right away (???)
 			let cancelled = false;
 			setCancel(() => () => cancelled = true);
-			await new Promise(resolve => setTimeout(resolve, 500));
+			await new Promise(resolve => setTimeout(resolve, 1000));
 			if (cancelled)
 				return;
 		}
 
 		const ac = new AbortController();
 		const cancelThis = () => {
-			abortCompletion({ endpoint, endpointAPI });
+			abortCompletion({
+				endpoint,
+				endpointAPI,
+				...(isMikupadEndpoint ? { endpoint: `${sessionStorage.sessionEndpoint}/proxy`, realEndpoint: endpoint } : {})
+			});
 			ac.abort();
 		};
 		setCancel(() => cancelThis);
@@ -2340,6 +2425,7 @@ export function App({ sessionStorageRef }) {
 				...(endpointAPI == 3 || endpointAPI == 0 ? { endpointAPIKey } : {}),
 				content: ` ${prompt}`,
 				signal: ac.signal,
+				...(isMikupadEndpoint ? { endpoint: `${sessionStorage.sessionEndpoint}/proxy`, realEndpoint: endpoint } : {})
 			});
 			setTokens(tokenCount);
 			setPredictStartTokens(tokenCount);
@@ -2368,6 +2454,7 @@ export function App({ sessionStorageRef }) {
 					repeat_last_n: repeatLastN,
 					penalize_nl: penalizeNl,
 					ignore_eos: ignoreEos,
+					stop: JSON.parse(stoppingStrings) || [],
 				} : {}),
 				presence_penalty: presencePenalty,
 				frequency_penalty: frequencyPenalty,
@@ -2386,8 +2473,8 @@ export function App({ sessionStorageRef }) {
 				}),
 				n_predict: maxPredictTokens,
 				n_probs: 10,
-				stop: JSON.parse(stoppingStrings) || [],
 				signal: ac.signal,
+				...(isMikupadEndpoint ? { endpoint: `${sessionStorage.sessionEndpoint}/proxy`, realEndpoint: endpoint } : {})
 			})) {
 				ac.signal.throwIfAborted();
 				if (chunk.stopping_word)
@@ -2581,6 +2668,7 @@ export function App({ sessionStorageRef }) {
 					...(endpointAPI == 3 || endpointAPI == 0 ? { endpointAPIKey } : {}),
 					content: ` ${modifiedPrompt}`,
 					signal: ac.signal,
+					...(isMikupadEndpoint ? { endpoint: `${sessionStorage.sessionEndpoint}/proxy`, realEndpoint: endpoint } : {})
 				});
 				setTokens(tokenCount);
 			} catch (e) {
@@ -2604,6 +2692,7 @@ export function App({ sessionStorageRef }) {
 					endpointAPI,
 					...(endpointAPI == 3 ? { endpointAPIKey } : {}),
 					signal: ac.signal,
+					...(isMikupadEndpoint ? { endpoint: `${sessionStorage.sessionEndpoint}/proxy`, realEndpoint: endpoint } : {})
 				});
 				setOpenaiModels(models);
 			} catch (e) {
@@ -2826,54 +2915,30 @@ export function App({ sessionStorageRef }) {
 		return isHttps && (url.protocol !== 'https:' && url.protocol !== 'wss:');
 	}
 
-	async function toggleSessionServer() {
-		setSessionEndpointError(undefined);
-		
-		if (!sessionEndpointConnected) {
-			setSessionEndpointConnecting(true);
-
-			const ac = new AbortController();
-			const cancelThis = () => ac.abort();
-			setCancel(() => cancelThis);
-
-			const sessionStorage = new WebSessionStorage(defaultPresets, sessionEndpoint);
-			sessionStorage.dependents = sessionStorageRef.sessionStorage.dependents;
-			sessionStorage.onchange = sessionStorageRef.sessionStorage.onchange;
-			sessionStorage.onsessionchange = sessionStorageRef.sessionStorage.onsessionchange;
-			try {
-				await sessionStorage.init();
-			} catch (e) {
-				setSessionEndpointError(e);
-				setCancel(null);
-				setSessionEndpointConnecting(false);
-				return;
-			}
-			sessionStorageRef.setSessionStorage(sessionStorage);
-
-			setCancel(null);
-			setSessionEndpointConnecting(false);
-			setSessionEndpointConnected(true);
-		} else {
-			setSessionEndpointConnecting(true);
-
-			const sessionStorage = new SessionStorage(defaultPresets);
-			sessionStorage.dependents = sessionStorageRef.sessionStorage.dependents;
-			sessionStorage.onchange = sessionStorageRef.sessionStorage.onchange;
-			sessionStorage.onsessionchange = sessionStorageRef.sessionStorage.onsessionchange;
-			await sessionStorage.init();
-			sessionStorageRef.setSessionStorage(sessionStorage);
-
-			setSessionEndpointConnecting(false);
-			setSessionEndpointConnected(false);
-		}
-	}
-
 	function onSessionChange() {
 		// TODO: Store the undo/redo in the session.
 		redoStack.current = [];
 		undoStack.current = [];
 		setUndoHovered(false);
 		setTitleToSession();
+	}
+
+	function onSessionError(e) {
+		if (!sessionReconnectTimer.current) {
+			sessionReconnectTimer.current = setInterval(async () => {
+				try {
+					await sessionStorage.saveToDatabase('selectedSessionId', sessionStorage.selectedSession);
+					setSessionEndpointError(undefined);
+					clearTimeout(sessionReconnectTimer.current);
+					sessionReconnectTimer.current = undefined;
+				} catch (e) {
+					reportError(e);
+				}
+			}, 1000);
+		}
+		setSessionEndpointError("Mikupad server is unreachable!");
+		setCurrentPromptChunk(undefined);
+		setUndoHovered(false);
 	}
 
 	const probs = useMemo(() =>
@@ -2935,23 +3000,10 @@ export function App({ sessionStorageRef }) {
 				]}/>
 			<div class="horz-separator"/>
 			<${CollapsibleGroup} label="Sessions">
-				<${InputBox} label="Session Server"
-					className="${sessionEndpointError ? 'rejected' : (isMixedContent() ? 'mixed-content' : '')}"
-					tooltip="${sessionEndpointError ? sessionEndpointError : (isMixedContent() ? 'This URL might be blocked due to mixed content. If the connection fails, download mikupad.html and run it locally.' : '')}"
-					tooltipSize="short"
-					readOnly=${!!cancel}
-					value=${sessionEndpoint}
-					onValueChange=${setSessionEndpoint}>
-					<button
-						className="${sessionEndpointConnecting ? 'processing' : ''}"
-						disabled=${!!cancel}
-						onClick=${toggleSessionServer}>
-						<svg fill="${sessionEndpointConnected ? 'limegreen' : 'var(--color-light)'}" width="16" height="16" viewBox="0 0 135 135"><path d="M 68.589358,96.528086 86.974134,78.143309 c 1.561999,-1.561998 1.561999,-4.094855 0,-5.656854 -1.561999,-1.561999 -4.094855,-1.561999 -5.656854,0 L 62.932504,90.871232 44.547727,72.486455 62.932504,54.101679 c 1.561999,-1.561999 1.561999,-4.094856 0,-5.656854 -1.561999,-1.561999 -4.094856,-1.561999 -5.656854,0 L 38.890873,66.829601 32.526912,60.46564 21.213204,71.779348 C 10.950256,82.042296 9.6788776,97.889973 17.396241,109.53744 L 0,126.93368 8.4852813,135.41896 25.881523,118.02272 c 11.647463,7.71736 27.49514,6.44598 37.758088,-3.81697 l 11.313708,-11.3137 -6.363961,-6.363964 z"/><path d="m 102.89204,74.953321 11.31372,-11.313712 c 10.26295,-10.262948 11.53433,-26.110625 3.81696,-37.758088 L 135.41896,8.48528 126.93368,0 109.53744,17.396239 C 97.889972,9.67888 82.042292,10.95025 71.779342,21.213202 l -11.3137,11.313708 c 41.502088,41.502087 0.33001,0.330023 42.426398,42.426411 z"/></svg>
-					</button>
-				</${InputBox}>
 				<${Sessions} sessionStorage=${sessionStorage}
 					disabled=${!!cancel}
-					onSessionChange=${onSessionChange}/>
+					onSessionChange=${onSessionChange}
+					onSessionError=${onSessionError}/>
 			</${CollapsibleGroup}>
 			<${CollapsibleGroup} label="Parameters" expanded>
 				<${InputBox} label="Server"
@@ -3379,24 +3431,42 @@ export function App({ sessionStorageRef }) {
 				`)}
 			</div>
 		</${Modal}>
+		${sessionEndpointError && html`
+			<div className="modal-overlay">
+				<div id="error-bar">
+					<div>
+						${sessionEndpointError}
+					</div>
+				</div>
+			</div>`}
 	`;
 }
 
 async function main() {
-	const sessionStorage = new SessionStorage(defaultPresets);
-	await sessionStorage.init();
+	let sessionStorage = null;
+	let isMikupadEndpoint = false;
 
-	const sessionStorageRef = {
-		sessionStorage: sessionStorage,
-		setSessionStorage: (sessionStorage) => {
-			sessionStorageRef.sessionStorage = sessionStorage;
-			sessionStorageRef.useSessionState = (name, initialState) => useSessionState(sessionStorage, name, initialState);
-		},
-		useSessionState: (name, initialState) => useSessionState(sessionStorage, name, initialState),
-	};
+	if (window.location.protocol != 'file:' && window.location.pathname == '/') {
+		sessionStorage = new WebSessionStorage(defaultPresets, window.location.protocol + '//' + window.location.host);
+		try {
+			await sessionStorage.init();
+			isMikupadEndpoint = true;
+		} catch (e) {
+			sessionStorage = null;
+			reportError(e);
+		}
+	}
+	
+	if (sessionStorage == null) {
+		sessionStorage = new SessionStorage(defaultPresets);
+		await sessionStorage.init();
+	}
 
-	const root = createRoot(document.body);
-	root.render(html`<${App} sessionStorageRef=${sessionStorageRef}/>`);
+	createRoot(document.body).render(html`
+		<${App}
+			sessionStorage=${sessionStorage}
+			useSessionState=${(name, initialState) => useSessionState(sessionStorage, name, initialState)}
+			isMikupadEndpoint=${isMikupadEndpoint}/>`);
 }
 
 main();

--- a/mikupad.html
+++ b/mikupad.html
@@ -1893,6 +1893,7 @@ class WebSessionStorage extends SessionStorage {
 	constructor(defaultPresets, sessionEndpoint) {
 		super(defaultPresets);
 		this.sessionEndpoint = sessionEndpoint;
+		this.proxyEndpoint = `${sessionEndpoint}/proxy`;
 	}
 
 	async openDatabase() {
@@ -2407,7 +2408,7 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 			abortCompletion({
 				endpoint,
 				endpointAPI,
-				...(isMikupadEndpoint ? { endpoint: `${sessionStorage.sessionEndpoint}/proxy`, realEndpoint: endpoint } : {})
+				...(isMikupadEndpoint ? { endpoint: sessionStorage.proxyEndpoint, realEndpoint: endpoint } : {})
 			});
 			ac.abort();
 		};
@@ -2425,7 +2426,7 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 				...(endpointAPI == 3 || endpointAPI == 0 ? { endpointAPIKey } : {}),
 				content: ` ${prompt}`,
 				signal: ac.signal,
-				...(isMikupadEndpoint ? { endpoint: `${sessionStorage.sessionEndpoint}/proxy`, realEndpoint: endpoint } : {})
+				...(isMikupadEndpoint ? { endpoint: sessionStorage.proxyEndpoint, realEndpoint: endpoint } : {})
 			});
 			setTokens(tokenCount);
 			setPredictStartTokens(tokenCount);
@@ -2474,7 +2475,7 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 				n_predict: maxPredictTokens,
 				n_probs: 10,
 				signal: ac.signal,
-				...(isMikupadEndpoint ? { endpoint: `${sessionStorage.sessionEndpoint}/proxy`, realEndpoint: endpoint } : {})
+				...(isMikupadEndpoint ? { endpoint: sessionStorage.proxyEndpoint, realEndpoint: endpoint } : {})
 			})) {
 				ac.signal.throwIfAborted();
 				if (chunk.stopping_word)
@@ -2668,7 +2669,7 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 					...(endpointAPI == 3 || endpointAPI == 0 ? { endpointAPIKey } : {}),
 					content: ` ${modifiedPrompt}`,
 					signal: ac.signal,
-					...(isMikupadEndpoint ? { endpoint: `${sessionStorage.sessionEndpoint}/proxy`, realEndpoint: endpoint } : {})
+					...(isMikupadEndpoint ? { endpoint: sessionStorage.proxyEndpoint, realEndpoint: endpoint } : {})
 				});
 				setTokens(tokenCount);
 			} catch (e) {
@@ -2692,7 +2693,7 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 					endpointAPI,
 					...(endpointAPI == 3 ? { endpointAPIKey } : {}),
 					signal: ac.signal,
-					...(isMikupadEndpoint ? { endpoint: `${sessionStorage.sessionEndpoint}/proxy`, realEndpoint: endpoint } : {})
+					...(isMikupadEndpoint ? { endpoint: sessionStorage.proxyEndpoint, realEndpoint: endpoint } : {})
 				});
 				setOpenaiModels(models);
 			} catch (e) {

--- a/server/package.json
+++ b/server/package.json
@@ -9,6 +9,8 @@
     "body-parser": "^1.20.2",
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "sqlite3": "^5.1.7"
+    "sqlite3": "^5.1.7",
+    "minimist": "^1.2.8",
+    "axios": "^1.6.8"
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "server",
+  "main": "server.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "body-parser": "^1.20.2",
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "sqlite3": "^5.1.7"
+  }
+}

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,86 @@
+const express = require('express');
+const cors = require('cors');
+const bodyParser = require('body-parser');
+const sqlite3 = require('sqlite3');
+const app = express();
+const port = 3000;
+
+app.use(cors(), bodyParser.json());
+
+// Open a database connection
+const db = new sqlite3.Database('./web-session-storage.db', (err) => {
+    if (err) {
+        console.error(err.message);
+        throw err;
+    } else {
+        db.run(`CREATE TABLE IF NOT EXISTS sessions (
+            key TEXT PRIMARY KEY,
+            data TEXT
+        )`);
+    }
+});
+
+// POST route to load data
+app.post('/load', (req, res) => {
+    const { key } = req.body;
+    db.get('SELECT data FROM sessions WHERE key = ?', [key], (err, row) => {
+        if (err) {
+            res.status(500).json({ ok: false, message: 'Error querying the database' });
+        } else if (row) {
+            res.json({ ok: true, result: JSON.parse(row.data) });
+        } else {
+            res.status(404).json({ ok: false, message: 'Key not found' });
+        }
+    });
+});
+
+// POST route to save data
+app.post('/save', (req, res) => {
+    const { key, data } = req.body;
+    db.run('INSERT OR REPLACE INTO sessions (key, data) VALUES (?, ?)', [key, JSON.stringify(data)], (err) => {
+        if (err) {
+            res.status(500).json({ ok: false, message: 'Error writing to the database' });
+        } else {
+            res.json({ ok: true, result: 'Data saved successfully' });
+        }
+    });
+});
+
+// POST route to get all sessions
+app.post('/sessions', (req, res) => {
+    db.all('SELECT key, data FROM sessions', [], (err, rows) => {
+        if (err) {
+            res.status(500).json({ ok: false, message: 'Error querying the database' });
+        } else {
+            const sessions = {};
+            rows.forEach((row) => {
+                sessions[row.key] = JSON.parse(row.data);
+            });
+            res.json({ ok: true, result: sessions });
+        }
+    });
+});
+
+// POST route to delete a session
+app.post('/delete', (req, res) => {
+    const { sessionId } = req.body;
+    db.run('DELETE FROM sessions WHERE key = ?', [sessionId], (err) => {
+        if (err) {
+            res.status(500).json({ ok: false, message: 'Error deleting from the database' });
+        } else {
+            res.json({ ok: true, result: 'Session deleted successfully' });
+        }
+    });
+});
+
+// Start the server
+app.listen(port, () => {
+    console.log(`Server listening at http://localhost:${port}`);
+});
+
+// Close db connection on server close
+process.on('SIGINT', () => {
+    db.close(() => {
+        process.exit(0);
+    });
+});

--- a/server/server.js
+++ b/server/server.js
@@ -74,8 +74,8 @@ app.post('/delete', (req, res) => {
 });
 
 // Start the server
-app.listen(port, () => {
-    console.log(`Server listening at http://localhost:${port}`);
+app.listen(port, '0.0.0.0', () => {
+    console.log(`Server listening at http://0.0.0.0:${port}`);
 });
 
 // Close db connection on server close

--- a/server/start.bat
+++ b/server/start.bat
@@ -1,0 +1,15 @@
+@echo off
+
+where node >nul 2>&1
+if %errorlevel% neq 0 (
+    echo Node.js is not installed.
+    exit /b 1
+)
+where npm >nul 2>&1
+if %errorlevel% neq 0 (
+    echo npm is not installed.
+    exit /b 1
+)
+
+call npm install --no-audit
+call npm start

--- a/server/start.bat
+++ b/server/start.bat
@@ -12,4 +12,4 @@ if %errorlevel% neq 0 (
 )
 
 call npm install --no-audit
-call npm start
+call node server.js %*


### PR DESCRIPTION
Closes #34

Connecting to a session server allows you to share your sessions between multiple devices over the LAN, the implementation currently is very basic and there are no safeguards or automatic synchronization between the local database and the server database.
![image](https://github.com/lmg-anon/mikupad/assets/139719567/6e943d08-2f2a-41ef-9ad5-a589f4bf2a26)

**Edit**: I have decided to remove the ability to manually connect to the session server. Now, it will automatically connect to the session server if you open MikuPad through the server URL