### PR TITLE
added compile workflow

### DIFF
--- a/.github/workflows/compile_mikupad.yml
+++ b/.github/workflows/compile_mikupad.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 jobs:
   build:

--- a/.github/workflows/compile_mikupad.yml
+++ b/.github/workflows/compile_mikupad.yml
@@ -1,0 +1,53 @@
+name: compile mikupad
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '16'
+
+    - name: Copy mikupad.html to project directory
+      run: cp -f mikupad.html project
+
+    - name: Install dependencies
+      run: npm install
+      working-directory: ./project
+
+    - name: Build the project
+      run: npm run build
+      working-directory: ./project
+
+    - name: Copy built mikupad.html to root directory
+      run: cp -f ./project/dist/mikupad.html ./mikupad_compiled.html
+
+    - name: Commit and push changes
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "github-actions[bot]@users.noreply.github.com"
+        git add -f mikupad_compiled.html
+        git commit -m "Update mikupad_compiled.html"
+        git push origin main
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: mikupad_compiled
+        path: mikupad_compiled.html
+

--- a/.github/workflows/compile_mikupad.yml
+++ b/.github/workflows/compile_mikupad.yml
@@ -60,7 +60,7 @@ jobs:
         else
           OLD_COMMIT="${{ steps.last_release.outputs.tag }}"
           NUM_COMMITS="${{ steps.build_ids.outputs.number }}"
-          NEW_COMMITS="$(($NUM_COMMITS - $OLD_COMMIT + 1))"
+          NEW_COMMITS="$(($NUM_COMMITS - $OLD_COMMIT))"
           echo "Generating changelog with $NEW_COMMITS commits starting from $OLD_COMMIT"
           
           # echo changelog

--- a/.github/workflows/compile_mikupad.yml
+++ b/.github/workflows/compile_mikupad.yml
@@ -1,4 +1,4 @@
-name: compile mikupad
+name: Release Mikupad
 
 on:
   push:
@@ -12,7 +12,10 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-
+      with:
+        fetch-depth: 0
+        ref: main
+        
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:
@@ -21,19 +24,58 @@ jobs:
     - name: run compile.sh
       run: chmod +x compile.sh; ./compile.sh
 
-    - name: Commit and push changes
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Determine Tag and Build Names
+      id: build_ids
       run: |
-        git config --global user.name "github-actions[bot]"
-        git config --global user.email "github-actions[bot]@users.noreply.github.com"
-        git add -f mikupad_compiled.html
-        git commit -m "Update mikupad_compiled.html" || echo "No changes to commit"
-        git push origin main || echo "Nothing to push"
+        # use number of commits as build ID
+        
+        BUILD_NUMBER="$(git rev-list --count HEAD)"
+        echo "number=${BUILD_NUMBER}" >> $GITHUB_OUTPUT
+        
+        SHORT_HASH="$(git rev-parse --short=7 HEAD)"
+        echo "buildName=Mikupad #${BUILD_NUMBER} [${SHORT_HASH}]" >> $GITHUB_OUTPUT
+        
+        echo "Build: $BUILD_NUMBER $SHORT_HASH"
+      
+    - name: Get Last Release Tag
+      id: last_release
+      run: |
+        # find previous release to determine how many commits should be displayed in the changelog
+        TAG=$(git tag --list 'release*' --sort=-v:refname | head -n 1)
+        if [ -z "$TAG" ]; then
+          echo "No release tag found"
+          echo "tag=$(echo 'none')" >> $GITHUB_OUTPUT
+        else
+          TAG_NUMBER=$(echo $TAG | sed 's/release//')
+          echo "Found release tag: $TAG"
+          echo "tag=$TAG_NUMBER" >> $GITHUB_OUTPUT
+        fi
 
-    - name: Upload artifact
-      uses: actions/upload-artifact@v4
+    - name: Generate Changelog
+      id: changelog
+      run: |
+        # if no previous release, don't dump the entire history
+        if [ "${{ steps.last_release.outputs.tag }}" = "none" ]; then
+          echo "mikudayo~" > CHANGELOG.txt
+        else
+          OLD_COMMIT="${{ steps.last_release.outputs.tag }}"
+          NUM_COMMITS="${{ steps.build_ids.outputs.number }}"
+          NEW_COMMITS="$(($NUM_COMMITS - $OLD_COMMIT))"
+          echo "Generating changelog with $NEW_COMMITS commits starting from $OLD_COMMIT"
+          
+          # echo changelog
+          echo "Generated $(date +'%Y-%m-%d %T')" >> CHANGELOG.txt
+          echo "\`\`\`" >> CHANGELOG.txt
+          echo "$(git log --graph -n $NEW_COMMITS --oneline)" >> CHANGELOG.txt
+          echo "\`\`\`" >> CHANGELOG.txt
+        fi
+
+    - name: Release
+      uses: softprops/action-gh-release@v2
       with:
-        name: mikupad_compiled
-        path: mikupad_compiled.html
+        tag_name: release${{ steps.build_ids.outputs.number }}
+        name: ${{ steps.build_ids.outputs.buildName }}
+        body_path: CHANGELOG.txt 
+        files: mikupad_compiled.html
+        token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/compile_mikupad.yml
+++ b/.github/workflows/compile_mikupad.yml
@@ -64,7 +64,7 @@ jobs:
           echo "Generating changelog with $NEW_COMMITS commits starting from $OLD_COMMIT"
           
           # echo changelog
-          echo "Generated $(date +'%Y-%m-%d %T %Z %z')" >> CHANGELOG.txt
+          echo "Generated $(date +'%Y-%m-%d %T %Z%z')" >> CHANGELOG.txt
           echo "\`\`\`" >> CHANGELOG.txt
           echo "$(git log --graph -n $NEW_COMMITS --oneline)" >> CHANGELOG.txt
           echo "\`\`\`" >> CHANGELOG.txt

--- a/.github/workflows/compile_mikupad.yml
+++ b/.github/workflows/compile_mikupad.yml
@@ -39,8 +39,8 @@ jobs:
         git config --global user.name "github-actions[bot]"
         git config --global user.email "github-actions[bot]@users.noreply.github.com"
         git add -f mikupad_compiled.html
-        git commit -m "Update mikupad_compiled.html"
-        git push origin main
+        git commit -m "Update mikupad_compiled.html" || echo "No changes to commit"
+        git push origin main || echo "Nothing to push"
 
     - name: Upload artifact
       uses: actions/upload-artifact@v3

--- a/.github/workflows/compile_mikupad.yml
+++ b/.github/workflows/compile_mikupad.yml
@@ -60,7 +60,7 @@ jobs:
         else
           OLD_COMMIT="${{ steps.last_release.outputs.tag }}"
           NUM_COMMITS="${{ steps.build_ids.outputs.number }}"
-          NEW_COMMITS="$(($NUM_COMMITS - $OLD_COMMIT))"
+          NEW_COMMITS="$(($NUM_COMMITS - $OLD_COMMIT + 1))"
           echo "Generating changelog with $NEW_COMMITS commits starting from $OLD_COMMIT"
           
           # echo changelog

--- a/.github/workflows/compile_mikupad.yml
+++ b/.github/workflows/compile_mikupad.yml
@@ -18,19 +18,8 @@ jobs:
       with:
         node-version: '20'
 
-    - name: Copy mikupad.html to project directory
-      run: cp -f mikupad.html project
-
-    - name: Install dependencies
-      run: npm install
-      working-directory: ./project
-
-    - name: Build the project
-      run: npm run build
-      working-directory: ./project
-
-    - name: Copy built mikupad.html to root directory
-      run: cp -f ./project/dist/mikupad.html ./mikupad_compiled.html
+    - name: run compile.sh
+      run: chmod +x compile.sh; ./compile.sh
 
     - name: Commit and push changes
       env:

--- a/.github/workflows/compile_mikupad.yml
+++ b/.github/workflows/compile_mikupad.yml
@@ -64,7 +64,7 @@ jobs:
           echo "Generating changelog with $NEW_COMMITS commits starting from $OLD_COMMIT"
           
           # echo changelog
-          echo "Generated $(date +'%Y-%m-%d %T')" >> CHANGELOG.txt
+          echo "Generated $(date +'%Y-%m-%d %T %Z %z')" >> CHANGELOG.txt
           echo "\`\`\`" >> CHANGELOG.txt
           echo "$(git log --graph -n $NEW_COMMITS --oneline)" >> CHANGELOG.txt
           echo "\`\`\`" >> CHANGELOG.txt

--- a/.github/workflows/compile_mikupad.yml
+++ b/.github/workflows/compile_mikupad.yml
@@ -11,12 +11,12 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
-        node-version: '16'
+        node-version: '20'
 
     - name: Copy mikupad.html to project directory
       run: cp -f mikupad.html project
@@ -43,7 +43,7 @@ jobs:
         git push origin main || echo "Nothing to push"
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: mikupad_compiled
         path: mikupad_compiled.html


### PR DESCRIPTION
A workflow that automatically builds `mikupad_compiled.html`. Feel free to close if this isn't something you want.
It runs the compile.sh script, and then automatically pushed to the repository.
I've got it running on [my main branch](https://github.com/neCo2/mikupad) if you want to see the result.

~~It kept bugging me about updating to the v4 actions and the npm version, so I did that, but for some reason it gets stuck on `Cleaning up orphan processes` for 20+ minutes now. It builds and pushes no problem, but then the action gets stuck at the end and doesn't actually complete.~~

~~It appears that this might be caused by issues with github rather than the action itself: https://github.com/orgs/community/discussions/15133#discussioncomment-5469332
![firefox_2024-05-21_15-15-09](https://github.com/lmg-anon/mikupad/assets/50079394/508b965d-f032-4b37-a1ee-5467fc1b1f61)~~

Everything working as intended now. Looks like it was the partial outage.