### PR TITLE
added breakdown bar for context

### DIFF
--- a/mikupad.html
+++ b/mikupad.html
@@ -1086,6 +1086,15 @@ html.monospace-dark .eye-button {
 	}
 }
 
+.contextBar {
+	height:1.25em;
+	border-radius:2px;
+	overflow:hidden;
+}
+.contextBar-contextModal {
+	margin-top:.25em;
+}
+
 @media (min-width: 767.98px) {
 	#sidebar .SelectBox:first-child, .horz-separator, .collapsible-group {
 		display: block !important;
@@ -1975,7 +1984,27 @@ function Sessions({ sessionStorage, disabled }) {
 		</div>`;
 }
 
+const PercentageBar = ({ values, names, className, colors }) => {
+	const color = colors ? colors : ["#fff","#8c94ff","#8cff94","#ff948c"]
+	const total = values.reduce((acc, curr) => acc + curr, 0);
+	const percentages = values.map(value => (value / total) * 100);
 
+	return html`
+		<div className="${className}" style=${{ opacity: "80%", background: 'grey', display: 'flex', flexDirection: 'row' }}>
+		${values.map((value, index) =>  html`
+			<div class="tooltip"
+			key=${index}
+			title='${names[index]} (${percentages[index].toFixed(1)}%)'
+			style=${{
+				backgroundColor: color[index],
+				width: percentages[index] + '%',
+				height: '100%'
+			}}>
+			</div>
+		`)}
+		</div>
+	`;
+};
 
 function Modal({ isOpen, onClose, title, description, children, ...props }) {
 	if (!isOpen) {
@@ -2098,10 +2127,10 @@ function ContextModal({ isOpen, closeModal, tokens, memoryTokens, authorNoteToke
 				<thead>
 					<tr>
 						<th></th>
+						<th>Prompt</th>
 						<th>Memory</th>
 						<th>World Info</th>
 						<th>Author's Note</th>
-						<th>Prompt</th>
 						<th></th>
 						<th>Total</th>
 					</tr>
@@ -2109,15 +2138,30 @@ function ContextModal({ isOpen, closeModal, tokens, memoryTokens, authorNoteToke
 				<tbody>
 					<tr>
 						<th>Tokens</th>
+						<td>${tokens - authorNoteTokens.tokens - memoryTokens.tokensWI - memoryTokens.tokens}</td>
 						<td>${memoryTokens.tokens}</td>
 						<td>${memoryTokens.tokensWI}</td>
 						<td>${authorNoteTokens.tokens}</td>
-						<td>${tokens - authorNoteTokens.tokens - memoryTokens.tokensWI - memoryTokens.tokens}</td>
 						<td></td>
 						<td>${tokens}</td>
 					</tr>
 				</tbody>
 			</table>
+			<${PercentageBar}
+					className="contextBar contextBar-contextModal"
+					values=${[
+						tokens - authorNoteTokens.tokens - memoryTokens.tokensWI - memoryTokens.tokens,
+						memoryTokens.tokens,
+						memoryTokens.tokensWI,
+						authorNoteTokens.tokens,
+					]}
+					names=${[
+						"Prompt",
+						"Memory",
+						"World Info",
+						"Author's Note"
+					]}>
+				</${PercentageBar}>
 			</div>
 			<${CollapsibleGroup} label="Advanced Context Ordering">
 				<div id="context-order-desc">
@@ -3696,6 +3740,7 @@ export function App({ sessionStorage, templateStorage, useSessionState, useDBTem
 	const [showProbs, setShowProbs] = useState(true);
 	const [cancel, setCancel] = useState(null);
 	const [spellCheck, setSpellCheck] = usePersistentState('spellCheck', false);
+	const [showContextBar, setShowContextBar] = usePersistentState('showContextBar', false);
 	const [attachSidebar, setAttachSidebar] = usePersistentState('attachSidebar', false);
 	const [showProbsMode, setShowProbsMode] = usePersistentState('showProbsMode', 0);
 	const [highlightGenTokens, setHighlightGenTokens] = usePersistentState('highlightGenTokens', true);
@@ -5206,6 +5251,23 @@ export function App({ sessionStorage, templateStorage, useSessionState, useDBTem
 			</${CollapsibleGroup}>
 			${!!tokens && html`
 				<${InputBox} label="Tokens" value=${tokens} readOnly/>`}
+			${showContextBar && !!tokens && html`
+				<${PercentageBar}
+				className="contextBar"
+					values=${[
+						tokens - authorNoteTokens.tokens - memoryTokens.tokensWI - memoryTokens.tokens,
+						memoryTokens.tokens,
+						memoryTokens.tokensWI,
+						authorNoteTokens.tokens,
+					]}
+					names=${[
+						"Prompt",
+						"Memory",
+						"World Info",
+						"Author's Note"
+					]}>
+				</${PercentageBar}>
+			`}
 			<div className="buttons">
 				<button
 					title="Run next prediction (Ctrl + Enter)"
@@ -5268,6 +5330,8 @@ export function App({ sessionStorage, templateStorage, useSessionState, useDBTem
 			closeModal=${() => closeModal("prompt")}>
 			<${Checkbox} label="Enable spell checking"
 				value=${spellCheck} onValueChange=${setSpellCheck}/>
+			<${Checkbox} label="Show Context Breakdown Bar"
+				value=${showContextBar} onValueChange=${setShowContextBar}/>
 			<${Checkbox} label="Attach sidebar"
 				value=${attachSidebar} onValueChange=${setAttachSidebar}/>
 			<${Checkbox} label="Highlight generated tokens"

--- a/mikupad.html
+++ b/mikupad.html
@@ -1099,6 +1099,19 @@ html.monospace-dark .eye-button {
 	margin-top:.25em;
 }
 
+.contextBar .percentagebar-Prompt {
+	background-color: #fff;
+}
+.contextBar .percentagebar-Memory {
+	background-color: #8c94ff;
+}
+.contextBar .percentagebar-World-Info {
+	background-color: #8cff94;
+}
+.contextBar .percentagebar-Author-s-Note {
+	background-color: #ff948c;
+}
+
 @media (min-width: 767.98px) {
 	#sidebar .SelectBox:first-child, .horz-separator, .collapsible-group {
 		display: block !important;
@@ -2174,8 +2187,11 @@ const SVG_Redo = ({...props}) => {
 	<${SVG_Undo}
 		...${props}
 		style=${{ 'transform':'scaleX(-1)' }}/>
-`};const PercentageBar = ({ values, names, className, colors }) => {
-	const color = colors ? colors : ["#fff","#8c94ff","#8cff94","#ff948c"]
+`};
+
+
+const PercentageBar = ({ values, names, className, colors }) => {
+	// const color = colors ? colors : ["#fff","#8c94ff","#8cff94","#ff948c"]
 	const total = values.reduce((acc, curr) => acc + curr, 0);
 	const percentages = values.map(value => (value / total) * 100);
 
@@ -2183,13 +2199,14 @@ const SVG_Redo = ({...props}) => {
 		<div className="${className}" style=${{ opacity: "80%", background: 'grey', display: 'flex', flexDirection: 'row' }}>
 		${values.map((value, index) =>  html`
 			<div class="tooltip"
-			key=${index}
-			title='${names[index]} (${percentages[index].toFixed(1)}%)'
-			style=${{
-				backgroundColor: color[index],
-				width: percentages[index] + '%',
-				height: '100%'
-			}}>
+				key=${index}
+				title='${names[index]} (${percentages[index].toFixed(1)}%)'
+				classNames='${"percentagebar-" + names[index].replace(/[ .'*]/g,"-")}'
+				style=${{
+					...( colors ? { backgroundColor: colors[index], } : {} ),
+					width: percentages[index] + '%',
+					height: '100%'
+				}}>
 			</div>
 		`)}
 		</div>

--- a/mikupad.html
+++ b/mikupad.html
@@ -2204,7 +2204,7 @@ const PercentageBar = ({ values, names, className, colors }) => {
 			<div class="tooltip"
 				key=${index}
 				title='${names[index]} (${percentages[index].toFixed(1)}%)'
-				classNames='${"percentagebar-" + names[index].replace(/[ .'*]/g,"-")}'
+				className='${"percentagebar-" + names[index].replace(/[^a-z]/ig,"-")}'
 				style=${{
 					...( colors ? { backgroundColor: colors[index], } : {} ),
 					width: percentages[index] + '%',

--- a/mikupad.html
+++ b/mikupad.html
@@ -1111,6 +1111,9 @@ html.monospace-dark .eye-button {
 .contextBar .percentagebar-Author-s-Note {
 	background-color: #ff948c;
 }
+.contextBar .percentagebar-Free-Context {
+	background-color: #fff0;
+}
 
 @media (min-width: 767.98px) {
 	#sidebar .SelectBox:first-child, .horz-separator, .collapsible-group {
@@ -2324,7 +2327,7 @@ function AuthorNoteModal({ isOpen, closeModal, authorNoteTokens, handleauthorNot
 			</${Modal}>`;
 }
 
-function ContextModal({ isOpen, closeModal, tokens, memoryTokens, authorNoteTokens, handleMemoryTokensChange, finalPromptText, defaultPresets, cancel }) {
+function ContextModal({ isOpen, closeModal, tokens, contextLength, memoryTokens, authorNoteTokens, handleMemoryTokensChange, finalPromptText, defaultPresets, cancel }) {
 	return html`
 		<${Modal} isOpen=${isOpen} onClose=${closeModal}
 			title="Context"
@@ -2361,12 +2364,14 @@ function ContextModal({ isOpen, closeModal, tokens, memoryTokens, authorNoteToke
 						memoryTokens.tokens,
 						memoryTokens.tokensWI,
 						authorNoteTokens.tokens,
+						Math.max(contextLength - tokens, 0)
 					]}
 					names=${[
 						"Prompt",
 						"Memory",
 						"World Info",
-						"Author's Note"
+						"Author's Note",
+						"Free Context"
 					]}>
 				</${PercentageBar}>
 			</div>
@@ -5497,12 +5502,14 @@ export function App({ sessionStorage, templateStorage, useSessionState, useDBTem
 						memoryTokens.tokens,
 						memoryTokens.tokensWI,
 						authorNoteTokens.tokens,
+						Math.max(contextLength - tokens, 0)
 					]}
 					names=${[
 						"Prompt",
 						"Memory",
 						"World Info",
-						"Author's Note"
+						"Author's Note",
+						"Free Context"
 					]}>
 				</${PercentageBar}>
 			`}
@@ -5614,6 +5621,7 @@ export function App({ sessionStorage, templateStorage, useSessionState, useDBTem
 			isOpen=${modalState.context}
 			closeModal=${() => closeModal("context")}
 			tokens=${tokens}
+			contextLength=${contextLength}
 			memoryTokens=${memoryTokens}
 			authorNoteTokens=${authorNoteTokens}
 			handleMemoryTokensChange=${handleMemoryTokensChange}

--- a/mikupad.html
+++ b/mikupad.html
@@ -1105,13 +1105,13 @@ html.monospace-dark .eye-button {
 .contextBar .percentagebar-Memory {
 	background-color: #8c94ff;
 }
-.contextBar .percentagebar-World-Info {
+.contextBar .percentagebar-WorldInfo {
 	background-color: #8cff94;
 }
-.contextBar .percentagebar-Author-s-Note {
+.contextBar .percentagebar-AuthorsNote {
 	background-color: #ff948c;
 }
-.contextBar .percentagebar-Free-Context {
+.contextBar .percentagebar-FreeContext {
 	background-color: #fff0;
 }
 
@@ -2193,18 +2193,18 @@ const SVG_Redo = ({...props}) => {
 `};
 
 
-const PercentageBar = ({ values, names, className, colors }) => {
+const PercentageBar = ({ values, className, colors }) => {
 	// const color = colors ? colors : ["#fff","#8c94ff","#8cff94","#ff948c"]
-	const total = values.reduce((acc, curr) => acc + curr, 0);
-	const percentages = values.map(value => (value / total) * 100);
+	const total = Object.values(values).reduce((acc, curr) => acc + curr, 0);
+	const percentages = Object.values(values).map(value => (value / total) * 100);
 
 	return html`
 		<div className="${className}" style=${{ opacity: "80%", background: 'grey', display: 'flex', flexDirection: 'row' }}>
-		${values.map((value, index) =>  html`
+		${Object.keys(values).map((name, index) =>  html`
 			<div class="tooltip"
 				key=${index}
-				title='${names[index]} (${percentages[index].toFixed(1)}%)'
-				className='${"percentagebar-" + names[index].replace(/[^a-z]/ig,"-")}'
+				title='${name} (${percentages[index].toFixed(1)}%)'
+				className='${"percentagebar-" + name.replace(/[^a-z]/ig,"")}'
 				style=${{
 					...( colors ? { backgroundColor: colors[index], } : {} ),
 					width: percentages[index] + '%',
@@ -2359,20 +2359,13 @@ function ContextModal({ isOpen, closeModal, tokens, contextLength, memoryTokens,
 			</table>
 			<${PercentageBar}
 					className="contextBar contextBar-contextModal"
-					values=${[
-						tokens - authorNoteTokens.tokens - memoryTokens.tokensWI - memoryTokens.tokens,
-						memoryTokens.tokens,
-						memoryTokens.tokensWI,
-						authorNoteTokens.tokens,
-						Math.max(contextLength - tokens, 0)
-					]}
-					names=${[
-						"Prompt",
-						"Memory",
-						"World Info",
-						"Author's Note",
-						"Free Context"
-					]}>
+					values=${{
+						"Prompt": tokens - authorNoteTokens.tokens - memoryTokens.tokensWI - memoryTokens.tokens,
+						"Memory": memoryTokens.tokens,
+						"World Info": memoryTokens.tokensWI,
+						"Author's Note": authorNoteTokens.tokens,
+						"Free Context": Math.max(contextLength - tokens, 0)
+					}}>
 				</${PercentageBar}>
 			</div>
 			<${CollapsibleGroup} label="Advanced Context Ordering">
@@ -5497,20 +5490,13 @@ export function App({ sessionStorage, templateStorage, useSessionState, useDBTem
 			${showContextBar && !!tokens && html`
 				<${PercentageBar}
 				className="contextBar"
-					values=${[
-						tokens - authorNoteTokens.tokens - memoryTokens.tokensWI - memoryTokens.tokens,
-						memoryTokens.tokens,
-						memoryTokens.tokensWI,
-						authorNoteTokens.tokens,
-						Math.max(contextLength - tokens, 0)
-					]}
-					names=${[
-						"Prompt",
-						"Memory",
-						"World Info",
-						"Author's Note",
-						"Free Context"
-					]}>
+					values=${{
+						"Prompt": tokens - authorNoteTokens.tokens - memoryTokens.tokensWI - memoryTokens.tokens,
+						"Memory": memoryTokens.tokens,
+						"World Info": memoryTokens.tokensWI,
+						"Author's Note": authorNoteTokens.tokens,
+						"Free Context": Math.max(contextLength - tokens, 0)
+					}}>
 				</${PercentageBar}>
 			`}
 			<div className="buttons">


### PR DESCRIPTION
Added bars that show the composition of your current context in the sidebar and in the context modal. Per default, it isn't visible in the sidebar and has to be turned on in the editor settings modal.

![firefox_2024-06-04_21-16-24](https://github.com/lmg-anon/mikupad/assets/50079394/f372a9df-8f68-4a61-babc-49145133c7af)
![firefox_2024-06-04_21-16-38](https://github.com/lmg-anon/mikupad/assets/50079394/5c8f16b9-a2f2-4dc0-a675-e06af1309a5f)

We should probably talk about the colors, because it's pretty ugly right now.