### PR TITLE
Fix Uncaught TypeError: chunk.completion_probabilities[0] is undefined in Chat Mode

### DIFF
--- a/mikupad.html
+++ b/mikupad.html
@@ -1354,7 +1354,7 @@ async function* llamaCppCompletion({ endpoint, endpointAPIKey, proxyEndpoint, si
 	if (!res.ok)
 		throw new Error(`HTTP ${res.status}`);
 	for await (const chunk of parseEventStream(res.body)) {
-		const probs = chunk.completion_probabilities[0].probs;
+		const probs = chunk.completion_probabilities[0]?.probs;
 		const prob = probs?.find(p => p.tok_str === chunk.content)?.prob;
 		yield {
 			content: chunk.content,


### PR DESCRIPTION
When chat mode is active, the following error occurs at the end of generation, and the instruct prefix fails to be added to the end of the prompt.
```
Uncaught TypeError: chunk.completion_probabilities[0] is undefined
    llamaCppCompletion file:///C:/Programs/mikupad/mikupad.html:1357
```
Changing the operator to optional chaining should take care of the problem.