### PR TITLE
Removed any zero probability tokens from hover pop-up

### DIFF
--- a/mikupad.html
+++ b/mikupad.html
@@ -5661,7 +5661,7 @@ export function App({ sessionStorage, templateStorage, useSessionState, useDBTem
 				style=${{
 					'display': 'none'
 				}}>
-				${probs.map((prob, i) => {
+				${probs.filter(prob => prob.prob > 0).map((prob, i) => {
 					const index = currentPromptChunk?.index;
 					const isCurrentToken = promptChunks[index]?.prob == prob.prob;
 					return html`<button key=${i} className=${isCurrentToken ? 'current' : ''} onClick=${() => switchCompletion(index, prob)}>


### PR DESCRIPTION
Fixes #84

This just removes any that are zero, but could also remove any that round down to `0.00%` like this:

```javascript
${probs ? html`
    <div
        id="probs"
        style=${{
            'display': 'none'
        }}>
        ${probs.map((prob, i) => {
            const probPercentage = (prob.prob * 100).toFixed(2);
            if (probPercentage === '0.00') return null;

            const index = currentPromptChunk?.index;
            const isCurrentToken = promptChunks[index]?.prob == prob.prob;
            return html`<button key=${i} className=${isCurrentToken ? 'current' : ''} onClick=${() => switchCompletion(index, prob)}>
                <div className="tok">${replaceUnprintableBytes(prob.tok_str)}</div>
                <div className="prob">${probPercentage}%</div>
            </button>`;
        }).filter(Boolean)}
    </div>` : null}
```

but if the samplers are set up to select an (extremely unlikely!) sub top-10 `0.00005` probability token; it will look odd that the selected token isn't in the popup IMO... So decided against this.