### PR TITLE
fix togetherai (openai-compatible)

### DIFF
--- a/mikupad.html
+++ b/mikupad.html
@@ -1248,7 +1248,8 @@ async function openaiModels({ endpoint, endpointAPIKey, realEndpoint, signal, ..
 }
 
 function openaiConvertOptions(options, realEndpoint){
-	const isOpenAI = realEndpoint.toLowerCase().includes("openai.com") || realEndpoint.toLowerCase().includes("together.xyz");
+	const isOpenAI = realEndpoint.toLowerCase().includes("openai.com");
+	const isTogetherAI = realEndpoint.toLowerCase().includes("together.xyz")
 	const swapOption = (lhs, rhs) => {
 		if (lhs in options) {
 			options[rhs] = options[lhs];
@@ -1280,7 +1281,7 @@ function openaiConvertOptions(options, realEndpoint){
 	swapOption("mirostat", "mirostat_mode");
 	swapOption("ignore_eos", "ban_eos_token")
 
-	if (realEndpoint.toLowerCase().includes("together.xyz")) {
+	if (isTogetherAI) {
 		// errors 400 without this.
 		delete options.logprobs;
 	}

--- a/mikupad.html
+++ b/mikupad.html
@@ -1249,7 +1249,7 @@ async function openaiModels({ endpoint, endpointAPIKey, realEndpoint, signal, ..
 
 function openaiConvertOptions(options, realEndpoint){
 	const isOpenAI = realEndpoint.toLowerCase().includes("openai.com");
-	const isTogetherAI = realEndpoint.toLowerCase().includes("together.xyz")
+	const isTogetherAI = realEndpoint.toLowerCase().includes("together.xyz");
 	const swapOption = (lhs, rhs) => {
 		if (lhs in options) {
 			options[rhs] = options[lhs];

--- a/mikupad.html
+++ b/mikupad.html
@@ -917,9 +917,9 @@ export async function getTokenCount({ endpoint, endpointAPI, endpointAPIKey, sig
 			return await koboldCppTokenCount({ endpoint, signal, ...options });
 		case 3: // openai
 			// OpenAI itself doesn't have a token count endpoint...
-			if (new URL(endpoint).host === 'api.openai.com')
+			if (new URL(endpoint).host === 'api.openai.com' || new URL(endpoint).host === 'api.together.xyz')
 				return 0;
-			if (options.realEndpoint && new URL(options.realEndpoint).host === 'api.openai.com')
+			if (options.realEndpoint && new URL(options.realEndpoint).host === 'api.openai.com' || new URL(options.realEndpoint).host === 'api.together.xyz')
 				return 0;
 
 			// Each backend that exposes an OpenAI-compatible API may have a different token count endpoint.
@@ -1247,7 +1247,8 @@ async function openaiModels({ endpoint, endpointAPIKey, realEndpoint, signal, ..
 	return data.map(item => item.id);
 }
 
-function openaiConvertOptions(options, isOpenAI) {
+function openaiConvertOptions(options, realEndpoint){
+	const isOpenAI = realEndpoint.toLowerCase().includes("openai.com") || realEndpoint.toLowerCase().includes("together.xyz");
 	const swapOption = (lhs, rhs) => {
 		if (lhs in options) {
 			options[rhs] = options[lhs];
@@ -1278,6 +1279,12 @@ function openaiConvertOptions(options, isOpenAI) {
 	swapOption("tfs_z", "tfs");
 	swapOption("mirostat", "mirostat_mode");
 	swapOption("ignore_eos", "ban_eos_token")
+
+	if (realEndpoint.toLowerCase().includes("together.xyz")) {
+		// errors 400 without this.
+		delete options.logprobs;
+	}
+
 	return options;
 }
 
@@ -1292,7 +1299,7 @@ async function* openaiCompletion({ endpoint, endpointAPIKey, realEndpoint, signa
 			...(realEndpoint ? { 'X-Real-URL': realEndpoint } : {})
 		},
 		body: JSON.stringify({
-			...openaiConvertOptions(options, endpoint.toLowerCase().includes("openai.com")),
+			...openaiConvertOptions(options, realEndpoint),
 			stream: true,
 		}),
 		signal,


### PR DESCRIPTION
ignore the other closed one, accidentally pushed with wrong variable.

This pr only removes ```logprobs``` and adds ```api.together.xyz``` conditionals

```openaiModels() -> getModels()``` is still broken. 

Here's some models to put in ```Model```. [Model String for API](https://docs.together.ai/docs/inference-models) or [api.together.xyz/v1/models](https://api.together.xyz/v1/models)