### PR TITLE
Fix a couple of things that break when using Together AI

### DIFF
--- a/mikupad.html
+++ b/mikupad.html
@@ -1212,6 +1212,8 @@ async function openaiTabbyTokenCount({ endpoint, endpointAPIKey, proxyEndpoint, 
 }
 
 async function openaiModels({ endpoint, endpointAPIKey, proxyEndpoint, signal, ...options }) {
+	const isTogetherAI = endpoint.toLowerCase().includes("together.xyz");
+
 	const res = await fetch(`${proxyEndpoint ?? endpoint}/v1/models`, {
 		method: 'GET',
 		headers: {
@@ -1223,7 +1225,15 @@ async function openaiModels({ endpoint, endpointAPIKey, proxyEndpoint, signal, .
 	});
 	if (!res.ok)
 		throw new Error(`HTTP ${res.status}`);
-	const { data } = await res.json();
+
+	const response = await res.json();
+	let data;
+
+	if (isTogetherAI) {
+		data = response;
+	} else {
+		data = response.data;
+	}
 	return data.map(item => item.id);
 }
 

--- a/mikupad.html
+++ b/mikupad.html
@@ -1242,6 +1242,9 @@ function openaiConvertOptions(options, endpoint){
 	if (isOpenAI && options.n_probs > 5) {
 		options.n_probs = 5;
 	}
+	if (isTogetherAI && options.n_probs > 1) {
+		options.n_probs = 1;
+	}
 	if ("dynatemp_range" in options && options.dynatemp_range !== 0) {
 		// oobabooga specific.
 		options.dynamic_temperature = true;

--- a/mikupad.html
+++ b/mikupad.html
@@ -1230,6 +1230,7 @@ async function openaiModels({ endpoint, endpointAPIKey, proxyEndpoint, signal, .
 	let data;
 
 	if (isTogetherAI) {
+		// TogetherAI returns an array.
 		data = response;
 	} else {
 		data = response.data;


### PR DESCRIPTION
Fixes #55. When I tried to use mikupad with Together, inference failed because the API won't accept more than 1 n_probs in the request. Moreover, fetching the model list also failed. These two commits fix these problems.