### PR TITLE
Fix Uncaught TypeError: value is undefined when switching Chat Templates

### DIFF
--- a/mikupad.html
+++ b/mikupad.html
@@ -3578,7 +3578,7 @@ function replaceUnprintableBytes(inputString) {
 
 function replaceNewlines(template) {
 	return Object.fromEntries(
-		Object.entries(template).map(([key, value]) => [key, value.replaceAll("\\n", "\n")])
+		Object.entries(template).map(([key, value]) => [key, value?.replaceAll("\\n", "\n")])
 	);
 }
 


### PR DESCRIPTION
I think the undefined `fimTemplate`s were causing problems with the `replaceNewlines` function when trying to generate after switching the template. Again a `?` should fix the issue.
```
Uncaught TypeError: value is undefined
    replaceNewlines mikupad.html:3581
```