### PR TITLE
Feature/instruct templates

### DIFF
--- a/mikupad.html
+++ b/mikupad.html
@@ -2727,15 +2727,6 @@ function InstructModal({ isOpen, closeModal, sessionStorage, updateTemplateDB, s
 						onInput=${e => handleInstructTemplateChange(selectedTemplate,"sysSuf",e.target.value)}
 						onValueChange=${() => {}}/>
 				</div>
-				<hr/>
-				<${InputBox} label="Bot End String (Chat Mode)"
-					placeholder="<|im_end|>"
-					className=""
-					tooltip=""
-					readOnly=${!!cancel}
-					value=${getArrObjByName(templateList,selectedTemplate)?.affixes.botEnd || ""}
-					onInput=${e => handleInstructTemplateChange(selectedTemplate,"botEnd",e.target.value)}
-					onValueChange=${() => {}}/>
 			</div>
 
 

--- a/mikupad.html
+++ b/mikupad.html
@@ -2803,82 +2803,34 @@ function InstructModal({ isOpen, closeModal, sessionStorage, selectedTemplate, s
 		</${Modal}>`;
 }
 
-class SessionStorage extends EventTarget {
+class IndexedDBAdapter {
 	constructor() {
-		super();
 		this.dbName = 'MikuPad';
-		this.storeNames = ['Sessions','Templates'];
-		this.nextId = undefined;
-		this.saveQueue = [];
-		this.saveTimer = undefined;
-		this.sessions = {};
-		this.templates = {};
-		this.selectedSession = undefined;
-	}
-
-	dispatchChangeEvent() {
-		this.dispatchEvent(new CustomEvent('change'));
-	}
-
-	dispatchSessionChangeEvent() {
-		this.dispatchEvent(new CustomEvent('sessionchange'));
-	}
-
-	dispatchErrorEvent(detail) {
-		this.dispatchEvent(new CustomEvent('error', { detail }));
 	}
 
 	async init() {
-		const db = await this.openDatabase();
-		this.nextId = (await this.loadFromDatabase(db, 'nextSessionId')) || 0;
-		this.selectedSession = (await this.loadFromDatabase(db, 'selectedSessionId')) || 0;
-		await this.loadSessions(db);
-		await this.loadTemplates(db);
-		this.saveTimer = setInterval(async () => await this.saveTimerHandler(), 500);
 	}
 
 	async openDatabase() {
 		return new Promise((resolve, reject) => {
 			const openRequest = indexedDB.open(this.dbName, 2);
 
-			openRequest.onerror = () => {
-				this.dispatchErrorEvent(openRequest.error);
-				reject(openRequest.error);
-			};
+			openRequest.onerror = () => reject(openRequest.error);
 			openRequest.onsuccess = () => resolve(openRequest.result);
 
 			openRequest.onupgradeneeded = (event) => {
 				const db = event.target.result;
-				this.storeNames.forEach(storeName => {
+				for (const storeName of ["Sessions", "Templates"]) {
 					if (!db.objectStoreNames.contains(storeName)) {
 						db.createObjectStore(storeName);
 					}
-				});
+				}
 			};
 			openRequest.onblocked = () => console.warn('Request was blocked');
 		});
 	}
 
-	async getNewId() {
-		this.nextId += 1;
-		await this.saveToDatabase('nextSessionId', this.nextId);
-		return this.nextId - 1;
-	}
-
-	async saveTimerHandler() {
-		const sessions = [];
-		while (this.saveQueue.length) {
-			sessions.push(this.saveQueue.pop());
-		}
-
-		for (const sessionId of sessions) {
-			if (!this.sessions[sessionId])
-				continue;
-			await this.saveToDatabase(sessionId, this.sessions[sessionId]);
-		}
-	}
-
-	async loadFromDatabase(db, key, storeName = this.storeNames[0]) {
+	async loadFromDatabase(db, storeName, key) {
 		return new Promise((resolve, reject) => {
 			const tx = db.transaction(storeName, 'readonly');
 			const store = tx.objectStore(storeName);
@@ -2889,8 +2841,28 @@ class SessionStorage extends EventTarget {
 		});
 	}
 
-	async saveToDatabase(key, data, storeName = this.storeNames[0]) {
-		const db = await this.openDatabase();
+	async loadAllFromDatabase(db, storeName) {
+		return new Promise((resolve, reject) => {
+			const tx = db.transaction(storeName, 'readonly');
+			const store = tx.objectStore(storeName);
+			const request = store.openCursor();
+
+			let allTables = {};
+
+			request.onsuccess = async (event) => {
+				const cursor = event.target.result;
+				if (cursor) {
+					allTables[cursor.key] = cursor.value;
+					cursor.continue();
+				} else {
+					resolve(allTables);
+				}
+			};
+			request.onerror = () => reject(request.error);
+		});
+	}
+
+	async saveToDatabase(db, storeName, key, data) {
 		return new Promise((resolve, reject) => {
 			const tx = db.transaction(storeName, 'readwrite');
 			const store = tx.objectStore(storeName);
@@ -2900,41 +2872,263 @@ class SessionStorage extends EventTarget {
 			request.onerror = () => reject(request.error);
 		});
 	}
+
+	async deleteFromDatabase(db, storeName, key) {
+		return new Promise((resolve, reject) => {
+			const tx = db.transaction(storeName, 'readwrite');
+			const store = tx.objectStore(storeName);
+			const request = store.delete(key);
+
+			request.onsuccess = () => resolve();
+			request.onerror = () => reject(request.error);
+		});
+	}
+}
+
+class ServerDBAdapter {
+	constructor(sessionEndpoint) {
+		this.sessionEndpoint = sessionEndpoint;
+	}
+
+	async init() {
+		// Test connection
+		const db = await this.openDatabase();
+		await this.loadFromDatabase(db, "Sessions", "selectedSessionId");
+	}
+
+	async openDatabase() {
+		return async (route, options) => {
+			try {
+				return await fetch(new URL(route, this.sessionEndpoint), {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+					},
+					body: JSON.stringify(options),
+				});
+			} catch (e) {
+				reportError(e);
+				return { ok: false, status: e.toString() };
+			}
+		};
+	}
+
+	async loadFromDatabase(db, storeName, key) {
+		return new Promise(async (resolve, reject) => {
+			const res = await db("/load", { storeName, key });
+			if (!res.ok) {
+				if (res.status == 404) {
+					resolve(undefined);
+				} else {
+					reject(res.status);
+				}
+				return;
+			}
+			const { result } = await res.json();
+			resolve(result);
+		});
+	}
+
+	async loadAllFromDatabase(db, storeName) {
+		return new Promise(async (resolve, reject) => {
+			const res = await db("/all", { storeName });
+			if (!res.ok) {
+				reject(res.status);
+				return;
+			}
+			const { result } = await res.json();
+			resolve(result);
+		});
+	}
+
+	async saveToDatabase(db, storeName, key, data) {
+		return new Promise(async (resolve, reject) => {
+			const res = await db("/save", { storeName, key, data });
+			if (!res.ok) {
+				reject(res.status);
+				return;
+			}
+			const { result } = await res.json();
+			resolve(result);
+		});
+	}
+
+	async deleteFromDatabase(db, storeName, key) {
+		return new Promise(async (resolve, reject) => {
+			const res = await db("/delete", { storeName, key });
+			if (!res.ok) {
+				reject(res.status);
+				return;
+			}
+			resolve();
+		});
+	}
+}
+
+class AbstractStorage extends EventTarget {
+	constructor(storeName, dbAdapter) {
+		super();
+		this.storeName = storeName;
+		this.dbAdapter = dbAdapter;
+		this.saveQueue = [];
+		this.saveTimer = undefined;
+	}
+
+	dispatchChangeEvent() {
+		this.dispatchEvent(new CustomEvent('change'));
+	}
+
+	dispatchErrorEvent(detail) {
+		this.dispatchEvent(new CustomEvent('error', { detail }));
+	}
+
+	startSaveTimer(saveCallback) {
+		this.saveTimer = setInterval(async () => await this.saveTimerHandler(saveCallback), 500);
+	}
+
+	async saveTimerHandler(saveCallback) {
+		const keys = [];
+		while (this.saveQueue.length) {
+			keys.push(this.saveQueue.pop());
+		}
+
+		for (const key of keys) {
+			await saveCallback(key);
+		}
+	}
+
+	enqueueSave(key) {
+		if (!this.saveQueue.includes(key))
+			this.saveQueue.push(key);
+	}
+
+	async openDatabase() {
+		try {
+			return await this.dbAdapter.openDatabase();
+		} catch (e) {
+			this.dispatchErrorEvent(e);
+			throw e;
+		}
+	}
+
+	async loadFromDatabase(db, key) {
+		try {
+			return await this.dbAdapter.loadFromDatabase(db, this.storeName, key);
+		} catch (e) {
+			this.dispatchErrorEvent(e);
+			throw e;
+		}
+	}
+
+	async loadAllFromDatabase(db) {
+		try {
+			return await this.dbAdapter.loadAllFromDatabase(db, this.storeName);
+		} catch (e) {
+			this.dispatchErrorEvent(e);
+			throw e;
+		}
+	}
+
+	async saveToDatabase(db, key, data) {
+		try {
+			return await this.dbAdapter.saveToDatabase(db, this.storeName, key, data);
+		} catch (e) {
+			this.dispatchErrorEvent(e);
+			throw e;
+		}
+	}
+
+	async deleteFromDatabase(db, key) {
+		try {
+			return await this.dbAdapter.deleteFromDatabase(db, this.storeName, key);
+		} catch (e) {
+			this.dispatchErrorEvent(e);
+			throw e;
+		}
+	}
+}
+
+class TemplateStorage extends AbstractStorage {
+	constructor(dbAdapter) {
+		super('Templates', dbAdapter);
+		this.templates = {};
+	}
+
+	async init() {
+		const db = await this.openDatabase();
+		await this.loadTemplates(db);
+	}
+
 	async saveTemplates(newTemplates,writeOnly=false) {
 		const db = await this.openDatabase();
-		return new Promise((resolve, reject) => {
-			const tx = db.transaction('Templates', 'readwrite');
-			const store = tx.objectStore('Templates');
 
-			const request = store.getAllKeys();
-			request.onsuccess = function(event) {
-			const DBkeys = event.target.result;
-
-			// Check if the keys exists in input, if not, delete
-			DBkeys.forEach(key => {
-				if ( !(Object.keys(newTemplates).includes(key)) ) {
-					if (writeOnly)
-						return
-					// If the key not in input, delete it
-					const deleteRequest = store.delete(key);
-					deleteRequest.onsuccess = function(event) {
-						console.warn('Deleted key:', key);
-					}
-					deleteRequest.onerror = function(event) {
-						console.error('Error deleting key:', key);
-					}
-				}
-			});
-
-			// put input keys
-			for (const [key, value] of Object.entries(newTemplates)) {
-				const request = store.put(value, key);
-				request.onsuccess = () => resolve();
-				request.onerror = () => reject(request.error);
+		// Check if the keys exists in input, if not, delete
+		for (const key of Object.keys(this.templates)) {
+			if (Object.keys(newTemplates).includes(key))
+				continue;
+			if (writeOnly)
+				continue;
+			try {
+				// If the key not in input, delete it
+				await this.deleteFromDatabase(db, key);
+				console.warn('Deleted key:', key);
+			} catch {
+				console.error('Error deleting key:', key);
 			}
-
 		}
-		});
+
+		// put input keys
+		for (const [key, value] of Object.entries(newTemplates)) {
+			if (JSON.stringify(value) === JSON.stringify(this.templates[key]))
+				continue;
+			await this.saveToDatabase(db, key, value);
+		}
+
+		this.templates = newTemplates;
+	}
+
+	async loadTemplates(db) {
+		this.templates = await this.loadAllFromDatabase(db);
+	}
+}
+
+class SessionStorage extends AbstractStorage {
+	constructor(dbAdapter) {
+		super('Sessions', dbAdapter);
+		this.nextId = undefined;
+		this.sessions = {};
+		this.selectedSession = undefined;
+
+		if (dbAdapter.sessionEndpoint) {
+			this.sessionEndpoint = dbAdapter.sessionEndpoint;
+			this.proxyEndpoint = `${dbAdapter.sessionEndpoint}/proxy`;
+		}
+	}
+
+	dispatchSessionChangeEvent() {
+		this.dispatchEvent(new CustomEvent('sessionchange'));
+	}
+
+	async init() {
+		const db = await this.openDatabase();
+		this.nextId = (await this.loadFromDatabase(db, 'nextSessionId')) || 0;
+		this.selectedSession = (await this.loadFromDatabase(db, 'selectedSessionId')) || 0;
+		await this.loadSessions(db);
+		this.startSaveTimer((sessionId) => this.saveSessionToDB(sessionId));
+	}
+
+	async saveSessionToDB(sessionId) {
+		if (!this.sessions[sessionId])
+			return;
+		const db = await this.openDatabase();
+		await this.saveToDatabase(db, sessionId, this.sessions[sessionId]);
+	}
+
+	async getNewId() {
+		const db = await this.openDatabase();
+		await this.saveToDatabase(db, 'nextSessionId', this.nextId + 1);
+		this.nextId += 1;
+		return this.nextId - 1;
 	}
 
 	// We leave the localStorage content untouched for now,
@@ -2960,57 +3154,28 @@ class SessionStorage extends EventTarget {
 				this.sessions[sessionId][propertyName] = value;
 			}
 		};
-		await this.saveToDatabase('nextSessionId', this.nextId);
-		await this.saveToDatabase('selectedSessionId', this.selectedSession);
+		const db = await this.openDatabase();
+		await this.saveToDatabase(db, 'nextSessionId', this.nextId);
+		await this.saveToDatabase(db, 'selectedSessionId', this.selectedSession);
 		for (const sessionId of Object.keys(this.sessions)) {
-			await this.saveToDatabase(+sessionId, this.sessions[sessionId]);
+			await this.saveToDatabase(db, +sessionId, this.sessions[sessionId]);
 		}
 		return true;
 	}
 
 	async loadSessions(db) {
-		return new Promise((resolve, reject) => {
-			const tx = db.transaction(this.storeNames[0], 'readonly');
-			const store = tx.objectStore(this.storeNames[0]);
-			const request = store.openCursor();
-
-			request.onsuccess = async (event) => {
-				const cursor = event.target.result;
-				if (cursor) {
-					if (cursor.key !== 'nextSessionId' && cursor.key !== 'selectedSessionId') {
-						this.sessions[cursor.key] = cursor.value;
-					}
-					cursor.continue();
-				} else {
-					if (Object.keys(this.sessions).length === 0) {
-						if (!await this.migrateSessions()) {
-							await this.createSession('MikuPad #1');
-						}
-					}
-					await this.switchSession(this.selectedSession);
-					resolve();
-				}
-			};
-			request.onerror = () => reject(request.error);
-		});
-	}
-	async loadTemplates(db) {
-		return new Promise((resolve, reject) => {
-			const tx = db.transaction(this.storeNames[1], 'readonly');
-			const store = tx.objectStore(this.storeNames[1]);
-			const request = store.openCursor();
-
-			request.onsuccess = async (event) => {
-				const cursor = event.target.result;
-				if (cursor) {
-					this.templates[cursor.key] = cursor.value;
-					cursor.continue();
-				} else {
-					resolve();
-				}
-			};
-			request.onerror = () => reject(request.error);
-		});
+		const sessions = await this.loadAllFromDatabase(db);
+		for (const [key, value] of Object.entries(sessions)) {
+			if (key !== 'nextSessionId' && key !== 'selectedSessionId') {
+				this.sessions[key] = value;
+			}
+		}
+		if (Object.keys(this.sessions).length === 0) {
+			if (!await this.migrateSessions()) {
+				await this.createSession('MikuPad #1');
+			}
+		}
+		await this.switchSession(this.selectedSession);
 	}
 
 	getProperty(propertyName) {
@@ -3021,15 +3186,17 @@ class SessionStorage extends EventTarget {
 		if (!this.sessions[this.selectedSession])
 			return;
 		this.sessions[this.selectedSession][propertyName] = value;
-		if (!this.saveQueue.includes(this.selectedSession))
-			this.saveQueue.push(this.selectedSession);
+		this.enqueueSave(this.selectedSession);
 	}
 
 	async switchSession(sessionId) {
 		if (!this.sessions[sessionId])
 			return;
+		
+		const db = await this.openDatabase();
+		await this.saveToDatabase(db, 'selectedSessionId', +sessionId);
+
 		this.selectedSession = +sessionId;
-		await this.saveToDatabase('selectedSessionId', this.selectedSession);
 
 		this.dispatchChangeEvent();
 		this.dispatchSessionChangeEvent();
@@ -3037,7 +3204,9 @@ class SessionStorage extends EventTarget {
 
 	async renameSession(sessionId, renameSessionName) {
 		this.sessions[sessionId]['name'] = renameSessionName;
-		await this.saveToDatabase(sessionId, this.sessions[sessionId]);
+
+		const db = await this.openDatabase();
+		await this.saveToDatabase(db, sessionId, this.sessions[sessionId]);
 
 		this.dispatchChangeEvent();
 	}
@@ -3047,33 +3216,28 @@ class SessionStorage extends EventTarget {
 			return;
 		if (!window.confirm("Are you sure you want to delete this session? This action can't be undone."))
 			return;
+
 		const db = await this.openDatabase();
-		return new Promise((resolve, reject) => {
-			const tx = db.transaction(this.storeNames[0], 'readwrite');
-			const store = tx.objectStore(this.storeNames[0]);
-			const request = store.delete(sessionId);
+		await this.deleteFromDatabase(db, sessionId);
 
-			request.onsuccess = async () => {
-				// Select another session if the current was deleted
-				if (sessionId == this.selectedSession) {
-					const sessionIds = Object.keys(this.sessions).map(x => +x);
-					const sessionIdx = sessionIds.indexOf(sessionId);
-					const newSessionId = sessionIds[sessionIdx - 1] ?? sessionIds[sessionIdx + 1];
-					await this.switchSession(+newSessionId)
-				}
+		// Select another session if the current was deleted
+		if (sessionId == this.selectedSession) {
+			const sessionIds = Object.keys(this.sessions).map(x => +x);
+			const sessionIdx = sessionIds.indexOf(sessionId);
+			const newSessionId = sessionIds[sessionIdx - 1] ?? sessionIds[sessionIdx + 1];
+			await this.switchSession(+newSessionId)
+		}
 
-				delete this.sessions[sessionId];
-				this.dispatchChangeEvent();
-				resolve();
-			};
-			request.onerror = () => reject(request.error);
-		});
+		delete this.sessions[sessionId];
+		this.dispatchChangeEvent();
 	}
 
 	async createSession(newSessionName) {
 		const newId = await this.getNewId();
 		this.sessions[newId] = { name: newSessionName };
-		await this.saveToDatabase(newId, this.sessions[newId]);
+		
+		const db = await this.openDatabase();
+		await this.saveToDatabase(db, newId, this.sessions[newId]);
 
 		onchange?.();
 		return newId;
@@ -3096,136 +3260,11 @@ class SessionStorage extends EventTarget {
 			this.sessions[newId]['name'] = `Cloned ${this.sessions[newId]['name']}`;
 		}
 
-		await this.saveToDatabase(newId, this.sessions[newId]);
+		const db = await this.openDatabase();
+		await this.saveToDatabase(db, newId, this.sessions[newId]);
 
 		onchange?.();
 		return newId;
-	}
-}
-
-class WebSessionStorage extends SessionStorage {
-	constructor(sessionEndpoint) {
-		super();
-		this.sessionEndpoint = sessionEndpoint;
-		this.proxyEndpoint = `${sessionEndpoint}/proxy`;
-	}
-
-	async openDatabase() {
-		return async (route, options) => {
-			try {
-				return await fetch(new URL(route, this.sessionEndpoint), {
-					method: 'POST',
-					headers: {
-						'Content-Type': 'application/json',
-					},
-					body: JSON.stringify(options),
-				});
-			} catch (e) {
-				this.dispatchErrorEvent(e);
-				reportError(e);
-				return { ok: false, status: e.toString() };
-			}
-		};
-	}
-
-	async loadFromDatabase(db, key) {
-		return new Promise(async (resolve, reject) => {
-			const res = await db("/load", { key });
-			if (!res.ok) {
-				if (res.status == 404) {
-					resolve(undefined);
-				} else {
-					reject(res.status);
-				}
-				return;
-			}
-			const { result } = await res.json();
-			resolve(result);
-		});
-	}
-
-	async saveToDatabase(key, data) {
-		const db = await this.openDatabase();
-		return new Promise(async (resolve, reject) => {
-			const res = await db("/save", { data, key });
-			if (!res.ok) {
-				reject(res.status);
-				return;
-			}
-			const { result } = await res.json();
-			resolve(result);
-		});
-	}
-
-	async loadSessions(db) {
-		return new Promise(async (resolve, reject) => {
-			const res = await db("/sessions");
-			if (!res.ok) {
-				reject(res.status);
-				return;
-			}
-			const { result } = await res.json();
-			const sessions = result;
-
-			for (const [key, value] of Object.entries(sessions)) {
-				if (key !== 'nextSessionId' && key !== 'selectedSessionId') {
-					this.sessions[key] = value;
-				}
-			}
-
-			if (Object.keys(this.sessions).length === 0) {
-				if (!await this.migrateSessions()) {
-					await this.createSession('MikuPad #1');
-				}
-			}
-
-			await this.switchSession(this.selectedSession);
-			resolve();
-		});
-	}
-	async loadTemplates(db) {
-		return new Promise(async (resolve, reject) => {
-			const res = await db("/templates");
-			if (!res.ok) {
-				reject(res.status);
-				return;
-			}
-			const { result } = await res.json();
-			const sessions = result;
-
-			for (const [key, value] of Object.entries(templates)) {
-				this.templates[key] = value;
-			}
-
-			resolve();
-		});
-	}
-
-	async deleteSession(sessionId) {
-		if (Object.keys(this.sessions).length === 1)
-			return;
-		if (!window.confirm("Are you sure you want to delete this session? This action can't be undone."))
-			return;
-		const db = await this.openDatabase();
-		return new Promise(async (resolve, reject) => {
-			const res = await db("/delete", { sessionId });
-			if (!res.ok) {
-				reject(res.status);
-				return;
-			}
-
-			// Select another session if the current was deleted
-			if (sessionId == this.selectedSession) {
-				const sessionIds = Object.keys(this.sessions).map(x => +x);
-				const sessionIdx = sessionIds.indexOf(sessionId);
-				const newSessionId = sessionIds[sessionIdx - 1] ?? sessionIds[sessionIdx + 1];
-				await this.switchSession(+newSessionId)
-			}
-
-			delete this.sessions[sessionId];
-			this.dispatchChangeEvent();
-			resolve();
-		});
 	}
 }
 
@@ -3394,23 +3433,15 @@ function useSessionState(sessionStorage, name, initialState) {
 	return [value, updateState];
 }
 
-function useDBTemplates(sessionStorage,initialState) {
-	const savedState = useMemo(() => {
-		try {
-			return sessionStorage.templates;
-		} catch (e) {
-			reportError(e);
-			return null;
-		}
-	}, []);
+function useDBTemplates(templateStorage, initialState) {
+	const savedState = useMemo(() => templateStorage.templates, []);
 
 	const [value, setValue] = useState(Object.keys(savedState).length === 0 ? initialState : savedState);
 
 	const updateState = (newValue) => {
 		setValue((prevValue) => {
 			const updatedValue = typeof newValue === 'function' ? newValue(prevValue) : newValue;
-			sessionStorage.templates = updatedValue;
-			sessionStorage.saveTemplates(updatedValue)
+			templateStorage.saveTemplates(updatedValue)
 			return updatedValue;
 		});
 	};
@@ -4380,7 +4411,7 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 			if (!sessionReconnectTimer.current) {
 				sessionReconnectTimer.current = setInterval(async () => {
 					try {
-						await sessionStorage.saveToDatabase('selectedSessionId', sessionStorage.selectedSession);
+						await sessionStorage.dbAdapter.init();
 						setSessionEndpointError(undefined);
 						clearTimeout(sessionReconnectTimer.current);
 						sessionReconnectTimer.current = undefined;
@@ -4820,30 +4851,31 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 }
 
 async function main() {
-	let sessionStorage = null;
+	let dbAdapter = new IndexedDBAdapter();
 	let isMikupadEndpoint = false;
 
 	if (window.location.protocol != 'file:' && window.location.pathname == '/') {
-		sessionStorage = new WebSessionStorage(window.location.protocol + '//' + window.location.host);
+		let serverAdapter = new ServerDBAdapter(window.location.protocol + '//' + window.location.host);
 		try {
-			await sessionStorage.init();
+			await serverAdapter.init();
+			dbAdapter = serverAdapter;
 			isMikupadEndpoint = true;
 		} catch (e) {
-			sessionStorage = null;
 			reportError(e);
 		}
 	}
 
-	if (sessionStorage == null) {
-		sessionStorage = new SessionStorage();
-		await sessionStorage.init();
-	}
+	const sessionStorage = new SessionStorage(dbAdapter);
+	await sessionStorage.init();
+
+	const templateStorage = new TemplateStorage(dbAdapter);
+	await templateStorage.init();
 
 	createRoot(document.body).render(html`
 		<${App}
 			sessionStorage=${sessionStorage}
 			useSessionState=${(name, initialState) => useSessionState(sessionStorage, name, initialState)}
-			useDBTemplates=${(initialState => useDBTemplates(sessionStorage,initialState))}
+			useDBTemplates=${(initialState => useDBTemplates(templateStorage, initialState))}
 			isMikupadEndpoint=${isMikupadEndpoint}/>`);
 }
 

--- a/mikupad.html
+++ b/mikupad.html
@@ -2727,6 +2727,15 @@ function InstructModal({ isOpen, closeModal, sessionStorage, updateTemplateDB, s
 						onInput=${e => handleInstructTemplateChange(selectedTemplate,"sysSuf",e.target.value)}
 						onValueChange=${() => {}}/>
 				</div>
+				<hr/>
+				<${InputBox} label="Bot End String (Chat Mode)"
+					placeholder="<|im_end|>"
+					className=""
+					tooltip=""
+					readOnly=${!!cancel}
+					value=${getArrObjByName(templateList,selectedTemplate)?.affixes.botEnd || ""}
+					onInput=${e => handleInstructTemplateChange(selectedTemplate,"botEnd",e.target.value)}
+					onValueChange=${() => {}}/>
 			</div>
 
 
@@ -3210,8 +3219,8 @@ const defaultPresets = {
 	instructTemplates:{
 		'Alpaca': {
 			'sysPre' : '### System:\\n',
-			'sysSuf' : '\\n\\n',
-			'instPre': '### Instruction:\\n',
+			'sysSuf' : '',
+			'instPre': '\\n\\n### Instruction:\\n',
 			'instSuf': '\\n\\n### Response:',
 		},
 		'Mistral': {
@@ -3222,32 +3231,32 @@ const defaultPresets = {
 		},
 		'ChatML': {
 			'sysPre' : '<|im_start|>system\\n',
-			'sysSuf' : '<|im_end|>\\n',
-			'instPre': '<|im_start|>user\\n',
+			'sysSuf' : '',
+			'instPre': '<|im_end|>\\n<|im_start|>user\\n',
 			'instSuf': '<|im_end|>\\n<|im_start|>assistant\\n',
 		},
 		'Llama 3': {
 			'sysPre' : '<|start_header_id|>system<|end_header_id|>\\n\\n',
-			'sysSuf' : '<|eot_id|>',
-			'instPre': '<|start_header_id|>user<|end_header_id|>\\n\\n',
+			'sysSuf' : '',
+			'instPre': '<|eot_id|><|start_header_id|>user<|end_header_id|>\\n\\n',
 			'instSuf': '<|eot_id|><|start_header_id|>assistant<|end_header_id|>\\n\\n',
 		},
 		'Phi 2': {
 			'sysPre' : '',
 			'sysSuf' : '',
-			'instPre': 'Instruct: ',
+			'instPre': '\\nInstruct: ',
 			'instSuf': '\\nOutput: ',
 		},
 		'Phi 3': {
 			'sysPre' : '<|system|>\\n',
-			'sysSuf' : '<|end|>\\n',
-			'instPre': '<|user|>\\n',
+			'sysSuf' : '',
+			'instPre': '<|end|>\\n<|user|>\\n',
 			'instSuf': '<|end|>\\n<|assistant|>\\n',
 		},
 		'Command-R': {
 			'sysPre' : '<|START_OF_TURN_TOKEN|><|SYSTEM_TOKEN|>',
-			'sysSuf' : '<|END_OF_TURN_TOKEN|>',
-			'instPre': '<|START_OF_TURN_TOKEN|><|USER_TOKEN|>',
+			'sysSuf' : '',
+			'instPre': '<|END_OF_TURN_TOKEN|><|START_OF_TURN_TOKEN|><|USER_TOKEN|>',
 			'instSuf': '<|END_OF_TURN_TOKEN|><|START_OF_TURN_TOKEN|><|CHATBOT_TOKEN|>',
 		},
 		'Metharme': {
@@ -3259,13 +3268,13 @@ const defaultPresets = {
 		'Vicuna': {
 			'sysPre' : '',
 			'sysSuf' : '\\n\\n',
-			'instPre': 'USER: ',
+			'instPre': '\\nUSER: ',
 			'instSuf': '\\nASSISTANT: ',
 		},
 		'Gemma': {
 			'sysPre' : '',
 			'sysSuf' : '',
-			'instPre': '<start_of_turn>user\\n',
+			'instPre': '\\n<end_of_turn><start_of_turn>user\\n',
 			'instSuf': '\\n<end_of_turn><start_of_turn>model\\n',
 		},
 	},
@@ -3384,6 +3393,7 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 	const [addDeleteTemplate, setAddDeleteTemplate] = useState(false);
 	const [templatesImport, setTemplatesImport] = useState(false);
 	const [selectedTemplate, setSelectedTemplate] = usePersistentState('template', "Llama 3");
+	const [chatMode, setChatMode] = usePersistentState('chatMode', false);
 	const [templateList, setTemplateList] = useState([]);
 	const [currentPromptChunk, setCurrentPromptChunk] = useState(undefined);
 	const [undoHovered, setUndoHovered] = useState(false);
@@ -3762,6 +3772,14 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 			setTokens(tokenCount);
 			setPredictStartTokens(tokenCount);
 
+			// Chat Mode
+			if (chatMode) {
+				// add user EOT template (instruct suffix)
+				const eotUser = templates[selectedTemplate]?.instSuf.replace(/\\n/g, '\n')
+				setPromptChunks(p => [...p, { type: 'user', content: eotUser }])
+				prompt += `${eotUser}`
+			}
+
 			while (undoStack.current.at(-1) >= chunkCount)
 				undoStack.current.pop();
 			undoStack.current.push(chunkCount);
@@ -3840,6 +3858,13 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 			setCancel(c => c === cancelThis ? null : c);
 			if (undoStack.current.at(-1) === chunkCount)
 				undoStack.current.pop();
+		}
+		// Chat Mode
+		if (chatMode) {
+			// add bot EOT template (instruct prefix)
+			const eotBot = templates[selectedTemplate]?.instPre.replace(/\\n/g, '\n')
+			setPromptChunks(p => [...p, { type: 'user', content: eotBot }])
+			prompt += `${eotBot}`
 		}
 	}
 
@@ -3975,7 +4000,8 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 			const oldHeight = elem.scrollHeight;
 			const atBottom = (elem.scrollTarget ?? elem.scrollTop) + elem.clientHeight + 1 > oldHeight;
 			const oldLen = elem.value.length;
-			if (!isTextSelected && !preserveCursorPosition) {
+			// disable preserveCursorPosition in chatMode
+			if ( (!isTextSelected && !preserveCursorPosition) || chatMode) {
 				elem.value = promptText;
 			} else {
 				elem.setRangeText(promptText.slice(oldLen), oldLen, oldLen, 'preserve');
@@ -4505,6 +4531,16 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 						onClick=${() => insertTemplate("inst")}>
 						<svg style=${{ 'height':'1.05em','transform':'translate(-50%, -60%)' }} xmlns="http://www.w3.org/2000/svg"  viewBox="0 -10 5 10"><path d="M 2.5 -6 A 0.75 0.75 90 0 0 3.25 -6.75 A 0.75 0.75 90 0 0 2.5 -7.5 A 0.75 0.75 90 0 0 1.75 -6.75 A 0.75 0.75 90 0 0 2.5 -6 M 1 0 L 4 0 L 4 -1 L 3 -1 L 3 -5 L 1 -5 L 1 -4 L 2 -4 L 2 -1 L 1 -1 Z" fill="var(--color-light)"/></svg>
 					</button>
+					<button
+						title="Toggle Chat Mode ${ chatMode ? "Off" : "On"}"
+						disabled=${!!cancel}
+						class="symbol-button"
+						onClick=${() => setChatMode( (prevState) => !prevState)}>
+						${ chatMode ? 
+						  html`<svg style=${{ 'width':'.9em' }} xmlns="http://www.w3.org/2000/svg"  viewBox="0 0 10 10"><path d="M 2 10 L 2 7 Q 0 7 0 5 L 0 2 Q 0 0 2 0 L 8 0 Q 10 0 10 2 Q 10 2 10 3 L 10 5 Q 10 7 8 7 L 6 7 Z" fill="var(--color-light)"/></svg>`
+						: html`<svg style=${{ 'width':'.9em' }} xmlns="http://www.w3.org/2000/svg"  viewBox="0 0 31 31"><path d="M 0 32 L 3 23 L 26 0 L 32 6 L 9 29 Z M 22 4 L 28 10 L 29 9 L 23 3 M 3 23 L 9 29 L 10 28 L 4 22 Z" fill="var(--color-light)"/></svg>`
+						}
+					</button>
 				</div>
 				<${InputBox} label="Seed (-1 = random)" type="text" inputmode="numeric"
 					readOnly=${!!cancel} value=${seed} onValueChange=${setSeed}/>
@@ -4705,7 +4741,7 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 				value=${attachSidebar} onValueChange=${setAttachSidebar}/>
 			<${Checkbox} label="Highlight generated tokens"
 				value=${highlightGenTokens} onValueChange=${setHighlightGenTokens}/>
-			<${Checkbox} label="Preserve cursor position after prediction"
+			<${Checkbox} label="Preserve cursor position after prediction (disabled in Chat Mode)"
 				value=${preserveCursorPosition} onValueChange=${setPreserveCursorPosition}/>
 			<${SelectBox}
 				label="Token probabilities"

--- a/mikupad.html
+++ b/mikupad.html
@@ -2508,7 +2508,7 @@ function LogitBiasModal({ isOpen, closeModal, logitBias, setLogitBias, logitBias
 			</${Modal}>`;
 }
 
-function InstructModal({ isOpen, closeModal, sessionStorage, updateTemplateDB, newTemplateName, setNewTemplateName, selectedTemplate, setSelectedTemplate, templateList, setTemplateList, templates, setTemplates, setAddDeleteTemplate, cancel }) {
+function InstructModal({ isOpen, closeModal, sessionStorage, updateTemplateDB, newTemplateName, setNewTemplateName, selectedTemplate, setSelectedTemplate, templateList, setTemplateList, templates, templatesImport, setTemplates, addDeleteTemplate, setAddDeleteTemplate, cancel }) {
 
 	function getArrObjByName(array,name,getIndex=false) {
 		const index = array.findIndex(obj => obj.name === name)
@@ -2566,6 +2566,38 @@ function InstructModal({ isOpen, closeModal, sessionStorage, updateTemplateDB, n
 		})
 		setAddDeleteTemplate(true)
 	}
+
+	// re-selecting doesn't work properly when I move this inside the InstructModal
+	const updateTemplateList = useEffect(() => {
+		const index = templateList.findIndex(obj => obj.name === selectedTemplate)
+		const reselectTemplate = templateList[index == -1 ? 0 : index]?.nameNew
+		const list = []
+		let i = 0;
+		for (const key in templates) {
+			list.push({
+				name: key,
+				nameNew:key,
+				value: key,
+				nameBack: key,
+				affixes: templates[key]
+			})
+		}
+		list.sort((a, b) => {
+			var nameA = a.name.toLowerCase();
+			var nameB = b.name.toLowerCase();
+			return (nameA < nameB) ? -1 : (nameA > nameB) ? 1 : 0;
+		});
+		setTemplateList(list)
+		if (reselectTemplate)
+			setSelectedTemplate(reselectTemplate)
+	}, [templates,selectedTemplate,templatesImport]);
+	const templateReselect = useEffect(() => {
+		if (!addDeleteTemplate)
+			return
+		setSelectedTemplate("")
+		setAddDeleteTemplate(false)
+
+	}, [addDeleteTemplate]);
 
 
 	const exportTemplates = () => {
@@ -3495,39 +3527,6 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 		onInput({ target: elem });
 	}
 
-	// re-selecting doesn't work properly when I move this inside the InstructModal
-	const updateTemplateList = useMemo(() => {
-		const index = templateList.findIndex(obj => obj.name === selectedTemplate)
-		const reselectTemplate = templateList[index == -1 ? 0 : index]?.nameNew
-		const list = []
-		let i = 0;
-		for (const key in templates) {
-			list.push({
-				name: key,
-				nameNew:key,
-				value: key,
-				nameBack: key,
-				affixes: templates[key]
-			})
-		}
-		list.sort((a, b) => {
-			var nameA = a.name.toLowerCase();
-			var nameB = b.name.toLowerCase();
-			return (nameA < nameB) ? -1 : (nameA > nameB) ? 1 : 0;
-		});
-		setTemplateList(list)
-		if (reselectTemplate)
-			setSelectedTemplate(reselectTemplate)
-	}, [templates,selectedTemplate,templatesImport]);
-	const templateReselect = useMemo(() => {
-		if (!addDeleteTemplate)
-			return
-		setSelectedTemplate("")
-		setAddDeleteTemplate(false)
-
-	}, [addDeleteTemplate]);
-
-
 	const updateTemplateDB = async () => {
 		setNewTemplateName(undefined);
 		setTemplates((prevState) => {
@@ -3562,7 +3561,7 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 			return { ...newState }
 		})
 	}
-	const updateTemplateDBCaller = useMemo(() => {
+	const updateTemplateDBCaller = useEffect(() => {
 		updateTemplateDB()
 	}, [modalState["instruct"],selectedTemplate]);
 
@@ -4809,10 +4808,12 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 			setNewTemplateName=${setNewTemplateName}
 			selectedTemplate=${selectedTemplate}
 			setSelectedTemplate=${setSelectedTemplate}
+			templatesImport=${templatesImport}
 			setTemplatesImport=${setTemplatesImport}
 			templates=${templates}
 			setTemplates=${setTemplates}
 			updateTemplateDB=${updateTemplateDB}
+			addDeleteTemplate=${addDeleteTemplate}
 			setAddDeleteTemplate=${setAddDeleteTemplate}
 			sessionStorage=${sessionStorage} endpoint=${endpoint} endpointAPI=${endpointAPI} endpointAPIKey=${endpointAPIKey} isMikupadEndpoint=${isMikupadEndpoint}
 			cancel=${cancel}/>

--- a/mikupad.html
+++ b/mikupad.html
@@ -3387,6 +3387,52 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 		setMemoryTokens((prevMemoryTokens) => ({ ...prevMemoryTokens, [key]: value }));
 	}
 
+
+
+	const insertTemplate = (sysInst) => {
+		// most of this function is shamelessly stolen from culturedniichan's deleted pull
+		// request for a similar implementation of instruct templates:
+		// https://github.com/lmg-anon/mikupad/pull/31
+
+		const [prefix,suffix] = sysInst == "sys"
+		? [templates[selectedTemplate]?.sysPre  || "", templates[selectedTemplate]?.sysSuf  || ""]
+		: [templates[selectedTemplate]?.instPre || "", templates[selectedTemplate]?.instSuf || ""];
+		if (!(prefix || suffix))
+			return;
+
+		console.log([prefix,suffix])
+
+		const elem = promptArea.current;
+		if (!elem)
+			return;
+
+		const startPos = elem.selectionStart;
+		const endPos = elem.selectionEnd;
+		const textBefore = elem.value.substring(0, startPos) || "";
+		const textAfter = elem.value.substring(endPos);
+		const selectedText = elem.value.substring(startPos, endPos);
+
+		const finalText = textBefore 
+						+ prefix.replace(/\\n/g,'\n')
+						+ selectedText 
+						+ suffix.replace(/\\n/g,'\n')
+						+ textAfter;
+
+		elem.value = finalText;
+
+		let newCursorPos;
+		if (selectedText.length === 0) {
+			newCursorPos = startPos + prefix.length;
+		} else {
+			newCursorPos = startPos 
+				+ prefix.length
+				+ selectedText.length 
+				+ suffix.length;
+		}
+		elem.setSelectionRange(0, 2);
+		onInput({ target: elem });
+	}
+
 	// re-selecting doesn't work properly when I move this inside the InstructModal
 	const updateTemplateList = useMemo(() => {
 		const index = templateList.findIndex(obj => obj.name === selectedTemplate)
@@ -4372,13 +4418,31 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 						value=${selectedTemplate}
 						onValueChange=${setSelectedTemplate}
 						options=${templateList}/>
-						<button
-							title="Edit Instruct Templates"
-							disabled=${!!cancel}
-							class="hbox-button"
-							onClick=${() => toggleModal("instruct")}>
-							Edit
-						</button>
+					<button
+						title="Edit Instruct Templates"
+						disabled=${!!cancel}
+						class="hbox-button"
+						onClick=${() => toggleModal("instruct")}>
+						Edit
+					</button>
+				</div>
+				<div class="hbox">
+					<button
+						style=${{ 'width':'unset' }}
+						title="Insert Instruct Template"
+						disabled=${!!cancel}
+						class="hbox-button"
+						onClick=${() => insertTemplate("inst")}>
+						Insert Instruct
+					</button>
+					<button
+						style=${{ 'width':'unset' }}
+						title="Insert System Prompt Template"
+						disabled=${!!cancel}
+						class="hbox-button"
+						onClick=${() => insertTemplate("sys")}>
+						Insert System
+					</button>
 				</div>
 				<${InputBox} label="Seed (-1 = random)" type="text" inputmode="numeric"
 					readOnly=${!!cancel} value=${seed} onValueChange=${setSeed}/>

--- a/mikupad.html
+++ b/mikupad.html
@@ -2508,7 +2508,9 @@ function LogitBiasModal({ isOpen, closeModal, logitBias, setLogitBias, logitBias
 			</${Modal}>`;
 }
 
-function InstructModal({ isOpen, closeModal, sessionStorage, updateTemplateDB, newTemplateName, setNewTemplateName, selectedTemplate, setSelectedTemplate, templateList, setTemplateList, templates, templatesImport, setTemplates, addDeleteTemplate, setAddDeleteTemplate, cancel }) {
+function InstructModal({ isOpen, closeModal, sessionStorage, selectedTemplate, setSelectedTemplate, templateList, setTemplateList, templates, templatesImport, setTemplates, cancel }) {
+	const [addDeleteTemplate, setAddDeleteTemplate] = useState(false);
+	const [newTemplateName, setNewTemplateName] = useState(undefined);
 
 	function getArrObjByName(array,name,getIndex=false) {
 		const index = array.findIndex(obj => obj.name === name)
@@ -2567,7 +2569,7 @@ function InstructModal({ isOpen, closeModal, sessionStorage, updateTemplateDB, n
 		setAddDeleteTemplate(true)
 	}
 
-	const updateTemplateList = useEffect(() => {
+	useEffect(() => {
 		const index = templateList.findIndex(obj => obj.name === selectedTemplate)
 		const reselectTemplate = templateList[index == -1 ? 0 : index]?.nameNew
 		const list = []
@@ -2590,14 +2592,50 @@ function InstructModal({ isOpen, closeModal, sessionStorage, updateTemplateDB, n
 		if (reselectTemplate)
 			setSelectedTemplate(reselectTemplate)
 	}, [templates,selectedTemplate,templatesImport]);
-	const templateReselect = useEffect(() => {
+	useEffect(() => {
 		if (!addDeleteTemplate)
 			return
 		setSelectedTemplate("")
 		setAddDeleteTemplate(false)
-
 	}, [addDeleteTemplate]);
 
+	const updateTemplateDB = async () => {
+		setNewTemplateName(undefined);
+		setTemplates((prevState) => {
+			var newState = {
+				...prevState
+			}
+			for (let i=0;i<templateList.length;i++) {
+				const template = templateList[i]
+				const name = template.nameNew
+				const nameBack = template.nameBack
+
+				if (name === undefined || nameBack === undefined)
+					continue
+				// if template has been renamed, delete old entry, make sure to reselect 
+				// current entry after
+				if (name != nameBack) {
+					newState[name] = prevState[nameBack]
+					delete newState[nameBack]
+				}
+
+				// if no changes, skip
+				if (newState[name] == prevState[name])
+					continue
+
+				newState[name] = {
+					"sysPre": template.affixes.sysPre,
+					"sysSuf": template.affixes.sysSuf,
+					"instPre": template.affixes.instPre,
+					"instSuf": template.affixes.instSuf,
+				}
+			}
+			return { ...newState }
+		})
+	}
+	useEffect(() => {
+		updateTemplateDB()
+	}, [isOpen, selectedTemplate]);
 
 	const exportTemplates = () => {
 		exportText(`instruct_templates.json`, JSON.stringify(templates));
@@ -3413,8 +3451,6 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 	const sessionReconnectTimer = useRef();
 	const useScrollSmoothing = useRef(true);
 	const [templates, setTemplates] = useDBTemplates(defaultPresets.instructTemplates);
-	const [newTemplateName, setNewTemplateName] = useState(undefined);
-	const [addDeleteTemplate, setAddDeleteTemplate] = useState(false);
 	const [templatesImport, setTemplatesImport] = useState(false);
 	const [selectedTemplate, setSelectedTemplate] = useSessionState('template', "Llama 3");
 	const [chatMode, setChatMode] = useSessionState('chatMode', false);
@@ -3483,7 +3519,6 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 	}
 
 
-
 	const insertTemplate = (sysInst) => {
 		// most of this function is shamelessly stolen from culturedniichan's deleted pull
 		// request for a similar implementation of instruct templates:
@@ -3525,44 +3560,6 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 		elem.setSelectionRange(0, 2);
 		onInput({ target: elem });
 	}
-
-	const updateTemplateDB = async () => {
-		setNewTemplateName(undefined);
-		setTemplates((prevState) => {
-			var newState = {
-				...prevState
-			}
-			for (let i=0;i<templateList.length;i++) {
-				const template = templateList[i]
-				const name = template.nameNew
-				const nameBack = template.nameBack
-
-				if (name === undefined || nameBack === undefined)
-					continue
-				// if template has been renamed, delete old entry, make sure to reselect 
-				// current entry after
-				if (name != nameBack) {
-					newState[name] = prevState[nameBack]
-					delete newState[nameBack]
-				}
-
-				// if no changes, skip
-				if (newState[name] == prevState[name])
-					continue
-
-				newState[name] = {
-					"sysPre": template.affixes.sysPre,
-					"sysSuf": template.affixes.sysSuf,
-					"instPre": template.affixes.instPre,
-					"instSuf": template.affixes.instSuf,
-				}
-			}
-			return { ...newState }
-		})
-	}
-	const updateTemplateDBCaller = useEffect(() => {
-		updateTemplateDB()
-	}, [modalState["instruct"],selectedTemplate]);
 
 
 	const toggleModal = (modalKey) => {
@@ -4502,7 +4499,7 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 					<${SelectBoxTemplate}
 						label="Instruct Template"
 						disabled=${!!cancel}
-						value=${newTemplateName ?? selectedTemplate}
+						value=${selectedTemplate}
 						onValueChange=${setSelectedTemplate}
 						options=${templateList}/>
 					<button
@@ -4803,18 +4800,12 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 			closeModal=${() => closeModal("instruct")}
 			templateList=${templateList}
 			setTemplateList=${setTemplateList}
-			newTemplateName=${newTemplateName}
-			setNewTemplateName=${setNewTemplateName}
 			selectedTemplate=${selectedTemplate}
 			setSelectedTemplate=${setSelectedTemplate}
 			templatesImport=${templatesImport}
-			setTemplatesImport=${setTemplatesImport}
 			templates=${templates}
 			setTemplates=${setTemplates}
-			updateTemplateDB=${updateTemplateDB}
-			addDeleteTemplate=${addDeleteTemplate}
-			setAddDeleteTemplate=${setAddDeleteTemplate}
-			sessionStorage=${sessionStorage} endpoint=${endpoint} endpointAPI=${endpointAPI} endpointAPIKey=${endpointAPIKey} isMikupadEndpoint=${isMikupadEndpoint}
+			sessionStorage=${sessionStorage}
 			cancel=${cancel}/>
 
 		${sessionEndpointError && html`

--- a/mikupad.html
+++ b/mikupad.html
@@ -2508,7 +2508,7 @@ function LogitBiasModal({ isOpen, closeModal, logitBias, setLogitBias, logitBias
 			</${Modal}>`;
 }
 
-function InstructModal({ isOpen, closeModal, sessionStorage, selectedTemplate, setSelectedTemplate, templateList, setTemplateList, templates, templatesImport, setTemplates, cancel }) {
+function InstructModal({ isOpen, closeModal, templateStorage, selectedTemplate, setSelectedTemplate, templateList, setTemplateList, templates, templatesImport, setTemplates, cancel }) {
 	const [addDeleteTemplate, setAddDeleteTemplate] = useState(false);
 	const [newTemplateName, setNewTemplateName] = useState(undefined);
 
@@ -2644,7 +2644,7 @@ function InstructModal({ isOpen, closeModal, sessionStorage, selectedTemplate, s
 		if (importDefaults) {
 			if (!window.confirm("This will add all default templates, and overwrite any changes you made to the default templates. This action cannot be undone. Do you wish to continue?"))
 				return;
-			await sessionStorage.saveTemplates(defaultPresets.instructTemplates,true)
+			await templateStorage.saveTemplates(defaultPresets.instructTemplates,true)
 			window.location.reload()
 			// a little dirty, but updateTemplateList isn't cooperating
 			return
@@ -2664,7 +2664,7 @@ function InstructModal({ isOpen, closeModal, sessionStorage, selectedTemplate, s
 			reader.readAsText(file);
 		}
 		fileInput.func = async (text) => {
-			await sessionStorage.saveTemplates(JSON.parse(text),true)
+			await templateStorage.saveTemplates(JSON.parse(text),true)
 			window.location.reload()
 			// a little dirty, but updateTemplateList isn't cooperating
 		};
@@ -3472,7 +3472,7 @@ function usePersistentState(name, initialState) {
 	return [value, updateState];
 }
 
-export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupadEndpoint }) {
+export function App({ sessionStorage, templateStorage, useSessionState, useDBTemplates, isMikupadEndpoint }) {
 	const promptArea = useRef();
 	const promptOverlay = useRef();
 	const undoStack = useRef([]);
@@ -4836,7 +4836,7 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 			templatesImport=${templatesImport}
 			templates=${templates}
 			setTemplates=${setTemplates}
-			sessionStorage=${sessionStorage}
+			templateStorage=${templateStorage}
 			cancel=${cancel}/>
 
 		${sessionEndpointError && html`
@@ -4874,6 +4874,7 @@ async function main() {
 	createRoot(document.body).render(html`
 		<${App}
 			sessionStorage=${sessionStorage}
+			templateStorage=${templateStorage}
 			useSessionState=${(name, initialState) => useSessionState(sessionStorage, name, initialState)}
 			useDBTemplates=${(initialState => useDBTemplates(templateStorage, initialState))}
 			isMikupadEndpoint=${isMikupadEndpoint}/>`);

--- a/mikupad.html
+++ b/mikupad.html
@@ -819,6 +819,13 @@ button.completing {
 	height: 100%;
 }
 
+.instructTemplateSidebar > .SelectBox {
+	width: 100%;
+}
+.instructTemplateSidebar > .hbox-button {
+	width: min-content;
+}
+
 .collapsible-group {
 	border: none;
 	outline: none;
@@ -1611,9 +1618,23 @@ function SelectBox({ label, value, onValueChange, options, ...props }) {
 				value=${value}
 				onChange=${({ target }) => onValueChange(JSON.parse(target.value))}
 				...${props}>
-				${options.map(o => html`<option
+				${(options = typeof options === 'function' ? options() : options).map(o => html`<option
 					key=${JSON.stringify(o.value)}
 					value=${JSON.stringify(o.value)}>${o.name}</option>`)}
+			</select>
+		</label>`;
+}
+function SelectBoxTemplate({ label, value, onValueChange, options, ...props }) {
+	return html`
+		<label className="SelectBox">
+			${label}
+			<select
+				value=${value}
+				onChange=${({ target }) => onValueChange(JSON.parse(JSON.stringify(target.value)))}
+				...${props}>
+				${(options = typeof options === 'function' ? options() : options).map(o => html`<option
+					key=${JSON.stringify(o.value)}
+					value=${o.value}>${o.name}</option>`)}
 			</select>
 		</label>`;
 }
@@ -2460,13 +2481,90 @@ function LogitBiasModal({ isOpen, closeModal, logitBias, setLogitBias, logitBias
 			</${Modal}>`;
 }
 
-class TemplateStorage {
-	constructor() {
-		this.templates = new Map();
-		this.nextId = 1;
-		this.selectedTemplate = 1;
-		this.initial = 1;
-	}
+function InstructModal({ isOpen, closeModal, sessionStorage, selectedTemplate, setSelectedTemplate, handleInstructTemplateChange, handleInstructTemplateDelete, getArrObjByName, templateList, cancel }) {
+	// if (typeof templateList[selectedTemplate] === 'undefined') {
+	// 	console.log("instruct modal now")
+	// 	setSelectedTemplate(0)
+	// }
+	return getArrObjByName(templateList,selectedTemplate) && html`
+		<${Modal} isOpen=${isOpen} onClose=${closeModal}
+			title="Instruct Templates"
+			description="Use placeholders to replace with the selected instruct template format when sending your prompt to the llm.
+			Changes are saved on exiting the modal.">
+			<div className="buttons instructTemplateSidebar">
+				<${SelectBoxTemplate}
+					id="instructModalSelect"
+					label="Instruct Template"
+					value=${selectedTemplate}
+					onValueChange=${setSelectedTemplate}
+					options=${templateList}/>
+					<button
+						title="Add Instruct Template"
+						disabled=${!!cancel}
+						class="hbox-button"
+						onClick=${() => toggleModal("instruct")}>
+						New
+					</button>
+					<button
+						title="Delete Selected Instruct Template"
+						disabled=${!!cancel}
+						class="hbox-button"
+						onClick=${() => handleInstructTemplateDelete(selectedTemplate)}>
+						Delete
+					</button>
+			</div>
+			<hr/>
+			<${InputBox} label="Name"
+					placeholder="Name of This Template"
+					className=""
+					tooltip=""
+					readOnly=${!!cancel}
+					value=${getArrObjByName(templateList,selectedTemplate).nameNew}
+					onInput=${e => handleInstructTemplateChange(selectedTemplate,"name",e.target.value,getArrObjByName(templateList,selectedTemplate).nameBack)}
+					onValueChange=${() => {}}/>
+			
+			<div className="hbox">
+				<${InputBox} label="Instruct Prefix"
+					placeholder="[INST]"
+					className=""
+					tooltip=""
+					readOnly=${!!cancel}
+					value=${getArrObjByName(templateList,selectedTemplate).affixes.instPre}
+					onInput=${e => handleInstructTemplateChange(selectedTemplate,"instPre",e.target.value)}
+					onValueChange=${() => {}}/>
+
+					<${InputBox} label="Instruct Suffix"
+					placeholder="[/INST]"
+					className=""
+					tooltip=""
+					readOnly=${!!cancel}
+					value=${getArrObjByName(templateList,selectedTemplate).affixes.instSuf}
+					onInput=${e => handleInstructTemplateChange(selectedTemplate,"instSuf",e.target.value)}
+					onValueChange=${() => {}}/>
+			</div>
+
+			<div className="hbox">
+				<${InputBox} label="System Prompt Prefix"
+					placeholder="<<SYS>>"
+					className=""
+					tooltip=""
+					readOnly=${!!cancel}
+					value=${getArrObjByName(templateList,selectedTemplate).affixes.sysPre}
+					onInput=${e => handleInstructTemplateChange(selectedTemplate,"sysPre",e.target.value)}
+					onValueChange=${() => {}}/>
+
+					<${InputBox} label="System Prompt Suffix"
+					placeholder="<</SYS>>"
+					className=""
+					tooltip=""
+					readOnly=${!!cancel}
+					value=${getArrObjByName(templateList,selectedTemplate).affixes.sysSuf}
+					onInput=${e => handleInstructTemplateChange(selectedTemplate,"sysSuf",e.target.value)}
+					onValueChange=${() => {}}/>
+			</div>
+
+
+		</${Modal}>`;
 }
 
 class SessionStorage extends EventTarget {
@@ -2552,7 +2650,6 @@ class SessionStorage extends EventTarget {
 	}
 
 	async loadFromDatabase(db, key, storeName = this.storeNames[0]) {
-		console.log("load")
 		return new Promise((resolve, reject) => {
 			const tx = db.transaction(storeName, 'readonly');
 			const store = tx.objectStore(storeName);
@@ -2564,7 +2661,6 @@ class SessionStorage extends EventTarget {
 	}
 
 	async saveToDatabase(key, data, storeName = this.storeNames[0]) {
-		console.log("save")
 		const db = await this.openDatabase();
 		return new Promise((resolve, reject) => {
 			const tx = db.transaction(storeName, 'readwrite');
@@ -2576,21 +2672,41 @@ class SessionStorage extends EventTarget {
 		});
 	}
 	async saveTemplates(newTemplates) {
-		console.log("save templates")
 		const db = await this.openDatabase();
 		return new Promise((resolve, reject) => {
 			const tx = db.transaction('Templates', 'readwrite');
 			const store = tx.objectStore('Templates');
+
+			const request = store.getAllKeys();
+			request.onsuccess = function(event) {
+			const DBkeys = event.target.result;
+
+			// Check if the keys exists in input, if not, delete
+			//console.log(DBkeys,Object.keys(newTemplates))
+			DBkeys.forEach(key => {
+				if ( !(Object.keys(newTemplates).includes(key)) ) {
+					console.log(key,"NOT input")
+					// If the key not in input, delete it
+					const deleteRequest = store.delete(key);
+					deleteRequest.onsuccess = function(event) {
+						console.log('Deleted key:', key);
+					}
+					deleteRequest.onerror = function(event) {
+						console.error('Error deleting key:', key);
+					}
+				}
+			});
+
+			// put input keys
 			for (const [key, value] of Object.entries(newTemplates)) {
 				// if (this.templates[key] === value)
 				// 	continue
-				console.log("storing",key,value)
-				let request = store.put(value, key);
+				const request = store.put(value, key);
 				request.onsuccess = () => resolve();
 				request.onerror = () => reject(request.error);
 			}
 
-
+		}
 		});
 	}
 
@@ -2663,7 +2779,6 @@ class SessionStorage extends EventTarget {
 				// this.templates = { ...cursor }
 				// console.log(this.templates)
 				if (cursor) {
-					console.log("cursor",cursor)
 					this.templates[cursor.key] = cursor.value;
 					cursor.continue();
 				} else {
@@ -2951,6 +3066,21 @@ const defaultPresets = {
 		"suffix": ""
 	}),
 	logitBias:{ bias:{},model:"none" },
+	instructTemplates:{
+		'Mistral': {
+			'sysPre': '<<SYS>>',
+			'sysSuf': '<</SYS>>\n\n',
+			'instPre': '[INST]',
+			'instSuf': '[/INST]',
+		},
+		'LLama 3': {
+			'sysPre': '<<llama>>',
+			'sysSuf': '<</llama>>',
+			'instPre': '[llama]',
+			'instSuf': '[/llama]',
+		},
+
+	},
 	scrollTop: 0
 };
 
@@ -3011,7 +3141,6 @@ function useSessionState(sessionStorage, name, initialState) {
 }
 
 function useDBTemplates(sessionStorage,initialState) {
-	console.log("ss in function",sessionStorage)
 	const savedState = useMemo(() => {
 		try {
 			return sessionStorage.templates;
@@ -3023,8 +3152,6 @@ function useDBTemplates(sessionStorage,initialState) {
 	
 
 	const [value, setValue] = useState(Object.keys(savedState).length === 0 ? initialState : savedState);
-	console.log(savedState,initialState,value)
-	console.log()
 
 	// useEffect(() => {
 	// 	function deepCopy(value) {
@@ -3076,7 +3203,6 @@ function usePersistentState(name, initialState) {
 }
 
 export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupadEndpoint }) {
-	console.log("app",arguments)
 	const promptArea = useRef();
 	const promptOverlay = useRef();
 	const undoStack = useRef([]);
@@ -3085,7 +3211,10 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 	const keyState = useRef({});
 	const sessionReconnectTimer = useRef();
 	const useScrollSmoothing = useRef(true);
-	const [templates, setTemplates] = useDBTemplates({"stuff":"here"});
+	const [templates, setTemplates] = useDBTemplates(defaultPresets.instructTemplates);
+	const [selectedTemplate, setSelectedTemplate] = usePersistentState('template', "LLama 3");
+	const [triggerTemplateDBUpdate, setTriggerTemplateDBUpdate] = useState(false);
+	const [templateList, setTemplateList] = useState([]);
 	const [currentPromptChunk, setCurrentPromptChunk] = useState(undefined);
 	const [undoHovered, setUndoHovered] = useState(false);
 	const [showProbs, setShowProbs] = useState(true);
@@ -3143,7 +3272,13 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 
 
 
-	console.log("read templates in app",templates)
+	function getArrObjByName(array,name,getIndex=false) {
+		const index = array.findIndex(obj => obj.name === name)
+		if (getIndex)
+			return index
+		return array[index == -1 ? 0 : index];
+	}
+	//console.log("read templates in app",templates)
 	// AN and Memory
 	function handleauthorNoteTokensChange(key,value) {
 		setAuthorNoteTokens((prevauthorNoteTokens) => ({ ...prevauthorNoteTokens, [key]: value }));
@@ -3151,6 +3286,130 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 	function handleMemoryTokensChange(key,value) {
 		setMemoryTokens((prevMemoryTokens) => ({ ...prevMemoryTokens, [key]: value }));
 	}
+
+	// re-select the correct index in case renaming changes order of array
+	// const reselectInstructTemplate = async (target) => {
+	// 	setSelectedTemplate(targetIndex)
+	// };
+	const updateTemplateList = useMemo(() => {
+		//var selectedTemplateName = templateList[selectedTemplate]?.name
+		
+		// console.log("selectedTemplateName",selectedTemplate,selectedTemplate)
+
+
+		const index = templateList.findIndex(obj => obj.name === selectedTemplate)
+		console.log(index)
+		const reselectTemplate = templateList[index == -1 ? 0 : index]?.nameNew
+
+
+		console.log("old",selectedTemplate,"new",reselectTemplate)
+
+		const list = []
+		let i = 0;
+		
+		// there has to be a more elegant way to do this
+		for (const key in templates) {
+			list.push({
+				name: key,
+				nameNew:key,
+				value: key,
+				nameBack: key,
+				affixes: templates[key]
+			})
+		}
+		list.sort((a, b) => {
+			var nameA = a.name.toLowerCase();
+			var nameB = b.name.toLowerCase();
+			return (nameA < nameB) ? -1 : (nameA > nameB) ? 1 : 0;
+		});
+
+		//console.log("templateList",list,selectedTemplate)
+		setTemplateList(list)
+		//console.log("selectedTemplateName",selectedTemplate)
+		// using templateList, get the newName before updating, then feed it here?
+		if (reselectTemplate)
+			setSelectedTemplate(reselectTemplate)
+	}, [templates,selectedTemplate]);
+
+	const debugAlt = useMemo(() => {
+		console.log(selectedTemplate)
+	}, [templates,selectedTemplate]);
+
+	function handleInstructTemplateChange(templateName,key,value,back="") {
+		
+		const templateListMod = templateList
+		const tempIndex = templateListMod.findIndex(obj => obj.name === templateName);
+		const index = tempIndex < 0 ? 0 : tempIndex;
+
+		console.log("change object",index,templateListMod[index])
+
+		if (key == "name") { //&& value != templateList[index].nameBack) {
+			// console.log("rename",templateList[index].nameBack,"to",value)
+			// console.log({[value]: templates[templateList[index].nameBack]})
+			// console.log("old",templateList[index].name)
+			templateListMod[index].nameNew = value
+		} else {
+			templateListMod[index].affixes[key] = value
+		}
+		setTemplateList((prevState) => ([
+			...templateListMod
+		]))
+	}
+	
+	function handleInstructTemplateDelete(entry) {
+		if (!window.confirm("Are you sure you want to delete this template? This action can't be undone."))
+			return;
+		const templateListMod = templateList
+		templateListMod.splice(templateListMod.findIndex(obj => obj.name === entry),1)
+
+		setTemplateList((prevState) => ([
+			...templateListMod
+		]))
+		setTriggerTemplateDBUpdate((prevState) => (!prevState))
+
+		setSelectedTemplate(templateListMod[0].name)
+	}
+
+	const updateTemplateDB = useMemo(() => {
+		console.warn("instruct modal",modalState["instruct"])
+
+		setTemplates((prevState) => {
+			var newState = {
+				...prevState
+			}
+			for (let i=0;i<templateList.length;i++) {
+				const template = templateList[i]
+				const name = template.nameNew
+				const nameBack = template.nameBack
+
+				if (name === undefined || nameBack === undefined)
+					continue
+
+				// if template has been renamed, delete old entry, make sure to reselect 
+				// current entry after
+				if (name != nameBack) {
+					console.log("RENAME SHIT")
+					newState[name] = prevState[nameBack]
+					console.log("delete",newState[nameBack])
+					delete newState[nameBack]
+					console.log("newstate",newState)
+				}
+
+				// if no changes, skip
+				if (newState[name] == prevState[name])
+					continue
+
+				newState[name] = {
+					"sysPre": template.affixes.sysPre,
+					"sysSuf": template.affixes.sysSuf,
+					"instPre": template.affixes.instPre,
+					"instSuf": template.affixes.instSuf,
+				}
+			}
+			// console.log("newstate",newState)
+			return { ...newState }
+		})
+	}, [modalState["instruct"],triggerTemplateDBUpdate]);
 	
 	const toggleModal = (modalKey) => {
 		setModalState((prevState) => ({
@@ -4059,6 +4318,20 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 						readOnly=${!!cancel}
 						value=${endpointModel}
 						onValueChange=${setEndpointModel}/>`}
+				<div className="buttons instructTemplateSidebar">
+					<${SelectBoxTemplate}
+						label="Instruct Template"
+						value=${selectedTemplate}
+						onValueChange=${setSelectedTemplate}
+						options=${templateList}/>
+						<button
+							title="Edit Instruct Templates"
+							disabled=${!!cancel}
+							class="hbox-button"
+							onClick=${() => toggleModal("instruct")}>
+							edit
+						</button>
+				</div>
 				<${InputBox} label="Seed (-1 = random)" type="text" inputmode="numeric"
 					readOnly=${!!cancel} value=${seed} onValueChange=${setSeed}/>
 				<${InputBox} tooltip="Currently not accurate to the token count, it will be used as an estimate." label="Max Context Length" type="text" inputmode="numeric"
@@ -4258,7 +4531,7 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 			</button>
 			<button
 				title=""
-				className=${cancel}
+				className="${cancel}"
 				disabled=${!!cancel || stoppingStringsError}
 				onClick=${() => logss()}>
 				log session storage
@@ -4339,6 +4612,19 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 			setLogitBias=${setLogitBias}
 			logitBiasParam=${logitBiasParam}
 			setLogitBiasParam=${setLogitBiasParam}
+			sessionStorage=${sessionStorage} endpoint=${endpoint} endpointAPI=${endpointAPI} endpointAPIKey=${endpointAPIKey} isMikupadEndpoint=${isMikupadEndpoint}
+			cancel=${cancel}/>
+		
+		<!-- You haven't seen shit yet -->
+		<${InstructModal}
+			isOpen=${modalState.instruct}
+			closeModal=${() => closeModal("instruct")}
+			templateList=${templateList}
+			selectedTemplate=${selectedTemplate}
+			setSelectedTemplate=${setSelectedTemplate}
+			handleInstructTemplateChange=${handleInstructTemplateChange}
+			handleInstructTemplateDelete=${handleInstructTemplateDelete}
+			getArrObjByName=${getArrObjByName}
 			sessionStorage=${sessionStorage} endpoint=${endpoint} endpointAPI=${endpointAPI} endpointAPIKey=${endpointAPIKey} isMikupadEndpoint=${isMikupadEndpoint}
 			cancel=${cancel}/>
 

--- a/mikupad.html
+++ b/mikupad.html
@@ -2567,7 +2567,6 @@ function InstructModal({ isOpen, closeModal, sessionStorage, updateTemplateDB, n
 		setAddDeleteTemplate(true)
 	}
 
-	// re-selecting doesn't work properly when I move this inside the InstructModal
 	const updateTemplateList = useEffect(() => {
 		const index = templateList.findIndex(obj => obj.name === selectedTemplate)
 		const reselectTemplate = templateList[index == -1 ? 0 : index]?.nameNew

--- a/mikupad.html
+++ b/mikupad.html
@@ -831,7 +831,7 @@ button.completing {
 	width: 100%;
 }
 .instructTemplateSidebar > .hbox-button {
-	width: min-content;
+	min-width: max-content;
 }
 
 .collapsible-group {
@@ -2553,7 +2553,15 @@ function InstructModal({ isOpen, closeModal, sessionStorage, updateTemplateDB, s
 	const exportTemplates = () => {
 		exportText(`instruct_templates.json`, JSON.stringify(templates));
 	};
-	const importTemplates = async () => {
+	const importTemplates = async (importDefaults=false) => {
+		if (importDefaults) {
+			if (!window.confirm("This will add all default templates, and overwrite any changes you made to the default templates. This action cannot be undone. Do you wish to continue?"))
+				return;
+			await sessionStorage.saveTemplates(defaultPresets.instructTemplates,true)
+			window.location.reload()
+			// a little dirty, but updateTemplateList isn't cooperating
+			return
+		}
 		const fileInput = document.createElement("input");
 		fileInput.type = 'file';
 		fileInput.style.display = 'none';
@@ -2642,6 +2650,13 @@ function InstructModal({ isOpen, closeModal, sessionStorage, updateTemplateDB, s
 						class="hbox-button"
 						onClick=${() => exportTemplates()}>
 						Export
+					</button>
+					<button
+						title="Re-add defaults"
+						disabled=${!!cancel}
+						class="hbox-button"
+						onClick=${() => importTemplates(true)}>
+						Add Defaults
 					</button>
 			</div>
 			<hr/>
@@ -3222,15 +3237,15 @@ const defaultPresets = {
 		},
 		'Vicuna': {
 			'sysPre' : '',
-			'sysSuf' : '\n\n',
+			'sysSuf' : '\\n\\n',
 			'instPre': 'USER: ',
-			'instSuf': '\nASSISTANT: ',
+			'instSuf': '\\nASSISTANT: ',
 		},
 		'Gemma': {
 			'sysPre' : '',
 			'sysSuf' : '',
-			'instPre': '<start_of_turn>user\n',
-			'instSuf': '\n<end_of_turn><start_of_turn>model\n',
+			'instPre': '<start_of_turn>user\\n',
+			'instSuf': '\\n<end_of_turn><start_of_turn>model\\n',
 		},
 	},
 	scrollTop: 0

--- a/mikupad.html
+++ b/mikupad.html
@@ -571,6 +571,14 @@ html.nockoffAI .wi-entry-name input {
 	gap: 8px;
 }
 
+#instructmodal-name {
+	
+	size:110%;
+}
+.instructmodal-edits .hbox {
+	margin-top:8px;
+}
+
 
 
 
@@ -2481,16 +2489,158 @@ function LogitBiasModal({ isOpen, closeModal, logitBias, setLogitBias, logitBias
 			</${Modal}>`;
 }
 
-function InstructModal({ isOpen, closeModal, sessionStorage, selectedTemplate, setSelectedTemplate, handleInstructTemplateChange, handleInstructTemplateDelete, getArrObjByName, templateList, cancel }) {
-	// if (typeof templateList[selectedTemplate] === 'undefined') {
-	// 	console.log("instruct modal now")
-	// 	setSelectedTemplate(0)
-	// }
+function InstructModal({ isOpen, closeModal, sessionStorage, selectedTemplate, setSelectedTemplate, templateList, setTemplateList, templates, setTemplates, addDeleteTemplate, setAddDeleteTemplate, updateTemplateDB, cancel }) {
+	
+	function getArrObjByName(array,name,getIndex=false) {
+		const index = array.findIndex(obj => obj.name === name)
+		if (getIndex)
+			return index
+		return array[index == -1 ? 0 : index];
+	}
+
+	const templateReselect = useMemo(() => {
+		if (!addDeleteTemplate)
+			return
+		setSelectedTemplate("")
+		setAddDeleteTemplate(false)
+	}, [addDeleteTemplate]);
+
+	const updateTemplateList = useMemo(() => {
+		const index = templateList.findIndex(obj => obj.name === selectedTemplate)
+		const reselectTemplate = templateList[index == -1 ? 0 : index]?.nameNew
+		const list = []
+		let i = 0;
+		for (const key in templates) {
+			list.push({
+				name: key,
+				nameNew:key,
+				value: key,
+				nameBack: key,
+				affixes: templates[key]
+			})
+		}
+		list.sort((a, b) => {
+			var nameA = a.name.toLowerCase();
+			var nameB = b.name.toLowerCase();
+			return (nameA < nameB) ? -1 : (nameA > nameB) ? 1 : 0;
+		});
+		setTemplateList(list)
+		if (reselectTemplate)
+			setSelectedTemplate(reselectTemplate)
+	}, [templates,selectedTemplate]);
+
+	function handleInstructTemplateChange(templateName,key,value,back="") {
+		
+		const templateListMod = templateList
+		const tempIndex = templateListMod.findIndex(obj => obj.name === templateName);
+		const index = tempIndex < 0 ? 0 : tempIndex;
+
+		console.log("change object",index,templateListMod[index])
+
+		if (key == "name") { 
+			templateListMod[index].nameNew = value
+		} else {
+			templateListMod[index].affixes[key] = value
+		}
+		setTemplateList((prevState) => ([
+			...templateListMod
+		]))
+	}
+
+	async function handleInstructTemplateAdd() {
+		await updateTemplateDB()
+		setTemplates((prevState) => {
+			var newState = {
+				...prevState
+			}
+			newState[""] = {
+				"sysPre": "",
+				"sysSuf": "",
+				"instPre": "",
+				"instSuf": "",
+			}
+			
+			return { ...newState }
+		})
+		setAddDeleteTemplate(true)
+	}
+
+	async function handleInstructTemplateDelete(name) {
+		console.log(Object.keys(templates).length)
+		if (Object.keys(templates).length < 2)
+			return
+		if (!window.confirm("Are you sure you want to delete this template? This action can't be undone."))
+			return;
+
+		console.warn("Deleting Template",name,":",templates[name])
+		setTemplates((prevState) => {
+			var newState = {
+				...prevState
+			}
+			delete newState[name]
+			return { ...newState }
+		})
+		setAddDeleteTemplate(true)
+	}
+
+
+	const exportTemplates = () => {
+		exportText(`instruct_templates.json`, JSON.stringify(templates));
+	};
+	const importTemplates = async () => {
+		const fileInput = document.createElement("input");
+		fileInput.type = 'file';
+		fileInput.style.display = 'none';
+		fileInput.onchange = (e) => {
+			const file = e.target.files[0];
+			if (!file)
+				return;
+			const reader = new FileReader();
+			reader.onload = (e) => {
+				const contents = e.target.result;
+				fileInput.func(contents);
+			}
+			reader.readAsText(file);
+		}
+		fileInput.func = async (text) => {
+			await sessionStorage.saveTemplates(JSON.parse(text),true)
+			window.location.reload()
+			// a little dirty, but updateTemplateList isn't cooperating
+		};
+		document.body.appendChild(fileInput);
+		fileInput.click();
+		document.body.removeChild(fileInput);
+	};
+	
 	return getArrObjByName(templateList,selectedTemplate) && html`
 		<${Modal} isOpen=${isOpen} onClose=${closeModal}
 			title="Instruct Templates"
-			description="Use placeholders to replace with the selected instruct template format when sending your prompt to the llm.
-			Changes are saved on exiting the modal.">
+			description="Use placeholders to insert the selected prompt template formats when sending your prompt to the model.
+			Placeholders are listed below. You can insert newlines with '\\n'.">
+			<div id="advancedContextPlaceholders">
+				<table border="1" frame="void" rules="all">
+					<thead>
+					<tr>
+						<th></th>
+						<th>Prefix</th>
+						<th>Suffix</th>
+					</tr>
+					</thead>
+					<tbody>
+					<tr>
+						<th>System Prompt</th>
+						<td>{sys}</td>
+						<td>{/sys}</td>
+					</tr>
+					<tr>
+						<th>Instructions</th>
+						<td>{inst}</td>
+						<td>{/inst}</td>
+					</tr>
+					</tbody>
+				</table>
+			</div>
+			<hr/>
 			<div className="buttons instructTemplateSidebar">
 				<${SelectBoxTemplate}
 					id="instructModalSelect"
@@ -2502,7 +2652,7 @@ function InstructModal({ isOpen, closeModal, sessionStorage, selectedTemplate, s
 						title="Add Instruct Template"
 						disabled=${!!cancel}
 						class="hbox-button"
-						onClick=${() => toggleModal("instruct")}>
+						onClick=${() => handleInstructTemplateAdd()}>
 						New
 					</button>
 					<button
@@ -2512,55 +2662,74 @@ function InstructModal({ isOpen, closeModal, sessionStorage, selectedTemplate, s
 						onClick=${() => handleInstructTemplateDelete(selectedTemplate)}>
 						Delete
 					</button>
+					<button
+						title="Import Instruct Templates"
+						disabled=${!!cancel}
+						class="hbox-button"
+						onClick=${() => importTemplates()}>
+						Import
+					</button>
+					<button
+						title="Export Instruct Template"
+						disabled=${!!cancel}
+						class="hbox-button"
+						onClick=${() => exportTemplates()}>
+						Export
+					</button>
 			</div>
 			<hr/>
-			<${InputBox} label="Name"
-					placeholder="Name of This Template"
-					className=""
-					tooltip=""
-					readOnly=${!!cancel}
-					value=${getArrObjByName(templateList,selectedTemplate).nameNew}
-					onInput=${e => handleInstructTemplateChange(selectedTemplate,"name",e.target.value,getArrObjByName(templateList,selectedTemplate).nameBack)}
-					onValueChange=${() => {}}/>
-			
-			<div className="hbox">
-				<${InputBox} label="Instruct Prefix"
-					placeholder="[INST]"
-					className=""
-					tooltip=""
-					readOnly=${!!cancel}
-					value=${getArrObjByName(templateList,selectedTemplate).affixes.instPre}
-					onInput=${e => handleInstructTemplateChange(selectedTemplate,"instPre",e.target.value)}
-					onValueChange=${() => {}}/>
+			<div class="instructmodal-edits">
+				<${InputBox} label="Name"
+						placeholder="Name of This Template"
+						id="instructmodal-name"
+						className=""
+						tooltip=""
+						readOnly=${!!cancel}
+						value=${getArrObjByName(templateList,selectedTemplate).nameNew}
+						onInput=${e => handleInstructTemplateChange(selectedTemplate,"name",e.target.value,getArrObjByName(templateList,selectedTemplate).nameBack)}
+						onValueChange=${() => {}}/>
+				
+				
 
-					<${InputBox} label="Instruct Suffix"
-					placeholder="[/INST]"
-					className=""
-					tooltip=""
-					readOnly=${!!cancel}
-					value=${getArrObjByName(templateList,selectedTemplate).affixes.instSuf}
-					onInput=${e => handleInstructTemplateChange(selectedTemplate,"instSuf",e.target.value)}
-					onValueChange=${() => {}}/>
-			</div>
+				<div className="hbox">
+					<${InputBox} label="Instruct Prefix {inst}"
+						placeholder="[INST]"
+						className=""
+						tooltip=""
+						readOnly=${!!cancel}
+						value=${getArrObjByName(templateList,selectedTemplate)?.affixes.instPre || ""}
+						onInput=${e => handleInstructTemplateChange(selectedTemplate,"instPre",e.target.value)}
+						onValueChange=${() => {}}/>
 
-			<div className="hbox">
-				<${InputBox} label="System Prompt Prefix"
-					placeholder="<<SYS>>"
-					className=""
-					tooltip=""
-					readOnly=${!!cancel}
-					value=${getArrObjByName(templateList,selectedTemplate).affixes.sysPre}
-					onInput=${e => handleInstructTemplateChange(selectedTemplate,"sysPre",e.target.value)}
-					onValueChange=${() => {}}/>
+						<${InputBox} label="Instruct Suffix {/inst}"
+						placeholder="[/INST]"
+						className=""
+						tooltip=""
+						readOnly=${!!cancel}
+						value=${getArrObjByName(templateList,selectedTemplate)?.affixes.instSuf || ""}
+						onInput=${e => handleInstructTemplateChange(selectedTemplate,"instSuf",e.target.value)}
+						onValueChange=${() => {}}/>
+				</div>
 
-					<${InputBox} label="System Prompt Suffix"
-					placeholder="<</SYS>>"
-					className=""
-					tooltip=""
-					readOnly=${!!cancel}
-					value=${getArrObjByName(templateList,selectedTemplate).affixes.sysSuf}
-					onInput=${e => handleInstructTemplateChange(selectedTemplate,"sysSuf",e.target.value)}
-					onValueChange=${() => {}}/>
+				<div className="hbox">
+					<${InputBox} label="System Prompt Prefix {sys}"
+						placeholder="<<SYS>>\n"
+						className=""
+						tooltip=""
+						readOnly=${!!cancel}
+						value=${getArrObjByName(templateList,selectedTemplate)?.affixes.sysPre || ""}
+						onInput=${e => handleInstructTemplateChange(selectedTemplate,"sysPre",e.target.value)}
+						onValueChange=${() => {}}/>
+
+						<${InputBox} label="System Prompt Suffix {/sys}"
+						placeholder="<</SYS>>\n\n"
+						className=""
+						tooltip=""
+						readOnly=${!!cancel}
+						value=${getArrObjByName(templateList,selectedTemplate)?.affixes.sysSuf || ""}
+						onInput=${e => handleInstructTemplateChange(selectedTemplate,"sysSuf",e.target.value)}
+						onValueChange=${() => {}}/>
+				</div>
 			</div>
 
 
@@ -2586,14 +2755,6 @@ class SessionStorage extends EventTarget {
 
 	dispatchSessionChangeEvent() {
 		this.dispatchEvent(new CustomEvent('sessionchange'));
-	}
-
-	dispatchTemplateChangeEvent() {
-		this.dispatchEvent(new CustomEvent('templatechange'));
-	}
-
-	dispatchTemplateRenameEvent() {
-		this.dispatchEvent(new CustomEvent('templaterename'));
 	}
 
 	dispatchErrorEvent(detail) {
@@ -2671,7 +2832,7 @@ class SessionStorage extends EventTarget {
 			request.onerror = () => reject(request.error);
 		});
 	}
-	async saveTemplates(newTemplates) {
+	async saveTemplates(newTemplates,writeOnly=false) {
 		const db = await this.openDatabase();
 		return new Promise((resolve, reject) => {
 			const tx = db.transaction('Templates', 'readwrite');
@@ -2682,10 +2843,11 @@ class SessionStorage extends EventTarget {
 			const DBkeys = event.target.result;
 
 			// Check if the keys exists in input, if not, delete
-			//console.log(DBkeys,Object.keys(newTemplates))
+			console.log(DBkeys,Object.keys(newTemplates))
 			DBkeys.forEach(key => {
 				if ( !(Object.keys(newTemplates).includes(key)) ) {
-					console.log(key,"NOT input")
+					if (writeOnly)
+						return
 					// If the key not in input, delete it
 					const deleteRequest = store.delete(key);
 					deleteRequest.onsuccess = function(event) {
@@ -2775,19 +2937,10 @@ class SessionStorage extends EventTarget {
 
 			request.onsuccess = async (event) => {
 				const cursor = event.target.result;
-				// console.log("get all",cursor)
-				// this.templates = { ...cursor }
-				// console.log(this.templates)
 				if (cursor) {
 					this.templates[cursor.key] = cursor.value;
 					cursor.continue();
 				} else {
-					if (Object.keys(this.templates).length === 0) {
-						// if (!await this.migrateSessions()) {
-						// 	await this.createSession('MikuPad #1');
-						// }
-					}
-					// await this.switchSession(this.selectedSession);
 					resolve();
 				}
 			};
@@ -3067,19 +3220,30 @@ const defaultPresets = {
 	}),
 	logitBias:{ bias:{},model:"none" },
 	instructTemplates:{
-		'Mistral': {
-			'sysPre': '<<SYS>>',
-			'sysSuf': '<</SYS>>\n\n',
+		'Alpaca': {
+			'sysPre' : '### System:\\n',
+			'sysSuf' : '\\n\\n',
+			'instPre': '### Instruction:\\n',
+			'instSuf': '\\n\\n### Response:',
+		},
+		'Mixtral': {
+			'sysPre' : '<<SYS>>\\n',
+			'sysSuf' : '<</SYS>>\\n\\n',
 			'instPre': '[INST]',
 			'instSuf': '[/INST]',
 		},
-		'LLama 3': {
-			'sysPre': '<<llama>>',
-			'sysSuf': '<</llama>>',
-			'instPre': '[llama]',
-			'instSuf': '[/llama]',
+		'ChatML': {
+			'sysPre' : '<|im_start|>system\\n',
+			'sysSuf' : '<|im_end|>\\n',
+			'instPre': '<|im_start|>user\\n',
+			'instSuf': '<|im_end|>\\n<|im_start|>assistant\\n',
 		},
-
+		'Llama 3': {
+			'sysPre' : '<|begin_of_text|><|start_header_id|>system<|end_header_id|>\\n\\n',
+			'sysSuf' : '<|eot_id|>',
+			'instPre': '<|start_header_id|>user<|end_header_id|>\\n\\n',
+			'instSuf': '<|eot_id|><|start_header_id|>assistant<|end_header_id|>\\n\\n',
+		},
 	},
 	scrollTop: 0
 };
@@ -3149,28 +3313,13 @@ function useDBTemplates(sessionStorage,initialState) {
 			return null;
 		}
 	}, []);
-	
 
 	const [value, setValue] = useState(Object.keys(savedState).length === 0 ? initialState : savedState);
-
-	// useEffect(() => {
-	// 	function deepCopy(value) {
-	// 		return JSON.parse(JSON.stringify(value));
-	// 	}
-	// 	function onSessionChange() {
-	// 		setValue(sessionStorage.templates ?? deepCopy(initialState));
-	// 	}
-
-	// 	sessionStorage.addEventListener('templatechange', onSessionChange);
-	// 	return () => sessionStorage.removeEventListener('templatechange', onSessionChange);
-	// }, []);
 
 	const updateState = (newValue) => {
 		setValue((prevValue) => {
 			const updatedValue = typeof newValue === 'function' ? newValue(prevValue) : newValue;
 			sessionStorage.templates = updatedValue;
-			// replace with put?
-			//sessionStorage.saveToDatabase(key,newValue,'Templates')
 			sessionStorage.saveTemplates(updatedValue)
 			return updatedValue;
 		});
@@ -3212,7 +3361,9 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 	const sessionReconnectTimer = useRef();
 	const useScrollSmoothing = useRef(true);
 	const [templates, setTemplates] = useDBTemplates(defaultPresets.instructTemplates);
-	const [selectedTemplate, setSelectedTemplate] = usePersistentState('template', "LLama 3");
+	const [addDeleteTemplate, setAddDeleteTemplate] = useState(false);
+	const [templatesImport, setTemplatesImport] = useState(false);
+	const [selectedTemplate, setSelectedTemplate] = usePersistentState('template', "Llama 3");
 	const [triggerTemplateDBUpdate, setTriggerTemplateDBUpdate] = useState(false);
 	const [templateList, setTemplateList] = useState([]);
 	const [currentPromptChunk, setCurrentPromptChunk] = useState(undefined);
@@ -3272,13 +3423,8 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 
 
 
-	function getArrObjByName(array,name,getIndex=false) {
-		const index = array.findIndex(obj => obj.name === name)
-		if (getIndex)
-			return index
-		return array[index == -1 ? 0 : index];
-	}
-	//console.log("read templates in app",templates)
+	
+
 	// AN and Memory
 	function handleauthorNoteTokensChange(key,value) {
 		setAuthorNoteTokens((prevauthorNoteTokens) => ({ ...prevauthorNoteTokens, [key]: value }));
@@ -3287,92 +3433,10 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 		setMemoryTokens((prevMemoryTokens) => ({ ...prevMemoryTokens, [key]: value }));
 	}
 
-	// re-select the correct index in case renaming changes order of array
-	// const reselectInstructTemplate = async (target) => {
-	// 	setSelectedTemplate(targetIndex)
-	// };
-	const updateTemplateList = useMemo(() => {
-		//var selectedTemplateName = templateList[selectedTemplate]?.name
-		
-		// console.log("selectedTemplateName",selectedTemplate,selectedTemplate)
 
 
-		const index = templateList.findIndex(obj => obj.name === selectedTemplate)
-		console.log(index)
-		const reselectTemplate = templateList[index == -1 ? 0 : index]?.nameNew
-
-
-		console.log("old",selectedTemplate,"new",reselectTemplate)
-
-		const list = []
-		let i = 0;
-		
-		// there has to be a more elegant way to do this
-		for (const key in templates) {
-			list.push({
-				name: key,
-				nameNew:key,
-				value: key,
-				nameBack: key,
-				affixes: templates[key]
-			})
-		}
-		list.sort((a, b) => {
-			var nameA = a.name.toLowerCase();
-			var nameB = b.name.toLowerCase();
-			return (nameA < nameB) ? -1 : (nameA > nameB) ? 1 : 0;
-		});
-
-		//console.log("templateList",list,selectedTemplate)
-		setTemplateList(list)
-		//console.log("selectedTemplateName",selectedTemplate)
-		// using templateList, get the newName before updating, then feed it here?
-		if (reselectTemplate)
-			setSelectedTemplate(reselectTemplate)
-	}, [templates,selectedTemplate]);
-
-	const debugAlt = useMemo(() => {
-		console.log(selectedTemplate)
-	}, [templates,selectedTemplate]);
-
-	function handleInstructTemplateChange(templateName,key,value,back="") {
-		
-		const templateListMod = templateList
-		const tempIndex = templateListMod.findIndex(obj => obj.name === templateName);
-		const index = tempIndex < 0 ? 0 : tempIndex;
-
-		console.log("change object",index,templateListMod[index])
-
-		if (key == "name") { //&& value != templateList[index].nameBack) {
-			// console.log("rename",templateList[index].nameBack,"to",value)
-			// console.log({[value]: templates[templateList[index].nameBack]})
-			// console.log("old",templateList[index].name)
-			templateListMod[index].nameNew = value
-		} else {
-			templateListMod[index].affixes[key] = value
-		}
-		setTemplateList((prevState) => ([
-			...templateListMod
-		]))
-	}
-	
-	function handleInstructTemplateDelete(entry) {
-		if (!window.confirm("Are you sure you want to delete this template? This action can't be undone."))
-			return;
-		const templateListMod = templateList
-		templateListMod.splice(templateListMod.findIndex(obj => obj.name === entry),1)
-
-		setTemplateList((prevState) => ([
-			...templateListMod
-		]))
-		setTriggerTemplateDBUpdate((prevState) => (!prevState))
-
-		setSelectedTemplate(templateListMod[0].name)
-	}
-
-	const updateTemplateDB = useMemo(() => {
-		console.warn("instruct modal",modalState["instruct"])
-
+	const updateTemplateDB = async () => {
+		console.log("update",templateList)
 		setTemplates((prevState) => {
 			var newState = {
 				...prevState
@@ -3388,11 +3452,8 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 				// if template has been renamed, delete old entry, make sure to reselect 
 				// current entry after
 				if (name != nameBack) {
-					console.log("RENAME SHIT")
 					newState[name] = prevState[nameBack]
-					console.log("delete",newState[nameBack])
 					delete newState[nameBack]
-					console.log("newstate",newState)
 				}
 
 				// if no changes, skip
@@ -3409,8 +3470,12 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 			// console.log("newstate",newState)
 			return { ...newState }
 		})
+	}
+	const updateTemplateDBCaller = useMemo(() => {
+		updateTemplateDB()
 	}, [modalState["instruct"],triggerTemplateDBUpdate]);
 	
+
 	const toggleModal = (modalKey) => {
 		setModalState((prevState) => ({
 			...prevState,
@@ -3499,7 +3564,7 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 			: "";
 
 		// replacements for the contextOrder string
-		const replacements = {
+		const contextReplacements = {
 			"{wiPrefix}": memoryTokens.worldInfo && memoryTokens.worldInfo !== ""
 				? worldInfo.prefix
 				: "", // wi prefix and suffix will be added whenever wi isn't empty
@@ -3516,9 +3581,23 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 				? memoryTokens.suffix
 				: "",
 		}
+		const templateReplacements = {
+			"{inst}": templates[selectedTemplate]?.instPre && templates[selectedTemplate]?.instPre !== ""
+				? templates[selectedTemplate]?.instPre
+				: "",
+			"{/inst}": templates[selectedTemplate]?.instSuf && templates[selectedTemplate]?.instSuf !== ""
+				? templates[selectedTemplate]?.instSuf
+				: "",
+			"{sys}": templates[selectedTemplate]?.sysPre && templates[selectedTemplate]?.sysPre !== ""
+				? templates[selectedTemplate]?.sysPre
+				: "",
+			"{/sys}": templates[selectedTemplate]?.sysSuf && templates[selectedTemplate]?.sysSuf !== ""
+				? templates[selectedTemplate]?.sysSuf
+				: "",
+		}
 
 		// prompt length estimation
-		const additionalContext = (Object.values(replacements)
+		const additionalContext = (Object.values(contextReplacements)
 			.filter(value => typeof value === 'string').join('')).length;
 		const estimatedContextStart = Math.round(
 			promptText.length - contextLength * defaultPresets.tokenRatio + additionalContext) + 1;
@@ -3540,7 +3619,7 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 			: truncPrompt;
 
 		// add the final replacement
-		replacements["{prompt}"] = authorNotePrompt
+		contextReplacements["{prompt}"] = authorNotePrompt
 
 		const workingContextOrder = memoryTokens.contextOrder && memoryTokens.contextOrder !== ""
 			? memoryTokens.contextOrder
@@ -3549,18 +3628,23 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 		// assemble context in order:
 		// the context is (1) split by line, (2) all placeholders get replaced,
 		// (3) non-empty lines are joined back together.
-				const permContextPrompt = workingContextOrder.split("\n").map(function (line) {
-				return line.replace(/\{[^}]+\}/g, function (placeholder) {
-		return replacements.hasOwnProperty(placeholder)
-			? replacements[placeholder]
-			: placeholder;
-				});
+		const permContextPrompt = workingContextOrder.split("\n").map(function (line) {
+			return line.replace(/\{[^}]+\}/g, function (placeholder) {
+				return contextReplacements.hasOwnProperty(placeholder)
+					? contextReplacements[placeholder]
+					: placeholder;
+			});
 		}).filter(function (line) {
-				return line.trim() !== "";
-		}).join("\n").replace(/\\n/g, '\n');
+			return line.trim() !== "";
+		}).join("\n")
+			.replace(/\{[^}]+\}/g, function (placeholder) {
+				return templateReplacements.hasOwnProperty(placeholder)
+					? templateReplacements[placeholder]
+					: placeholder;
+			}).replace(/\\n/g, '\n');
 
 		return permContextPrompt;
-	}, [contextLength, promptText, memoryTokens, authorNoteTokens, authorNoteDepth, assembledWorldInfo, worldInfo.prefix, worldInfo.suffix]);
+	}, [contextLength, promptText, memoryTokens, authorNoteTokens, authorNoteDepth, assembledWorldInfo, worldInfo.prefix, worldInfo.suffix, templates, selectedTemplate]);
 
 	async function predict(prompt = modifiedPrompt, chunkCount = promptChunks.length) {
 		if (cancel) {
@@ -4615,16 +4699,19 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 			sessionStorage=${sessionStorage} endpoint=${endpoint} endpointAPI=${endpointAPI} endpointAPIKey=${endpointAPIKey} isMikupadEndpoint=${isMikupadEndpoint}
 			cancel=${cancel}/>
 		
-		<!-- You haven't seen shit yet -->
+		<!-- Sorry. -->
 		<${InstructModal}
 			isOpen=${modalState.instruct}
 			closeModal=${() => closeModal("instruct")}
+			updateTemplateDB=${updateTemplateDB}
 			templateList=${templateList}
+			setTemplateList=${setTemplateList}
 			selectedTemplate=${selectedTemplate}
 			setSelectedTemplate=${setSelectedTemplate}
-			handleInstructTemplateChange=${handleInstructTemplateChange}
-			handleInstructTemplateDelete=${handleInstructTemplateDelete}
-			getArrObjByName=${getArrObjByName}
+			templates=${templates}
+			setTemplates=${setTemplates}
+			addDeleteTemplate=${addDeleteTemplate}
+			setAddDeleteTemplate=${setAddDeleteTemplate}
 			sessionStorage=${sessionStorage} endpoint=${endpoint} endpointAPI=${endpointAPI} endpointAPIKey=${endpointAPIKey} isMikupadEndpoint=${isMikupadEndpoint}
 			cancel=${cancel}/>
 

--- a/mikupad.html
+++ b/mikupad.html
@@ -3197,7 +3197,7 @@ const defaultPresets = {
 			'instSuf': '<|im_end|>\\n<|im_start|>assistant\\n',
 		},
 		'Llama 3': {
-			'sysPre' : '<|begin_of_text|><|start_header_id|>system<|end_header_id|>\\n\\n',
+			'sysPre' : '<|start_header_id|>system<|end_header_id|>\\n\\n',
 			'sysSuf' : '<|eot_id|>',
 			'instPre': '<|start_header_id|>user<|end_header_id|>\\n\\n',
 			'instSuf': '<|eot_id|><|start_header_id|>assistant<|end_header_id|>\\n\\n',
@@ -3209,7 +3209,7 @@ const defaultPresets = {
 			'instSuf': '\\nOutput: ',
 		},
 		'Command-R': {
-			'sysPre' : '<BOS_TOKEN><|START_OF_TURN_TOKEN|><|SYSTEM_TOKEN|>',
+			'sysPre' : '<|START_OF_TURN_TOKEN|><|SYSTEM_TOKEN|>',
 			'sysSuf' : '<|END_OF_TURN_TOKEN|>',
 			'instPre': '<|START_OF_TURN_TOKEN|><|USER_TOKEN|>',
 			'instSuf': '<|END_OF_TURN_TOKEN|><|START_OF_TURN_TOKEN|><|CHATBOT_TOKEN|>',

--- a/mikupad.html
+++ b/mikupad.html
@@ -840,6 +840,12 @@ button.completing {
 	height: 100%;
 }
 
+.instructTemplatesImportExport{
+	width: fit-content;
+	margin: auto;
+	display: flex;
+	gap: 8px;
+}
 .instructTemplateSidebar > .SelectBox {
 	width: 100%;
 }
@@ -2533,13 +2539,12 @@ function InstructModal({ isOpen, closeModal, sessionStorage, updateTemplateDB, s
 			var newState = {
 				...prevState
 			}
-			newState[""] = {
+			newState["New Template"] = {
 				"sysPre": "",
 				"sysSuf": "",
 				"instPre": "",
 				"instSuf": "",
 			}
-			
 			return { ...newState }
 		})
 		setAddDeleteTemplate(true)
@@ -2628,6 +2633,26 @@ function InstructModal({ isOpen, closeModal, sessionStorage, updateTemplateDB, s
 				</table>
 			</div>
 			<hr/>
+			<div class="instructTemplatesImportExport">
+				<button
+					title="Import Instruct Templates"
+					disabled=${!!cancel}
+					onClick=${() => importTemplates()}>
+					Import
+				</button>
+				<button
+					title="Export Instruct Templates"
+					disabled=${!!cancel}
+					onClick=${() => exportTemplates()}>
+					Export
+				</button>
+				<button
+					title="Re-Add Default Instruct Templates"
+					disabled=${!!cancel}
+					onClick=${() => importTemplates(true)}>
+					Re-Add Defaults
+				</button>
+			</div>
 			<div className="buttons instructTemplateSidebar">
 				<${SelectBoxTemplate}
 					id="instructModalSelect"
@@ -2649,27 +2674,6 @@ function InstructModal({ isOpen, closeModal, sessionStorage, updateTemplateDB, s
 						class="hbox-button"
 						onClick=${() => handleInstructTemplateDelete(selectedTemplate)}>
 						Delete
-					</button>
-					<button
-						title="Import Instruct Templates"
-						disabled=${!!cancel}
-						class="hbox-button"
-						onClick=${() => importTemplates()}>
-						Import
-					</button>
-					<button
-						title="Export Instruct Template"
-						disabled=${!!cancel}
-						class="hbox-button"
-						onClick=${() => exportTemplates()}>
-						Export
-					</button>
-					<button
-						title="Re-add defaults"
-						disabled=${!!cancel}
-						class="hbox-button"
-						onClick=${() => importTemplates(true)}>
-						Add Defaults
 					</button>
 			</div>
 			<hr/>
@@ -3382,7 +3386,6 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 	const [addDeleteTemplate, setAddDeleteTemplate] = useState(false);
 	const [templatesImport, setTemplatesImport] = useState(false);
 	const [selectedTemplate, setSelectedTemplate] = usePersistentState('template', "Llama 3");
-	const [triggerTemplateDBUpdate, setTriggerTemplateDBUpdate] = useState(false);
 	const [templateList, setTemplateList] = useState([]);
 	const [currentPromptChunk, setCurrentPromptChunk] = useState(undefined);
 	const [undoHovered, setUndoHovered] = useState(false);
@@ -3518,7 +3521,7 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 	const templateReselect = useMemo(() => {
 		if (!addDeleteTemplate)
 			return
-		setSelectedTemplate("")
+		setSelectedTemplate("New Template")
 		setAddDeleteTemplate(false)
 
 	}, [addDeleteTemplate]);
@@ -3559,7 +3562,7 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 	}
 	const updateTemplateDBCaller = useMemo(() => {
 		updateTemplateDB()
-	}, [modalState["instruct"],triggerTemplateDBUpdate,selectedTemplate]);
+	}, [modalState["instruct"],selectedTemplate]);
 	
 
 	const toggleModal = (modalKey) => {

--- a/mikupad.html
+++ b/mikupad.html
@@ -2460,15 +2460,25 @@ function LogitBiasModal({ isOpen, closeModal, logitBias, setLogitBias, logitBias
 			</${Modal}>`;
 }
 
+class TemplateStorage {
+	constructor() {
+		this.templates = new Map();
+		this.nextId = 1;
+		this.selectedTemplate = 1;
+		this.initial = 1;
+	}
+}
+
 class SessionStorage extends EventTarget {
 	constructor() {
 		super();
 		this.dbName = 'MikuPad';
-		this.storeName = 'Sessions';
+		this.storeNames = ['Sessions','Templates'];
 		this.nextId = undefined;
 		this.saveQueue = [];
 		this.saveTimer = undefined;
 		this.sessions = {};
+		this.templates = {};
 		this.selectedSession = undefined;
 	}
 
@@ -2480,6 +2490,14 @@ class SessionStorage extends EventTarget {
 		this.dispatchEvent(new CustomEvent('sessionchange'));
 	}
 
+	dispatchTemplateChangeEvent() {
+		this.dispatchEvent(new CustomEvent('templatechange'));
+	}
+
+	dispatchTemplateRenameEvent() {
+		this.dispatchEvent(new CustomEvent('templaterename'));
+	}
+
 	dispatchErrorEvent(detail) {
 		this.dispatchEvent(new CustomEvent('error', { detail }));
 	}
@@ -2489,6 +2507,7 @@ class SessionStorage extends EventTarget {
 		this.nextId = (await this.loadFromDatabase(db, 'nextSessionId')) || 0;
 		this.selectedSession = (await this.loadFromDatabase(db, 'selectedSessionId')) || 0;
 		await this.loadSessions(db);
+		await this.loadTemplates(db);
 		this.saveTimer = setInterval(async () => await this.saveTimerHandler(), 500);
 	}
 
@@ -2503,7 +2522,11 @@ class SessionStorage extends EventTarget {
 			openRequest.onsuccess = () => resolve(openRequest.result);
 			openRequest.onupgradeneeded = (event) => {
 				const db = event.target.result;
-				db.createObjectStore(this.storeName);
+				this.storeNames.forEach(storeName => {
+					if (!db.objectStoreNames.contains(storeName)) {
+						db.createObjectStore(storeName);
+					}
+				});
 			};
 			openRequest.onblocked = () => console.warn('Request was blocked');
 		});
@@ -2528,10 +2551,11 @@ class SessionStorage extends EventTarget {
 		}
 	}
 
-	async loadFromDatabase(db, key) {
+	async loadFromDatabase(db, key, storeName = this.storeNames[0]) {
+		console.log("load")
 		return new Promise((resolve, reject) => {
-			const tx = db.transaction(this.storeName, 'readonly');
-			const store = tx.objectStore(this.storeName);
+			const tx = db.transaction(storeName, 'readonly');
+			const store = tx.objectStore(storeName);
 			const request = store.get(key);
 
 			request.onsuccess = () => resolve(request.result);
@@ -2539,15 +2563,34 @@ class SessionStorage extends EventTarget {
 		});
 	}
 
-	async saveToDatabase(key, data) {
+	async saveToDatabase(key, data, storeName = this.storeNames[0]) {
+		console.log("save")
 		const db = await this.openDatabase();
 		return new Promise((resolve, reject) => {
-			const tx = db.transaction(this.storeName, 'readwrite');
-			const store = tx.objectStore(this.storeName);
+			const tx = db.transaction(storeName, 'readwrite');
+			const store = tx.objectStore(storeName);
 			const request = store.put(data, key);
 
 			request.onsuccess = () => resolve();
 			request.onerror = () => reject(request.error);
+		});
+	}
+	async saveTemplates(newTemplates) {
+		console.log("save templates")
+		const db = await this.openDatabase();
+		return new Promise((resolve, reject) => {
+			const tx = db.transaction('Templates', 'readwrite');
+			const store = tx.objectStore('Templates');
+			for (const [key, value] of Object.entries(newTemplates)) {
+				// if (this.templates[key] === value)
+				// 	continue
+				console.log("storing",key,value)
+				let request = store.put(value, key);
+				request.onsuccess = () => resolve();
+				request.onerror = () => reject(request.error);
+			}
+
+
 		});
 	}
 
@@ -2584,8 +2627,8 @@ class SessionStorage extends EventTarget {
 
 	async loadSessions(db) {
 		return new Promise((resolve, reject) => {
-			const tx = db.transaction(this.storeName, 'readonly');
-			const store = tx.objectStore(this.storeName);
+			const tx = db.transaction(this.storeNames[0], 'readonly');
+			const store = tx.objectStore(this.storeNames[0]);
 			const request = store.openCursor();
 
 			request.onsuccess = async (event) => {
@@ -2602,6 +2645,34 @@ class SessionStorage extends EventTarget {
 						}
 					}
 					await this.switchSession(this.selectedSession);
+					resolve();
+				}
+			};
+			request.onerror = () => reject(request.error);
+		});
+	}
+	async loadTemplates(db) {
+		return new Promise((resolve, reject) => {
+			const tx = db.transaction(this.storeNames[1], 'readonly');
+			const store = tx.objectStore(this.storeNames[1]);
+			const request = store.openCursor();
+
+			request.onsuccess = async (event) => {
+				const cursor = event.target.result;
+				// console.log("get all",cursor)
+				// this.templates = { ...cursor }
+				// console.log(this.templates)
+				if (cursor) {
+					console.log("cursor",cursor)
+					this.templates[cursor.key] = cursor.value;
+					cursor.continue();
+				} else {
+					if (Object.keys(this.templates).length === 0) {
+						// if (!await this.migrateSessions()) {
+						// 	await this.createSession('MikuPad #1');
+						// }
+					}
+					// await this.switchSession(this.selectedSession);
 					resolve();
 				}
 			};
@@ -2645,8 +2716,8 @@ class SessionStorage extends EventTarget {
 			return;
 		const db = await this.openDatabase();
 		return new Promise((resolve, reject) => {
-			const tx = db.transaction(this.storeName, 'readwrite');
-			const store = tx.objectStore(this.storeName);
+			const tx = db.transaction(this.storeNames[0], 'readwrite');
+			const store = tx.objectStore(this.storeNames[0]);
 			const request = store.delete(sessionId);
 
 			request.onsuccess = async () => {
@@ -2779,6 +2850,30 @@ class WebSessionStorage extends SessionStorage {
 			resolve();
 		});
 	}
+	async loadTemplates(db) {
+		return new Promise(async (resolve, reject) => {
+			const res = await db("/templates");
+			if (!res.ok) {
+				reject(res.status);
+				return;
+			}
+			const { result } = await res.json();
+			const sessions = result;
+
+			for (const [key, value] of Object.entries(templates)) {
+				this.templates[key] = value;
+			}
+
+			if (Object.keys(this.templates).length === 0) {
+				// if (!await this.migrateSessions()) {
+				// 	await this.createSession('MikuPad #1');
+				// }
+			}
+
+			// await this.switchSession(this.selectedSession);
+			resolve();
+		});
+	}
 
 	async deleteSession(sessionId) {
 		if (Object.keys(this.sessions).length === 1)
@@ -2877,6 +2972,8 @@ function replaceUnprintableBytes(inputString) {
 }
 
 function useSessionState(sessionStorage, name, initialState) {
+	//console.log(arguments)
+	//console.log("ss in useSessionState",sessionStorage)
 	const savedState = useMemo(() => {
 		try {
 			return sessionStorage.getProperty(name);
@@ -2885,6 +2982,8 @@ function useSessionState(sessionStorage, name, initialState) {
 			return null;
 		}
 	}, []);
+	//console.log(sessionStorage)
+	//console.log("name",name,savedState)
 
 	const [value, setValue] = useState(savedState ?? initialState);
 
@@ -2904,6 +3003,48 @@ function useSessionState(sessionStorage, name, initialState) {
 		setValue((prevValue) => {
 			const updatedValue = typeof newValue === 'function' ? newValue(prevValue) : newValue;
 			sessionStorage.setProperty(name, updatedValue);
+			return updatedValue;
+		});
+	};
+
+	return [value, updateState];
+}
+
+function useDBTemplates(sessionStorage,initialState) {
+	console.log("ss in function",sessionStorage)
+	const savedState = useMemo(() => {
+		try {
+			return sessionStorage.templates;
+		} catch (e) {
+			reportError(e);
+			return null;
+		}
+	}, []);
+	
+
+	const [value, setValue] = useState(Object.keys(savedState).length === 0 ? initialState : savedState);
+	console.log(savedState,initialState,value)
+	console.log()
+
+	// useEffect(() => {
+	// 	function deepCopy(value) {
+	// 		return JSON.parse(JSON.stringify(value));
+	// 	}
+	// 	function onSessionChange() {
+	// 		setValue(sessionStorage.templates ?? deepCopy(initialState));
+	// 	}
+
+	// 	sessionStorage.addEventListener('templatechange', onSessionChange);
+	// 	return () => sessionStorage.removeEventListener('templatechange', onSessionChange);
+	// }, []);
+
+	const updateState = (newValue) => {
+		setValue((prevValue) => {
+			const updatedValue = typeof newValue === 'function' ? newValue(prevValue) : newValue;
+			sessionStorage.templates = updatedValue;
+			// replace with put?
+			//sessionStorage.saveToDatabase(key,newValue,'Templates')
+			sessionStorage.saveTemplates(updatedValue)
 			return updatedValue;
 		});
 	};
@@ -2934,7 +3075,8 @@ function usePersistentState(name, initialState) {
 	return [value, updateState];
 }
 
-export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
+export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupadEndpoint }) {
+	console.log("app",arguments)
 	const promptArea = useRef();
 	const promptOverlay = useRef();
 	const undoStack = useRef([]);
@@ -2943,6 +3085,7 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 	const keyState = useRef({});
 	const sessionReconnectTimer = useRef();
 	const useScrollSmoothing = useRef(true);
+	const [templates, setTemplates] = useDBTemplates({"stuff":"here"});
 	const [currentPromptChunk, setCurrentPromptChunk] = useState(undefined);
 	const [undoHovered, setUndoHovered] = useState(false);
 	const [showProbs, setShowProbs] = useState(true);
@@ -2998,6 +3141,9 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 	const [authorNoteDepth, setAuthorNoteDepth] = useSessionState('authorNoteDepth', defaultPresets.authorNoteDepth);
 	const [worldInfo, setWorldInfo] = useSessionState('worldInfo', defaultPresets.worldInfo);
 
+
+
+	console.log("read templates in app",templates)
 	// AN and Memory
 	function handleauthorNoteTokensChange(key,value) {
 		setAuthorNoteTokens((prevauthorNoteTokens) => ({ ...prevauthorNoteTokens, [key]: value }));
@@ -3018,6 +3164,26 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 			[modalKey]: false,
 		}));
 	};
+
+	function writess() {
+		sessionStorage.saveToDatabase("A key",{"A":"value"},'Templates')
+	}
+
+	const writessapp = () => {
+		setTemplates((prevState) => ({
+			...prevState,
+			"new":"value"
+		}))
+	}
+
+	function logss() {
+		console.log("full",sessionStorage)
+		console.log(JSON.stringify(sessionStorage))
+		console.log("load",sessionStorage.templates)
+	}
+
+	
+
 
 	const promptText = useMemo(() => joinPrompt(promptChunks), [promptChunks]);
 
@@ -4081,6 +4247,29 @@ export function App({ sessionStorage, useSessionState, isMikupadEndpoint }) {
 			</div>
 			${!!lastError && html`
 				<span className="error-text">${lastError}</span>`}
+		
+
+			<button
+				title=""
+				className=${cancel}
+				disabled=${!!cancel || stoppingStringsError}
+				onClick=${() => writess()}>
+				write session storage
+			</button>
+			<button
+				title=""
+				className=${cancel}
+				disabled=${!!cancel || stoppingStringsError}
+				onClick=${() => logss()}>
+				log session storage
+			</button>
+			<button
+				title=""
+				className=${cancel}
+				disabled=${!!cancel || stoppingStringsError}
+				onClick=${() => writessapp()}>
+				write session storage app
+			</button>
 		</div>
 
 		<${EditorPreferencesModal}
@@ -4188,6 +4377,7 @@ async function main() {
 		<${App}
 			sessionStorage=${sessionStorage}
 			useSessionState=${(name, initialState) => useSessionState(sessionStorage, name, initialState)}
+			useDBTemplates=${(initialState => useDBTemplates(sessionStorage,initialState))}
 			isMikupadEndpoint=${isMikupadEndpoint}/>`);
 }
 

--- a/mikupad.html
+++ b/mikupad.html
@@ -1660,7 +1660,7 @@ function SelectBoxTemplate({ label, value, onValueChange, options, ...props }) {
 				...${props}>
 				${(options = typeof options === 'function' ? options() : options).map(o => html`<option
 					key=${JSON.stringify(o.value)}
-					value=${o.value}>${o.name}</option>`)}
+					value=${o.nameNew}>${o.nameNew}</option>`)}
 			</select>
 		</label>`;
 }
@@ -2508,7 +2508,7 @@ function LogitBiasModal({ isOpen, closeModal, logitBias, setLogitBias, logitBias
 			</${Modal}>`;
 }
 
-function InstructModal({ isOpen, closeModal, sessionStorage, updateTemplateDB, selectedTemplate, setSelectedTemplate, templateList, setTemplateList, templates, setTemplates, setAddDeleteTemplate, cancel }) {
+function InstructModal({ isOpen, closeModal, sessionStorage, updateTemplateDB, newTemplateName, setNewTemplateName, selectedTemplate, setSelectedTemplate, templateList, setTemplateList, templates, setTemplates, setAddDeleteTemplate, cancel }) {
 
 	function getArrObjByName(array,name,getIndex=false) {
 		const index = array.findIndex(obj => obj.name === name)
@@ -2524,6 +2524,7 @@ function InstructModal({ isOpen, closeModal, sessionStorage, updateTemplateDB, s
 
 		if (key == "name") { 
 			templateListMod[index].nameNew = value
+			setNewTemplateName(value)
 		} else {
 			templateListMod[index].affixes[key] = value
 		}
@@ -2538,7 +2539,7 @@ function InstructModal({ isOpen, closeModal, sessionStorage, updateTemplateDB, s
 			var newState = {
 				...prevState
 			}
-			newState["New Template"] = {
+			newState[""] = {
 				"sysPre": "",
 				"sysSuf": "",
 				"instPre": "",
@@ -2658,7 +2659,7 @@ function InstructModal({ isOpen, closeModal, sessionStorage, updateTemplateDB, s
 					id="instructModalSelect"
 					label="Instruct Template"
 					disabled=${!!cancel}
-					value=${selectedTemplate}
+					value=${newTemplateName ?? selectedTemplate}
 					onValueChange=${setSelectedTemplate}
 					options=${templateList}/>
 				<button
@@ -3381,10 +3382,11 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 	const sessionReconnectTimer = useRef();
 	const useScrollSmoothing = useRef(true);
 	const [templates, setTemplates] = useDBTemplates(defaultPresets.instructTemplates);
+	const [newTemplateName, setNewTemplateName] = useState(undefined);
 	const [addDeleteTemplate, setAddDeleteTemplate] = useState(false);
 	const [templatesImport, setTemplatesImport] = useState(false);
-	const [selectedTemplate, setSelectedTemplate] = usePersistentState('template', "Llama 3");
-	const [chatMode, setChatMode] = usePersistentState('chatMode', false);
+	const [selectedTemplate, setSelectedTemplate] = useSessionState('template', "Llama 3");
+	const [chatMode, setChatMode] = useSessionState('chatMode', false);
 	const [templateList, setTemplateList] = useState([]);
 	const [currentPromptChunk, setCurrentPromptChunk] = useState(undefined);
 	const [undoHovered, setUndoHovered] = useState(false);
@@ -3520,13 +3522,14 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 	const templateReselect = useMemo(() => {
 		if (!addDeleteTemplate)
 			return
-		setSelectedTemplate("New Template")
+		setSelectedTemplate("")
 		setAddDeleteTemplate(false)
 
 	}, [addDeleteTemplate]);
 
 
 	const updateTemplateDB = async () => {
+		setNewTemplateName(undefined);
 		setTemplates((prevState) => {
 			var newState = {
 				...prevState
@@ -4501,7 +4504,7 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 					<${SelectBoxTemplate}
 						label="Instruct Template"
 						disabled=${!!cancel}
-						value=${selectedTemplate}
+						value=${newTemplateName ?? selectedTemplate}
 						onValueChange=${setSelectedTemplate}
 						options=${templateList}/>
 					<button
@@ -4802,6 +4805,8 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 			closeModal=${() => closeModal("instruct")}
 			templateList=${templateList}
 			setTemplateList=${setTemplateList}
+			newTemplateName=${newTemplateName}
+			setNewTemplateName=${setNewTemplateName}
 			selectedTemplate=${selectedTemplate}
 			setSelectedTemplate=${setSelectedTemplate}
 			setTemplatesImport=${setTemplatesImport}

--- a/mikupad.html
+++ b/mikupad.html
@@ -3764,12 +3764,13 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 			setPredictStartTokens(tokenCount);
 
 			// Chat Mode
-			if (chatMode) {
-				// add user EOT template (instruct suffix)
+			if (chatMode && !restartedPredict) {
+				// add user EOT template (instruct suffix) if not switch completion
 				const eotUser = templates[selectedTemplate]?.instSuf.replace(/\\n/g, '\n')
 				setPromptChunks(p => [...p, { type: 'user', content: eotUser }])
 				prompt += `${eotUser}`
 			}
+			setRestartedPredict(false)
 
 			while (undoStack.current.at(-1) >= chunkCount)
 				undoStack.current.pop();
@@ -3877,6 +3878,7 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 	}
 
 	const [triggerPredict, setTriggerPredict] = useState(false);
+	const [restartedPredict, setRestartedPredict] = useState(false);
 
 	function undoAndPredict() {
 		if (!undoStack.current.length) return;
@@ -4328,6 +4330,7 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 		];
 		setPromptChunks(newPrompt);
 		setTriggerPredict(true);
+		setRestartedPredict(true);
 	}
 
 	function switchEndpointAPI(value) {

--- a/mikupad.html
+++ b/mikupad.html
@@ -3094,7 +3094,7 @@ class WebSessionStorage extends SessionStorage {
 			for (const [key, value] of Object.entries(templates)) {
 				this.templates[key] = value;
 			}
-			
+
 			resolve();
 		});
 	}
@@ -3464,25 +3464,6 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 			[modalKey]: false,
 		}));
 	};
-
-	function writess() {
-		sessionStorage.saveToDatabase("A key",{"A":"value"},'Templates')
-	}
-
-	const writessapp = () => {
-		setTemplates((prevState) => ({
-			...prevState,
-			"new":"value"
-		}))
-	}
-
-	function logss() {
-		console.log("full",sessionStorage)
-		console.log(JSON.stringify(sessionStorage))
-		console.log("load",sessionStorage.templates)
-	}
-
-	
 
 
 	const promptText = useMemo(() => joinPrompt(promptChunks), [promptChunks]);
@@ -4390,7 +4371,7 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 							disabled=${!!cancel}
 							class="hbox-button"
 							onClick=${() => toggleModal("instruct")}>
-							edit
+							Edit
 						</button>
 				</div>
 				<${InputBox} label="Seed (-1 = random)" type="text" inputmode="numeric"
@@ -4581,29 +4562,6 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 			</div>
 			${!!lastError && html`
 				<span className="error-text">${lastError}</span>`}
-		
-
-			<button
-				title=""
-				className=${cancel}
-				disabled=${!!cancel || stoppingStringsError}
-				onClick=${() => writess()}>
-				write session storage
-			</button>
-			<button
-				title=""
-				className="${cancel}"
-				disabled=${!!cancel || stoppingStringsError}
-				onClick=${() => logss()}>
-				log session storage
-			</button>
-			<button
-				title=""
-				className=${cancel}
-				disabled=${!!cancel || stoppingStringsError}
-				onClick=${() => writessapp()}>
-				write session storage app
-			</button>
 		</div>
 
 		<${EditorPreferencesModal}

--- a/mikupad.html
+++ b/mikupad.html
@@ -3200,6 +3200,12 @@ const defaultPresets = {
 			'instPre': '<|start_header_id|>user<|end_header_id|>\\n\\n',
 			'instSuf': '<|eot_id|><|start_header_id|>assistant<|end_header_id|>\\n\\n',
 		},
+		'Phi': {
+			'sysPre' : '',
+			'sysSuf' : '',
+			'instPre': 'Instruct: ',
+			'instSuf': '\\nOutput: ',
+		},
 	},
 	scrollTop: 0
 };

--- a/mikupad.html
+++ b/mikupad.html
@@ -3212,7 +3212,7 @@ const defaultPresets = {
 			'instPre': '### Instruction:\\n',
 			'instSuf': '\\n\\n### Response:',
 		},
-		'Mixtral': {
+		'Mistral': {
 			'sysPre' : '<<SYS>>\\n',
 			'sysSuf' : '<</SYS>>\\n\\n',
 			'instPre': '[INST]',
@@ -3230,11 +3230,17 @@ const defaultPresets = {
 			'instPre': '<|start_header_id|>user<|end_header_id|>\\n\\n',
 			'instSuf': '<|eot_id|><|start_header_id|>assistant<|end_header_id|>\\n\\n',
 		},
-		'Phi': {
+		'Phi 2': {
 			'sysPre' : '',
 			'sysSuf' : '',
 			'instPre': 'Instruct: ',
 			'instSuf': '\\nOutput: ',
+		},
+		'Phi 3': {
+			'sysPre' : '<|system|>\\n',
+			'sysSuf' : '<|end|>\\n',
+			'instPre': '<|user|>\\n',
+			'instSuf': '<|end|>\\n<|assistant|>\\n',
 		},
 		'Command-R': {
 			'sysPre' : '<|START_OF_TURN_TOKEN|><|SYSTEM_TOKEN|>',

--- a/mikupad.html
+++ b/mikupad.html
@@ -3400,8 +3400,6 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 		if (!(prefix || suffix))
 			return;
 
-		console.log([prefix,suffix])
-
 		const elem = promptArea.current;
 		if (!elem)
 			return;
@@ -3563,7 +3561,7 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 		return assembledWorldInfo
 	}, [worldInfo]);
 
-	const modifiedPrompt = useMemo(() => {
+	const additionalContextPrompt = useMemo(() => {
 		// add world info to memory for easier assembly
 		memoryTokens["worldInfo"] = assembledWorldInfo;
 
@@ -3588,20 +3586,6 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 			"{memText}": memoryTokens.text,
 			"{memSuffix}": memoryTokens.text && memoryTokens.text !== "" || memoryTokens.worldInfo !== ""
 				? memoryTokens.suffix
-				: "",
-		}
-		const templateReplacements = {
-			"{inst}": templates[selectedTemplate]?.instPre && templates[selectedTemplate]?.instPre !== ""
-				? templates[selectedTemplate]?.instPre
-				: "",
-			"{/inst}": templates[selectedTemplate]?.instSuf && templates[selectedTemplate]?.instSuf !== ""
-				? templates[selectedTemplate]?.instSuf
-				: "",
-			"{sys}": templates[selectedTemplate]?.sysPre && templates[selectedTemplate]?.sysPre !== ""
-				? templates[selectedTemplate]?.sysPre
-				: "",
-			"{/sys}": templates[selectedTemplate]?.sysSuf && templates[selectedTemplate]?.sysSuf !== ""
-				? templates[selectedTemplate]?.sysSuf
 				: "",
 		}
 
@@ -3646,15 +3630,35 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 			});
 		}).filter(function (line) {
 			return line.trim() !== "";
-		}).join("\n")
+		}).join("\n").replace(/\\n/g, '\n');
+
+		return permContextPrompt;
+	}, [contextLength, promptText, memoryTokens, authorNoteTokens, authorNoteDepth, assembledWorldInfo, worldInfo.prefix, worldInfo.suffix]);
+
+	const modifiedPrompt = useMemo(() => {
+		const templateReplacements = {
+			"{inst}": templates[selectedTemplate]?.instPre && templates[selectedTemplate]?.instPre !== ""
+				? templates[selectedTemplate]?.instPre
+				: "",
+			"{/inst}": templates[selectedTemplate]?.instSuf && templates[selectedTemplate]?.instSuf !== ""
+				? templates[selectedTemplate]?.instSuf
+				: "",
+			"{sys}": templates[selectedTemplate]?.sysPre && templates[selectedTemplate]?.sysPre !== ""
+				? templates[selectedTemplate]?.sysPre
+				: "",
+			"{/sys}": templates[selectedTemplate]?.sysSuf && templates[selectedTemplate]?.sysSuf !== ""
+				? templates[selectedTemplate]?.sysSuf
+				: "",
+		}
+		const finalPrompt = additionalContextPrompt
 			.replace(/\{[^}]+\}/g, function (placeholder) {
 				return templateReplacements.hasOwnProperty(placeholder)
 					? templateReplacements[placeholder]
 					: placeholder;
 			}).replace(/\\n/g, '\n');
 
-		return permContextPrompt;
-	}, [contextLength, promptText, memoryTokens, authorNoteTokens, authorNoteDepth, assembledWorldInfo, worldInfo.prefix, worldInfo.suffix, templates, selectedTemplate]);
+		return finalPrompt;
+	}, [additionalContextPrompt, templates, selectedTemplate]);
 
 	async function predict(prompt = modifiedPrompt, chunkCount = promptChunks.length) {
 		if (cancel) {

--- a/mikupad.html
+++ b/mikupad.html
@@ -2489,7 +2489,7 @@ function LogitBiasModal({ isOpen, closeModal, logitBias, setLogitBias, logitBias
 			</${Modal}>`;
 }
 
-function InstructModal({ isOpen, closeModal, sessionStorage, selectedTemplate, setSelectedTemplate, templateList, setTemplateList, templates, setTemplates, addDeleteTemplate, setAddDeleteTemplate, updateTemplateDB, cancel }) {
+function InstructModal({ isOpen, closeModal, sessionStorage, updateTemplateDB, selectedTemplate, setSelectedTemplate, templateList, setTemplateList, templates, setTemplates, setAddDeleteTemplate, cancel }) {
 	
 	function getArrObjByName(array,name,getIndex=false) {
 		const index = array.findIndex(obj => obj.name === name)
@@ -2498,44 +2498,10 @@ function InstructModal({ isOpen, closeModal, sessionStorage, selectedTemplate, s
 		return array[index == -1 ? 0 : index];
 	}
 
-	const templateReselect = useMemo(() => {
-		if (!addDeleteTemplate)
-			return
-		setSelectedTemplate("")
-		setAddDeleteTemplate(false)
-	}, [addDeleteTemplate]);
-
-	const updateTemplateList = useMemo(() => {
-		const index = templateList.findIndex(obj => obj.name === selectedTemplate)
-		const reselectTemplate = templateList[index == -1 ? 0 : index]?.nameNew
-		const list = []
-		let i = 0;
-		for (const key in templates) {
-			list.push({
-				name: key,
-				nameNew:key,
-				value: key,
-				nameBack: key,
-				affixes: templates[key]
-			})
-		}
-		list.sort((a, b) => {
-			var nameA = a.name.toLowerCase();
-			var nameB = b.name.toLowerCase();
-			return (nameA < nameB) ? -1 : (nameA > nameB) ? 1 : 0;
-		});
-		setTemplateList(list)
-		if (reselectTemplate)
-			setSelectedTemplate(reselectTemplate)
-	}, [templates,selectedTemplate]);
-
 	function handleInstructTemplateChange(templateName,key,value,back="") {
-		
 		const templateListMod = templateList
 		const tempIndex = templateListMod.findIndex(obj => obj.name === templateName);
 		const index = tempIndex < 0 ? 0 : tempIndex;
-
-		console.log("change object",index,templateListMod[index])
 
 		if (key == "name") { 
 			templateListMod[index].nameNew = value
@@ -2566,7 +2532,6 @@ function InstructModal({ isOpen, closeModal, sessionStorage, selectedTemplate, s
 	}
 
 	async function handleInstructTemplateDelete(name) {
-		console.log(Object.keys(templates).length)
 		if (Object.keys(templates).length < 2)
 			return
 		if (!window.confirm("Are you sure you want to delete this template? This action can't be undone."))
@@ -2772,13 +2737,14 @@ class SessionStorage extends EventTarget {
 
 	async openDatabase() {
 		return new Promise((resolve, reject) => {
-			const openRequest = indexedDB.open(this.dbName);
+			const openRequest = indexedDB.open(this.dbName, 2);
 
 			openRequest.onerror = () => {
 				this.dispatchErrorEvent(openRequest.error);
 				reject(openRequest.error);
 			};
 			openRequest.onsuccess = () => resolve(openRequest.result);
+			
 			openRequest.onupgradeneeded = (event) => {
 				const db = event.target.result;
 				this.storeNames.forEach(storeName => {
@@ -2843,7 +2809,6 @@ class SessionStorage extends EventTarget {
 			const DBkeys = event.target.result;
 
 			// Check if the keys exists in input, if not, delete
-			console.log(DBkeys,Object.keys(newTemplates))
 			DBkeys.forEach(key => {
 				if ( !(Object.keys(newTemplates).includes(key)) ) {
 					if (writeOnly)
@@ -2851,7 +2816,7 @@ class SessionStorage extends EventTarget {
 					// If the key not in input, delete it
 					const deleteRequest = store.delete(key);
 					deleteRequest.onsuccess = function(event) {
-						console.log('Deleted key:', key);
+						console.warn('Deleted key:', key);
 					}
 					deleteRequest.onerror = function(event) {
 						console.error('Error deleting key:', key);
@@ -2861,8 +2826,6 @@ class SessionStorage extends EventTarget {
 
 			// put input keys
 			for (const [key, value] of Object.entries(newTemplates)) {
-				// if (this.templates[key] === value)
-				// 	continue
 				const request = store.put(value, key);
 				request.onsuccess = () => resolve();
 				request.onerror = () => reject(request.error);
@@ -3131,14 +3094,7 @@ class WebSessionStorage extends SessionStorage {
 			for (const [key, value] of Object.entries(templates)) {
 				this.templates[key] = value;
 			}
-
-			if (Object.keys(this.templates).length === 0) {
-				// if (!await this.migrateSessions()) {
-				// 	await this.createSession('MikuPad #1');
-				// }
-			}
-
-			// await this.switchSession(this.selectedSession);
+			
 			resolve();
 		});
 	}
@@ -3266,8 +3222,6 @@ function replaceUnprintableBytes(inputString) {
 }
 
 function useSessionState(sessionStorage, name, initialState) {
-	//console.log(arguments)
-	//console.log("ss in useSessionState",sessionStorage)
 	const savedState = useMemo(() => {
 		try {
 			return sessionStorage.getProperty(name);
@@ -3276,8 +3230,6 @@ function useSessionState(sessionStorage, name, initialState) {
 			return null;
 		}
 	}, []);
-	//console.log(sessionStorage)
-	//console.log("name",name,savedState)
 
 	const [value, setValue] = useState(savedState ?? initialState);
 
@@ -3421,10 +3373,6 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 	const [authorNoteDepth, setAuthorNoteDepth] = useSessionState('authorNoteDepth', defaultPresets.authorNoteDepth);
 	const [worldInfo, setWorldInfo] = useSessionState('worldInfo', defaultPresets.worldInfo);
 
-
-
-	
-
 	// AN and Memory
 	function handleauthorNoteTokensChange(key,value) {
 		setAuthorNoteTokens((prevauthorNoteTokens) => ({ ...prevauthorNoteTokens, [key]: value }));
@@ -3433,10 +3381,40 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 		setMemoryTokens((prevMemoryTokens) => ({ ...prevMemoryTokens, [key]: value }));
 	}
 
+	// re-selecting doesn't work properly when I move this inside the InstructModal
+	const updateTemplateList = useMemo(() => {
+		const index = templateList.findIndex(obj => obj.name === selectedTemplate)
+		const reselectTemplate = templateList[index == -1 ? 0 : index]?.nameNew
+		const list = []
+		let i = 0;
+		for (const key in templates) {
+			list.push({
+				name: key,
+				nameNew:key,
+				value: key,
+				nameBack: key,
+				affixes: templates[key]
+			})
+		}
+		list.sort((a, b) => {
+			var nameA = a.name.toLowerCase();
+			var nameB = b.name.toLowerCase();
+			return (nameA < nameB) ? -1 : (nameA > nameB) ? 1 : 0;
+		});
+		setTemplateList(list)
+		if (reselectTemplate)
+			setSelectedTemplate(reselectTemplate)
+	}, [templates,selectedTemplate,templatesImport]);
+	const templateReselect = useMemo(() => {
+		if (!addDeleteTemplate)
+			return
+		setSelectedTemplate("")
+		setAddDeleteTemplate(false)
 
+	}, [addDeleteTemplate]);
+	
 
 	const updateTemplateDB = async () => {
-		console.log("update",templateList)
 		setTemplates((prevState) => {
 			var newState = {
 				...prevState
@@ -3448,7 +3426,6 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 
 				if (name === undefined || nameBack === undefined)
 					continue
-
 				// if template has been renamed, delete old entry, make sure to reselect 
 				// current entry after
 				if (name != nameBack) {
@@ -3467,13 +3444,12 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 					"instSuf": template.affixes.instSuf,
 				}
 			}
-			// console.log("newstate",newState)
 			return { ...newState }
 		})
 	}
 	const updateTemplateDBCaller = useMemo(() => {
 		updateTemplateDB()
-	}, [modalState["instruct"],triggerTemplateDBUpdate]);
+	}, [modalState["instruct"],triggerTemplateDBUpdate,selectedTemplate]);
 	
 
 	const toggleModal = (modalKey) => {
@@ -3626,8 +3602,9 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 			: defaultPresets.memoryTokens.contextOrder;
 
 		// assemble context in order:
-		// the context is (1) split by line, (2) all placeholders get replaced,
-		// (3) non-empty lines are joined back together.
+		// the context is (1) split by line, (2) persistent context placeholders are 
+		// replaced, (3) instruct template placeholders are replaced (4) non-empty
+		// lines are joined back together.
 		const permContextPrompt = workingContextOrder.split("\n").map(function (line) {
 			return line.replace(/\{[^}]+\}/g, function (placeholder) {
 				return contextReplacements.hasOwnProperty(placeholder)
@@ -4703,14 +4680,14 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 		<${InstructModal}
 			isOpen=${modalState.instruct}
 			closeModal=${() => closeModal("instruct")}
-			updateTemplateDB=${updateTemplateDB}
 			templateList=${templateList}
 			setTemplateList=${setTemplateList}
 			selectedTemplate=${selectedTemplate}
 			setSelectedTemplate=${setSelectedTemplate}
+			setTemplatesImport=${setTemplatesImport}
 			templates=${templates}
 			setTemplates=${setTemplates}
-			addDeleteTemplate=${addDeleteTemplate}
+			updateTemplateDB=${updateTemplateDB}
 			setAddDeleteTemplate=${setAddDeleteTemplate}
 			sessionStorage=${sessionStorage} endpoint=${endpoint} endpointAPI=${endpointAPI} endpointAPIKey=${endpointAPIKey} isMikupadEndpoint=${isMikupadEndpoint}
 			cancel=${cancel}/>

--- a/mikupad.html
+++ b/mikupad.html
@@ -2435,7 +2435,9 @@ function LogitBiasModal({ isOpen, closeModal, logitBias, setLogitBias, logitBias
 							onValueChange=${() => {} }
 							onInput=${(e) => {handleLogitBiasInput("string",e.target.value)} }
 							/>
-						<button disabled=${!!cancel} class="hbox-button" onClick=${() => logitBiasAdd(logitBiasInput.power,logitBiasInput.string)}>+</button>
+						<button disabled=${!!cancel} class="hbox-button" onClick=${() => logitBiasAdd(logitBiasInput.power,logitBiasInput.string)}>
+							+
+						</button>
 					</div>
 					${!!lastBiasError && html`
 						<div style=${{"margin":"8px auto"}} className="error-text">${lastBiasError}</div>`}
@@ -2471,8 +2473,7 @@ function LogitBiasModal({ isOpen, closeModal, logitBias, setLogitBias, logitBias
 											<button
 												disabled=${!!cancel}
 												class="hbox-button lb-modal-button lb-modal-button-add"
-												onClick=${() => logitBiasAdd(bias.power, bias.value, bias.valueBack)}
-												>
+												onClick=${() => logitBiasAdd(bias.power, bias.value, bias.valueBack)}>
 												+
 											</button>
 											<button
@@ -3206,6 +3207,12 @@ const defaultPresets = {
 			'sysSuf' : '',
 			'instPre': 'Instruct: ',
 			'instSuf': '\\nOutput: ',
+		},
+		'Command-R': {
+			'sysPre' : '<BOS_TOKEN><|START_OF_TURN_TOKEN|><|SYSTEM_TOKEN|>',
+			'sysSuf' : '<|END_OF_TURN_TOKEN|>',
+			'instPre': '<|START_OF_TURN_TOKEN|><|USER_TOKEN|>',
+			'instSuf': '<|END_OF_TURN_TOKEN|><|START_OF_TURN_TOKEN|><|CHATBOT_TOKEN|>',
 		},
 	},
 	scrollTop: 0

--- a/mikupad.html
+++ b/mikupad.html
@@ -482,6 +482,14 @@ html.nockoffAI .wi-entry-name input {
 	margin-bottom:4px;
 }
 
+.symbol-button {
+	margin-top: auto;
+	display: flex;
+	justify-content: center;
+	width: 1.625rem;
+	height: 1.625rem;
+} 
+
 /* logit bias */
 .hbox-button {
 	margin-top: auto;
@@ -4467,27 +4475,23 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 					<button
 						title="Edit Instruct Templates"
 						disabled=${!!cancel}
-						class="hbox-button"
+						class="symbol-button"
 						onClick=${() => toggleModal("instruct")}>
-						Edit
-					</button>
-				</div>
-				<div class="hbox">
-					<button
-						style=${{ 'width':'unset' }}
-						title="Insert Instruct Template"
-						disabled=${!!cancel}
-						class="hbox-button"
-						onClick=${() => insertTemplate("inst")}>
-						Insert Instruct
+						<svg xmlns="http://www.w3.org/2000/svg" width="12" height="-12" viewBox="-1 -5 8 7"><path d="M0 0 3-3C3-4 3-5 5-5L4-4 5-3 6-4C6-2 5-2 4-2L1 1C0 2-1 1 0 0" fill="var(--color-light)"/></svg>
 					</button>
 					<button
-						style=${{ 'width':'unset' }}
 						title="Insert System Prompt Template"
 						disabled=${!!cancel}
-						class="hbox-button"
+						class="symbol-button"
 						onClick=${() => insertTemplate("sys")}>
-						Insert System
+						<svg xmlns="http://www.w3.org/2000/svg" width="12" height="-12" viewBox="0 -10 10 10"><path d="M 0 -2 L 1 -1 L 5 -5 L 1 -9 L 0 -8 L 3 -5 L 0 -2 M 4 -1 L 10 -1 L 10 -2.4 L 4 -2.4" fill="var(--color-light)"/></svg>
+					</button>
+					<button
+						title="Insert Instruct Template"
+						disabled=${!!cancel}
+						class="symbol-button"
+						onClick=${() => insertTemplate("inst")}>
+						<svg xmlns="http://www.w3.org/2000/svg" width="10" height="15" viewBox="0 -10 5 10"><path d="M 2.5 -6 A 0.75 0.75 90 0 0 3.25 -6.75 A 0.75 0.75 90 0 0 2.5 -7.5 A 0.75 0.75 90 0 0 1.75 -6.75 A 0.75 0.75 90 0 0 2.5 -6 M 1 0 L 4 0 L 4 -1 L 3 -1 L 3 -5 L 1 -5 L 1 -4 L 2 -4 L 2 -1 L 1 -1 Z" fill="var(--color-light)"/></svg>
 					</button>
 				</div>
 				<${InputBox} label="Seed (-1 = random)" type="text" inputmode="numeric"

--- a/mikupad.html
+++ b/mikupad.html
@@ -3214,6 +3214,24 @@ const defaultPresets = {
 			'instPre': '<|START_OF_TURN_TOKEN|><|USER_TOKEN|>',
 			'instSuf': '<|END_OF_TURN_TOKEN|><|START_OF_TURN_TOKEN|><|CHATBOT_TOKEN|>',
 		},
+		'Metharme': {
+			'sysPre' : '<|system|>',
+			'sysSuf' : '',
+			'instPre': '<|user|>',
+			'instSuf': '<|model|>',
+		},
+		'Vicuna': {
+			'sysPre' : '',
+			'sysSuf' : '\n\n',
+			'instPre': 'USER: ',
+			'instSuf': '\nASSISTANT: ',
+		},
+		'Gemma': {
+			'sysPre' : '',
+			'sysSuf' : '',
+			'instPre': '<start_of_turn>user\n',
+			'instSuf': '\n<end_of_turn><start_of_turn>model\n',
+		},
 	},
 	scrollTop: 0
 };

--- a/mikupad.html
+++ b/mikupad.html
@@ -585,7 +585,7 @@ html.nockoffAI .wi-entry-name input {
 }
 
 #instructmodal-name {
-	
+
 	size:110%;
 }
 .instructmodal-edits .hbox {
@@ -1055,12 +1055,12 @@ function exportText(filename, text) {
 function normalizeEndpoint(endpoint) {
 	const url = new URL(endpoint.trim());
 	url.pathname = url.pathname.replace(/\/+/g, "/"); // normalize consecutive slashes
-	
+
 	let urlString = url.toString();
 	urlString = urlString.replace(/\/v1\/?$/, ""); // remove "/v1" from the end of the string
 	urlString = urlString.replace(/\/api\/?$/, ""); // remove "/api" from the end of the string
 	urlString = urlString.replace(/\/$/, ""); // remove "/" from the end of the string
-	
+
 	return urlString;
 }
 
@@ -1311,7 +1311,7 @@ async function koboldCppTokenize({ endpoint, proxyEndpoint, signal, ...options }
 	const { ids } = await res.json();
 	ids.shift() // kobold automatically adds a token, so we need to remove it
 	return {ids:ids,str:""};
-	
+
 }
 
 function koboldCppConvertOptions(options) {
@@ -1467,7 +1467,7 @@ async function openaiTokenize({ endpoint, endpointAPIKey, proxyEndpoint, signal,
 			strings.push(string);
 		};
 		return {ids:tokens,str:strings};
-		
+
 	} catch (e) {
 		reportError(e);
 		return -1;
@@ -2199,7 +2199,7 @@ function LogitBiasModal({ isOpen, closeModal, logitBias, setLogitBias, logitBias
 	const [logitBiasTemp, setLogitBiasTemp] = useState([]);
 	const [logitBiasSorted, setLogitBiasSorted] = useState([]);
 	const [logitBiasInput, setLogitBiasInput] = useState({power:"0",string:""});
-	
+
 	const handleLogitBiasInput = (key,value) => {
 		setLogitBiasInput((prevLogitBiasInput) => {
 			return {
@@ -2222,7 +2222,7 @@ function LogitBiasModal({ isOpen, closeModal, logitBias, setLogitBias, logitBias
 		biasPower = Number(biasPower);
 
 		const modBias = logitBias.bias;
-		
+
 		// delete entry if power 0 or empty
 		if (biasPower == 0) {	
 			if (!logitBias.bias[biasString]) {
@@ -2396,7 +2396,7 @@ function LogitBiasModal({ isOpen, closeModal, logitBias, setLogitBias, logitBias
 		setLogitBiasTemp((prevLogitBiasTemp) => {
 			const rest = { ...prevLogitBiasTemp };
 			const updatedTemp = [ ...prevLogitBiasTemp[posneg] ];
-			 
+
 			updatedTemp[index] = {
 				...updatedTemp[index],
 				[key]: value,
@@ -2487,7 +2487,7 @@ function LogitBiasModal({ isOpen, closeModal, logitBias, setLogitBias, logitBias
 												${endpointAPI == 0 && bias.strings != ""
 													? "["+bias.strings.join("|")+"] "
 													: "["+bias.tokens+"]" } 
-												
+
 											</div>
 											<button
 												disabled=${!!cancel}
@@ -2510,7 +2510,7 @@ function LogitBiasModal({ isOpen, closeModal, logitBias, setLogitBias, logitBias
 }
 
 function InstructModal({ isOpen, closeModal, sessionStorage, updateTemplateDB, selectedTemplate, setSelectedTemplate, templateList, setTemplateList, templates, setTemplates, setAddDeleteTemplate, cancel }) {
-	
+
 	function getArrObjByName(array,name,getIndex=false) {
 		const index = array.findIndex(obj => obj.name === name)
 		if (getIndex)
@@ -2603,7 +2603,7 @@ function InstructModal({ isOpen, closeModal, sessionStorage, updateTemplateDB, s
 		fileInput.click();
 		document.body.removeChild(fileInput);
 	};
-	
+
 	return getArrObjByName(templateList,selectedTemplate) && html`
 		<${Modal} isOpen=${isOpen} onClose=${closeModal}
 			title="Instruct Templates"
@@ -2661,20 +2661,20 @@ function InstructModal({ isOpen, closeModal, sessionStorage, updateTemplateDB, s
 					value=${selectedTemplate}
 					onValueChange=${setSelectedTemplate}
 					options=${templateList}/>
-					<button
-						title="Add Instruct Template"
-						disabled=${!!cancel}
-						class="hbox-button"
-						onClick=${() => handleInstructTemplateAdd()}>
-						New
-					</button>
-					<button
-						title="Delete Selected Instruct Template"
-						disabled=${!!cancel}
-						class="hbox-button"
-						onClick=${() => handleInstructTemplateDelete(selectedTemplate)}>
-						Delete
-					</button>
+				<button
+					title="Add Instruct Template"
+					disabled=${!!cancel}
+					class="hbox-button"
+					onClick=${() => handleInstructTemplateAdd()}>
+					New
+				</button>
+				<button
+					title="Delete Selected Instruct Template"
+					disabled=${!!cancel}
+					class="hbox-button"
+					onClick=${() => handleInstructTemplateDelete(selectedTemplate)}>
+					Delete
+				</button>
 			</div>
 			<hr/>
 			<div class="instructmodal-edits">
@@ -2687,8 +2687,6 @@ function InstructModal({ isOpen, closeModal, sessionStorage, updateTemplateDB, s
 						value=${getArrObjByName(templateList,selectedTemplate).nameNew}
 						onInput=${e => handleInstructTemplateChange(selectedTemplate,"name",e.target.value,getArrObjByName(templateList,selectedTemplate).nameBack)}
 						onValueChange=${() => {}}/>
-				
-				
 
 				<div className="hbox">
 					<${InputBox} label="Instruct Prefix {inst}"
@@ -2778,7 +2776,7 @@ class SessionStorage extends EventTarget {
 				reject(openRequest.error);
 			};
 			openRequest.onsuccess = () => resolve(openRequest.result);
-			
+
 			openRequest.onupgradeneeded = (event) => {
 				const db = event.target.result;
 				this.storeNames.forEach(storeName => {
@@ -3145,7 +3143,7 @@ class WebSessionStorage extends SessionStorage {
 				reject(res.status);
 				return;
 			}
-			
+
 			// Select another session if the current was deleted
 			if (sessionId == this.selectedSession) {
 				const sessionIds = Object.keys(this.sessions).map(x => +x);
@@ -3525,7 +3523,7 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 		setAddDeleteTemplate(false)
 
 	}, [addDeleteTemplate]);
-	
+
 
 	const updateTemplateDB = async () => {
 		setTemplates((prevState) => {
@@ -3563,7 +3561,7 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 	const updateTemplateDBCaller = useMemo(() => {
 		updateTemplateDB()
 	}, [modalState["instruct"],selectedTemplate]);
-	
+
 
 	const toggleModal = (modalKey) => {
 		setModalState((prevState) => ({
@@ -4162,7 +4160,7 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 					container.style.borderLeft = '2px dotted transparent';
 					break;
 			}
-			
+
 			if (!isDragging) return;
 
 			// reset selection
@@ -4767,7 +4765,7 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 			setLogitBiasParam=${setLogitBiasParam}
 			sessionStorage=${sessionStorage} endpoint=${endpoint} endpointAPI=${endpointAPI} endpointAPIKey=${endpointAPIKey} isMikupadEndpoint=${isMikupadEndpoint}
 			cancel=${cancel}/>
-		
+
 		<!-- Sorry. -->
 		<${InstructModal}
 			isOpen=${modalState.instruct}
@@ -4809,7 +4807,7 @@ async function main() {
 			reportError(e);
 		}
 	}
-	
+
 	if (sessionStorage == null) {
 		sessionStorage = new SessionStorage();
 		await sessionStorage.init();

--- a/mikupad.html
+++ b/mikupad.html
@@ -2610,6 +2610,7 @@ function InstructModal({ isOpen, closeModal, sessionStorage, updateTemplateDB, s
 				<${SelectBoxTemplate}
 					id="instructModalSelect"
 					label="Instruct Template"
+					disabled=${!!cancel}
 					value=${selectedTemplate}
 					onValueChange=${setSelectedTemplate}
 					options=${templateList}/>
@@ -4419,6 +4420,7 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 				<div className="buttons instructTemplateSidebar">
 					<${SelectBoxTemplate}
 						label="Instruct Template"
+						disabled=${!!cancel}
 						value=${selectedTemplate}
 						onValueChange=${setSelectedTemplate}
 						options=${templateList}/>

--- a/mikupad.html
+++ b/mikupad.html
@@ -483,11 +483,16 @@ html.nockoffAI .wi-entry-name input {
 }
 
 .symbol-button {
+	position: relative;
 	margin-top: auto;
-	display: flex;
-	justify-content: center;
-	width: 1.625rem;
+	width: 2.182rem;
 	height: 1.625rem;
+}
+.symbol-button > svg {
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
 } 
 
 /* logit bias */
@@ -4477,21 +4482,21 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 						disabled=${!!cancel}
 						class="symbol-button"
 						onClick=${() => toggleModal("instruct")}>
-						<svg xmlns="http://www.w3.org/2000/svg" width="12" height="-12" viewBox="-1 -5 8 7"><path d="M0 0 3-3C3-4 3-5 5-5L4-4 5-3 6-4C6-2 5-2 4-2L1 1C0 2-1 1 0 0" fill="var(--color-light)"/></svg>
+						<svg style=${{ 'width':'1em' }} xmlns="http://www.w3.org/2000/svg"  viewBox="-1 -5 8 7"><path d="M0 0 3-3C3-4 3-5 5-5L4-4 5-3 6-4C6-2 5-2 4-2L1 1C0 2-1 1 0 0" fill="var(--color-light)"/></svg>
 					</button>
 					<button
 						title="Insert System Prompt Template"
 						disabled=${!!cancel}
 						class="symbol-button"
 						onClick=${() => insertTemplate("sys")}>
-						<svg xmlns="http://www.w3.org/2000/svg" width="12" height="-12" viewBox="0 -10 10 10"><path d="M 0 -2 L 1 -1 L 5 -5 L 1 -9 L 0 -8 L 3 -5 L 0 -2 M 4 -1 L 10 -1 L 10 -2.4 L 4 -2.4" fill="var(--color-light)"/></svg>
+						<svg style=${{ 'width':'1em' }} xmlns="http://www.w3.org/2000/svg"  viewBox="0 -10 10 10"><path d="M 0 -2 L 1 -1 L 5 -5 L 1 -9 L 0 -8 L 3 -5 L 0 -2 M 4 -1 L 10 -1 L 10 -2.4 L 4 -2.4" fill="var(--color-light)"/></svg>
 					</button>
 					<button
 						title="Insert Instruct Template"
 						disabled=${!!cancel}
 						class="symbol-button"
 						onClick=${() => insertTemplate("inst")}>
-						<svg xmlns="http://www.w3.org/2000/svg" width="10" height="15" viewBox="0 -10 5 10"><path d="M 2.5 -6 A 0.75 0.75 90 0 0 3.25 -6.75 A 0.75 0.75 90 0 0 2.5 -7.5 A 0.75 0.75 90 0 0 1.75 -6.75 A 0.75 0.75 90 0 0 2.5 -6 M 1 0 L 4 0 L 4 -1 L 3 -1 L 3 -5 L 1 -5 L 1 -4 L 2 -4 L 2 -1 L 1 -1 Z" fill="var(--color-light)"/></svg>
+						<svg style=${{ 'height':'1.2em','transform':'translate(-50%, -60%)' }} xmlns="http://www.w3.org/2000/svg"  viewBox="0 -10 5 10"><path d="M 2.5 -6 A 0.75 0.75 90 0 0 3.25 -6.75 A 0.75 0.75 90 0 0 2.5 -7.5 A 0.75 0.75 90 0 0 1.75 -6.75 A 0.75 0.75 90 0 0 2.5 -6 M 1 0 L 4 0 L 4 -1 L 3 -1 L 3 -5 L 1 -5 L 1 -4 L 2 -4 L 2 -1 L 1 -1 Z" fill="var(--color-light)"/></svg>
 					</button>
 				</div>
 				<${InputBox} label="Seed (-1 = random)" type="text" inputmode="numeric"

--- a/mikupad.html
+++ b/mikupad.html
@@ -585,7 +585,6 @@ html.nockoffAI .wi-entry-name input {
 }
 
 #instructmodal-name {
-
 	size:110%;
 }
 .instructmodal-edits .hbox {
@@ -2608,7 +2607,8 @@ function InstructModal({ isOpen, closeModal, sessionStorage, updateTemplateDB, s
 		<${Modal} isOpen=${isOpen} onClose=${closeModal}
 			title="Instruct Templates"
 			description="Use placeholders to insert the selected prompt template formats when sending your prompt to the model.
-			Placeholders are listed below. You can insert newlines with '\\n'.">
+			Placeholders are listed below. You can insert newlines with '\\n'.
+			When Chat Mode is active, the 'Instruct Suffix' field of the current template will be added at the end of your prompt, before it is processed by the model. Similarly, the 'Instruct Prefix' field will be added at the end of the model's response.">
 			<div id="advancedContextPlaceholders">
 				<table border="1" frame="void" rules="all">
 					<thead>

--- a/mikupad.html
+++ b/mikupad.html
@@ -4482,21 +4482,21 @@ export function App({ sessionStorage, useSessionState, useDBTemplates, isMikupad
 						disabled=${!!cancel}
 						class="symbol-button"
 						onClick=${() => toggleModal("instruct")}>
-						<svg style=${{ 'width':'1em' }} xmlns="http://www.w3.org/2000/svg"  viewBox="-1 -5 8 7"><path d="M0 0 3-3C3-4 3-5 5-5L4-4 5-3 6-4C6-2 5-2 4-2L1 1C0 2-1 1 0 0" fill="var(--color-light)"/></svg>
+						<svg style=${{ 'width':'.95em','transform':'translate(-50%, -45%)' }} xmlns="http://www.w3.org/2000/svg"  viewBox="-1 -5 8 7"><path d="M0 0 3-3C3-4 3-5 5-5L4-4 5-3 6-4C6-2 5-2 4-2L1 1C0 2-1 1 0 0" fill="var(--color-light)"/></svg>
 					</button>
 					<button
 						title="Insert System Prompt Template"
 						disabled=${!!cancel}
 						class="symbol-button"
 						onClick=${() => insertTemplate("sys")}>
-						<svg style=${{ 'width':'1em' }} xmlns="http://www.w3.org/2000/svg"  viewBox="0 -10 10 10"><path d="M 0 -2 L 1 -1 L 5 -5 L 1 -9 L 0 -8 L 3 -5 L 0 -2 M 4 -1 L 10 -1 L 10 -2.4 L 4 -2.4" fill="var(--color-light)"/></svg>
+						<svg style=${{ 'width':'.9em' }} xmlns="http://www.w3.org/2000/svg"  viewBox="0 -10 10 10"><path d="M 0 -2 L 1 -1 L 5 -5 L 1 -9 L 0 -8 L 3 -5 L 0 -2 M 4 -1 L 10 -1 L 10 -2.4 L 4 -2.4" fill="var(--color-light)"/></svg>
 					</button>
 					<button
 						title="Insert Instruct Template"
 						disabled=${!!cancel}
 						class="symbol-button"
 						onClick=${() => insertTemplate("inst")}>
-						<svg style=${{ 'height':'1.2em','transform':'translate(-50%, -60%)' }} xmlns="http://www.w3.org/2000/svg"  viewBox="0 -10 5 10"><path d="M 2.5 -6 A 0.75 0.75 90 0 0 3.25 -6.75 A 0.75 0.75 90 0 0 2.5 -7.5 A 0.75 0.75 90 0 0 1.75 -6.75 A 0.75 0.75 90 0 0 2.5 -6 M 1 0 L 4 0 L 4 -1 L 3 -1 L 3 -5 L 1 -5 L 1 -4 L 2 -4 L 2 -1 L 1 -1 Z" fill="var(--color-light)"/></svg>
+						<svg style=${{ 'height':'1.05em','transform':'translate(-50%, -60%)' }} xmlns="http://www.w3.org/2000/svg"  viewBox="0 -10 5 10"><path d="M 2.5 -6 A 0.75 0.75 90 0 0 3.25 -6.75 A 0.75 0.75 90 0 0 2.5 -7.5 A 0.75 0.75 90 0 0 1.75 -6.75 A 0.75 0.75 90 0 0 2.5 -6 M 1 0 L 4 0 L 4 -1 L 3 -1 L 3 -5 L 1 -5 L 1 -4 L 2 -4 L 2 -1 L 1 -1 Z" fill="var(--color-light)"/></svg>
 					</button>
 				</div>
 				<${InputBox} label="Seed (-1 = random)" type="text" inputmode="numeric"


### PR DESCRIPTION
I've added functionality to select from a list of instruct formats. Then you can either click a button to insert the template directly into your prompt, or you can use placeholders, `{sys}` `{/sys}` `{inst}` and `{/inst}` in your prompt instead, which will be replaced with the selected instruct formats when being evaluated by the model. These placeholders can be used in the persistent context areas as well.
Furthermore, you can add, delete, import and export templates. The UI's ugly as sin, so I'll be more than happy to implement any suggestions you can think of.
![firefox_2024-05-01_21-37-11](https://github.com/lmg-anon/mikupad/assets/50079394/c3e7262f-99c9-44ae-990e-70d5bd427d9d)
![firefox_2024-05-01_19-49-38](https://github.com/lmg-anon/mikupad/assets/50079394/8cd3d8a8-5431-4ad7-b572-89a43918a988)
![firefox_2024-05-01_20-19-06](https://github.com/lmg-anon/mikupad/assets/50079394/22d5dbe1-4455-4326-bfc8-15c0d9667466)




I've never worked with indexedDB before, so be sure to double check the code related to this. Judging by some situations I've seen early on, this has potential to lock up the entire page if the db version upgrade doesn't work as intended, until you either clear the storage, or downgrade mikupad.