### PR TITLE
Add import and export buttons to the world info modal

### DIFF
--- a/mikupad.html
+++ b/mikupad.html
@@ -2812,21 +2812,6 @@ function WorldInfoModal({ isOpen, closeModal, worldInfo, setWorldInfo, cancel, t
 		anchor.click();
 	};
 
-	const handleOnDropImportJSON = e => {
-		e.preventDefault();
-		try {
-			const file = e.dataTransfer.files[0];
-			const reader = new FileReader();
-			reader.onload = loadEvent => {
-				setImportEntriesText(loadEvent.target.result);
-			};
-			reader.readAsText(file, "UTF-8");
-		} catch (err) {
-			alert("Error reading file. Please try copying and pasting its contents manually.");
-			console.error(err);
-		}
-	};
-
 	return html`
 		<${Modal} isOpen=${isOpen} onClose=${closeModal}
 			title="World Info"

--- a/mikupad.html
+++ b/mikupad.html
@@ -2643,6 +2643,9 @@ function ContextModal({ isOpen, closeModal, tokens, memoryTokens, authorNoteToke
 }
 
 function WorldInfoModal({ isOpen, closeModal, worldInfo, setWorldInfo, cancel }) {
+	const [showImportEntriesField, setShowImportEntriesField] = useState(false);
+	const [importEntriesText, setImportEntriesText] = useState(null);
+
 	const handleWorldInfoNew = () => {
 		setWorldInfo((prevWorldInfo) => {
 			return {
@@ -2701,14 +2704,142 @@ function WorldInfoModal({ isOpen, closeModal, worldInfo, setWorldInfo, cancel })
 		}));
 	};
 
+	const handleWorldInfoImport = () => {
+		if (showImportEntriesField) {
+			if (!importEntriesText) {
+				alert("Please enter the contents of the exported JSON file by copying and pasting or dragging and dropping the file into the text area.");
+				return;
+			}
+
+			try {
+				const json = JSON.parse(importEntriesText);
+				
+				setWorldInfo(prevWorldInfo => {
+					const updatedEntries = [...prevWorldInfo.entries];
+
+					Object.values(json.entries)?.forEach(entry => {
+						updatedEntries.push({
+							"displayName": entry.comment,
+							"text": entry.content,
+							"keys": [...entry.key],
+							"search": entry.scanDepth || ""
+						});
+					});
+
+					return {
+						...prevWorldInfo,
+						entries: updatedEntries
+					};
+				});
+
+				setShowImportEntriesField(false);
+				setImportEntriesText("");
+			} catch (e) {
+				alert("The JSON data could not be parsed. Please check that it is valid JSON.");
+				console.error(e);
+			}
+		} else {
+			setShowImportEntriesField(true);
+		}
+	};
+
+	const handleWorldInfoExport = () => {
+		const exportedObject = { "entries": {} };
+
+		worldInfo.entries.forEach((entry, entryIndex) => {
+			exportedObject.entries[entryIndex] = {
+				"uid": entryIndex,
+				"key": [...entry.keys],
+				"keysecondary": [],
+				"comment": entry.displayName,
+				"content": entry.text,
+				"constant": false,
+				"vectorized": false,
+				"selective": true,
+				"selectiveLogic": 0,
+				"addMemo": true,
+				"order": 100,
+				"position": 0,
+				"disable": false,
+				"excludeRecursion": false,
+				"preventRecursion": false,
+				"delayUntilRecursion": false,
+				"probability": 100,
+				"useProbability": true,
+				"depth": 4,
+				"group": "",
+				"groupOverride": false,
+				"groupWeight": 100,
+				"scanDepth": entry.search || null,
+				"caseSensitive": null,
+				"matchWholeWords": null,
+				"useGroupScoring": null,
+				"automationId": "",
+				"role": null,
+				"sticky": 0,
+				"cooldown": 0,
+				"delay": 0,
+				"displayIndex": 0
+			};
+		});
+
+		const blob = new Blob([JSON.stringify(exportedObject)], { type: "application/json" });
+		const anchor = document.createElement("a");
+
+		const now = new Date();
+		anchor.download = `mikupad-lorebook-${now.getFullYear()}-${(now.getMonth() + 1).padStart(2, "0")}-${now.getDate().padStart(2, "0")}.json`;
+		anchor.href = (window.webkitURL || window.URL).createObjectURL(blob);
+		anchor.dataset.downloadurl = ["application/json", anchor.download, anchor.href].join(":");
+		anchor.click();
+	};
+
+	const handleImportedJSONChange = (text) => {
+		setImportEntriesText(text);
+	}
+
+	const handleOnDropImportJSON = e => {
+		e.preventDefault();
+		try {
+			const file = e.dataTransfer.files[0];
+			const reader = new FileReader();
+			reader.onload = loadEvent => {
+				setImportEntriesText(loadEvent.target.result);
+			};
+			reader.readAsText(file, "UTF-8");
+		} catch (err) {
+			alert("Error reading file. Please try copying and pasting its contents manually.");
+			console.error(err);
+		}
+	};
+
+	const handleCloseModal = () => {
+		setImportEntriesText("");
+		setShowImportEntriesField(false);
+		closeModal();
+	};
+
 	return html`
-		<${Modal} isOpen=${isOpen} onClose=${closeModal}
+		<${Modal} isOpen=${isOpen} onClose=${handleCloseModal}
 			title="World Info"
 			description="Additional information that is added when specific keywords are found in context.
 			World info will be added at the top of your memory, in the order specified here.
 
 			Each entry will begin on a newline. Keys will be interpreted as case-insensitive regular expressions. Search Range specifies how many tokens back into the context will be searched for activation keys. Search range 0 to disable an entry.">
 			<div id="modal-wi-global">
+				${showImportEntriesField ?
+					html`<label class="TextArea">
+						<textarea
+							readOnly=${!!cancel}
+							placeholder="Drag and drop the exported JSON file here, or copy and paste its contents."
+							value=${importEntriesText}
+							onChange=${(e) => handleImportedJSONChange(e.target.value)}
+							onDrop=${(e) => handleOnDropImportJSON(e)}
+							class="wi-textarea" />
+					</label>`
+				: null}
+				<button id="button-wi-import" disabled=${!!cancel} onClick=${handleWorldInfoImport}>${showImportEntriesField ? "Import" : "Import entries"}</button>
+				<button id="button-wi-export" disabled=${!!cancel} onClick=${handleWorldInfoExport}>Export entries</button>
+				<br/>
 				<${CollapsibleGroup} label="Prefix/Suffix" stateLabel="Prefix/Suffix-WI">
 					The prefix and suffix will be added at the beginning or end of all your active World Info entries respectively.
 					<br />

--- a/mikupad.html
+++ b/mikupad.html
@@ -2902,7 +2902,7 @@ function WorldInfoModal({ isOpen, closeModal, worldInfo, setWorldInfo, cancel, t
 		</${Modal}>`;
 }
 
-function WorldInfoSelectImportBehaviorModal({ isOpen, closeModal, worldInfo, setWorldInfo, cancel, sillyTarvernWorldInfoJSON }) {
+function WorldInfoSelectImportBehaviorModal({ isOpen, closeModal, setWorldInfo, cancel, sillyTarvernWorldInfoJSON }) {
 	const handleImportReplace = () => {
 		importSillyTavernWorldInfo(sillyTarvernWorldInfoJSON, setWorldInfo, "replace");
 		closeModal();
@@ -6388,7 +6388,6 @@ export function App({ sessionStorage, templateStorage, useSessionState, useDBTem
 		<${WorldInfoSelectImportBehaviorModal}
 			isOpen=${modalState.wiImportMode}
 			closeModal=${() => closeModal("wiImportMode")}
-			worldInfo=${worldInfo}
 			setWorldInfo=${setWorldInfo}
 			sillyTarvernWorldInfoJSON=${sillyTarvernWorldInfoJSON}
 			cancel=${cancel}/>

--- a/mikupad.html
+++ b/mikupad.html
@@ -2643,9 +2643,6 @@ function ContextModal({ isOpen, closeModal, tokens, memoryTokens, authorNoteToke
 }
 
 function WorldInfoModal({ isOpen, closeModal, worldInfo, setWorldInfo, cancel }) {
-	const [showImportEntriesField, setShowImportEntriesField] = useState(false);
-	const [importEntriesText, setImportEntriesText] = useState(null);
-
 	const handleWorldInfoNew = () => {
 		setWorldInfo((prevWorldInfo) => {
 			return {
@@ -2705,42 +2702,45 @@ function WorldInfoModal({ isOpen, closeModal, worldInfo, setWorldInfo, cancel })
 	};
 
 	const handleWorldInfoImport = () => {
-		if (showImportEntriesField) {
-			if (!importEntriesText) {
-				alert("Please enter the contents of the exported JSON file by copying and pasting or dragging and dropping the file into the text area.");
+		const inputElement = document.createElement("input");
+		inputElement.type = "file";
+		inputElement.onchange = () => {
+			const file = inputElement.files[0];
+			if (!file)
 				return;
-			}
 
-			try {
-				const json = JSON.parse(importEntriesText);
-				
-				setWorldInfo(prevWorldInfo => {
-					const updatedEntries = [...prevWorldInfo.entries];
+			const reader = new FileReader();
+			
+			reader.onload = (e) => {
+				try {
+					const contents = e.target.result;
+					const json = JSON.parse(contents);
+					
+					setWorldInfo(prevWorldInfo => {
+						const updatedEntries = [...prevWorldInfo.entries];
 
-					Object.values(json.entries)?.forEach(entry => {
-						updatedEntries.push({
-							"displayName": entry.comment,
-							"text": entry.content,
-							"keys": [...entry.key],
-							"search": entry.scanDepth || ""
+						Object.values(json.entries)?.forEach(entry => {
+							updatedEntries.push({
+								"displayName": entry.comment,
+								"text": entry.content,
+								"keys": [...entry.key],
+								"search": entry.scanDepth || ""
+							});
 						});
+
+						return {
+							...prevWorldInfo,
+							entries: updatedEntries
+						};
 					});
-
-					return {
-						...prevWorldInfo,
-						entries: updatedEntries
-					};
-				});
-
-				setShowImportEntriesField(false);
-				setImportEntriesText("");
-			} catch (e) {
-				alert("The JSON data could not be parsed. Please check that it is valid JSON.");
-				console.error(e);
-			}
-		} else {
-			setShowImportEntriesField(true);
+				} catch (e) {
+					alert("The JSON data could not be parsed. Please check that it is valid JSON.");
+					console.error(e);
+				}
+			};
+			reader.readAsText(file);
 		}
+		inputElement.click();
 	};
 
 	const handleWorldInfoExport = () => {
@@ -2812,32 +2812,15 @@ function WorldInfoModal({ isOpen, closeModal, worldInfo, setWorldInfo, cancel })
 		}
 	};
 
-	const handleCloseModal = () => {
-		setImportEntriesText("");
-		setShowImportEntriesField(false);
-		closeModal();
-	};
-
 	return html`
-		<${Modal} isOpen=${isOpen} onClose=${handleCloseModal}
+		<${Modal} isOpen=${isOpen} onClose=${closeModal}
 			title="World Info"
 			description="Additional information that is added when specific keywords are found in context.
 			World info will be added at the top of your memory, in the order specified here.
 
 			Each entry will begin on a newline. Keys will be interpreted as case-insensitive regular expressions. Search Range specifies how many tokens back into the context will be searched for activation keys. Search range 0 to disable an entry.">
 			<div id="modal-wi-global">
-				${showImportEntriesField ?
-					html`<label class="TextArea">
-						<textarea
-							readOnly=${!!cancel}
-							placeholder="Drag and drop the exported JSON file here, or copy and paste its contents."
-							value=${importEntriesText}
-							onChange=${(e) => handleImportedJSONChange(e.target.value)}
-							onDrop=${(e) => handleOnDropImportJSON(e)}
-							class="wi-textarea" />
-					</label>`
-				: null}
-				<button id="button-wi-import" disabled=${!!cancel} onClick=${handleWorldInfoImport}>${showImportEntriesField ? "Import" : "Import entries"}</button>
+				<button id="button-wi-import" disabled=${!!cancel} onClick=${handleWorldInfoImport}>Import entries</button>
 				<button id="button-wi-export" disabled=${!!cancel} onClick=${handleWorldInfoExport}>Export entries</button>
 				<br/>
 				<${CollapsibleGroup} label="Prefix/Suffix" stateLabel="Prefix/Suffix-WI">

--- a/mikupad.html
+++ b/mikupad.html
@@ -2793,10 +2793,6 @@ function WorldInfoModal({ isOpen, closeModal, worldInfo, setWorldInfo, cancel })
 		anchor.click();
 	};
 
-	const handleImportedJSONChange = (text) => {
-		setImportEntriesText(text);
-	}
-
 	const handleOnDropImportJSON = e => {
 		e.preventDefault();
 		try {

--- a/mikupad.html
+++ b/mikupad.html
@@ -2642,7 +2642,7 @@ function ContextModal({ isOpen, closeModal, tokens, memoryTokens, authorNoteToke
 		</${Modal}>`;
 }
 
-function WorldInfoModal({ isOpen, closeModal, worldInfo, setWorldInfo, cancel }) {
+function WorldInfoModal({ isOpen, closeModal, worldInfo, setWorldInfo, cancel, toggleModal }) {
 	const handleWorldInfoNew = () => {
 		setWorldInfo((prevWorldInfo) => {
 			return {
@@ -2705,6 +2705,12 @@ function WorldInfoModal({ isOpen, closeModal, worldInfo, setWorldInfo, cancel })
 		const inputElement = document.createElement("input");
 		inputElement.type = "file";
 		inputElement.onchange = () => {
+
+			if (Object.values(worldInfo.entries)?.length) {
+				toggleModal("wiImportMode");
+				return;
+			}
+
 			const file = inputElement.files[0];
 			if (!file)
 				return;
@@ -2896,6 +2902,26 @@ function WorldInfoModal({ isOpen, closeModal, worldInfo, setWorldInfo, cancel })
 					</div>`)}
 			</div>
 		</${Modal}>`;
+}
+
+function WorldInfoSelectImportBehaviorModal({ isOpen, closeModal, worldInfo, setWorldInfo, cancel }) {
+	const handleCleanSlateImportSelected = () => {
+
+	};
+
+	const handleAddImportSelected = () => {
+		
+	};
+
+	return html`<${Modal} isOpen=${isOpen} onClose=${closeModal}
+		id="modal-wi-importbehavior"
+		title="Select import behavior"
+		description="There are already world info entries present. Would you like to delete them before importing the new ones? Or would you like to add the imported entries alongside the existing ones?" >
+		<div id="modal-wi-global">
+			<button id="button-wi-importbehavior-clean" disabled=${!!cancel} onClick=${handleCleanSlateImportSelected}>Clean slate import</button>
+			<button id="button-wi-importbehavior-add" disabled=${!!cancel} onClick=${handleAddImportSelected}>Add to existing</button>
+		</div>
+	</${Modal}>`;
 }
 
 function LogitBiasModal({ isOpen, closeModal, logitBias, setLogitBias, logitBiasParam, setLogitBiasParam, sessionStorage, endpoint, endpointAPI, endpointAPIKey, isMikupadEndpoint, cancel }) {
@@ -6352,6 +6378,14 @@ export function App({ sessionStorage, templateStorage, useSessionState, useDBTem
 		<${WorldInfoModal}
 			isOpen=${modalState.wi}
 			closeModal=${() => closeModal("wi")}
+			worldInfo=${worldInfo}
+			setWorldInfo=${setWorldInfo}
+			toggleModal=${toggleModal}
+			cancel=${cancel}/>
+
+		<${WorldInfoSelectImportBehaviorModal}
+			isOpen=${modalState.wiImportMode}
+			closeModal=${() => closeModal("wiImportMode")}
 			worldInfo=${worldInfo}
 			setWorldInfo=${setWorldInfo}
 			cancel=${cancel}/>

--- a/mikupad.html
+++ b/mikupad.html
@@ -1931,6 +1931,35 @@ async function openaiOobaAbortCompletion({ endpoint, proxyEndpoint, ...options }
 	}
 }
 
+function importSillyTavernWorldInfo(json, setWorldInfo, importBehavior) {
+	setWorldInfo(prevWorldInfo => {
+		let updatedEntries;
+
+		if (importBehavior === "replace") {
+			updatedEntries = [];
+		} else if (importBehavior === "append") {
+			updatedEntries = [...prevWorldInfo.entries];
+		} else {
+			throw new Error("Unknown import behavior " + importBehavior);
+			return;
+		}
+
+		Object.values(json.entries)?.forEach(entry => {
+			updatedEntries.push({
+				"displayName": entry.comment,
+				"text": entry.content,
+				"keys": [...entry.key],
+				"search": entry.scanDepth || ""
+			});
+		});
+
+		return {
+			...prevWorldInfo,
+			entries: updatedEntries
+		};
+	});
+}
+
 function InputSlider({ label, value, min = 0, max = 100, step = 1, readOnly, strict, onValueChange, ...props }) {
 	const handleChange = (newValue) => {
 		if (strict) {
@@ -2642,7 +2671,7 @@ function ContextModal({ isOpen, closeModal, tokens, memoryTokens, authorNoteToke
 		</${Modal}>`;
 }
 
-function WorldInfoModal({ isOpen, closeModal, worldInfo, setWorldInfo, cancel, toggleModal }) {
+function WorldInfoModal({ isOpen, closeModal, worldInfo, setWorldInfo, cancel, toggleModal, setSillyTarvernWorldInfoJSON }) {
 	const handleWorldInfoNew = () => {
 		setWorldInfo((prevWorldInfo) => {
 			return {
@@ -2705,12 +2734,6 @@ function WorldInfoModal({ isOpen, closeModal, worldInfo, setWorldInfo, cancel, t
 		const inputElement = document.createElement("input");
 		inputElement.type = "file";
 		inputElement.onchange = () => {
-
-			if (Object.values(worldInfo.entries)?.length) {
-				toggleModal("wiImportMode");
-				return;
-			}
-
 			const file = inputElement.files[0];
 			if (!file)
 				return;
@@ -2721,24 +2744,14 @@ function WorldInfoModal({ isOpen, closeModal, worldInfo, setWorldInfo, cancel, t
 				try {
 					const contents = e.target.result;
 					const json = JSON.parse(contents);
-					
-					setWorldInfo(prevWorldInfo => {
-						const updatedEntries = [...prevWorldInfo.entries];
 
-						Object.values(json.entries)?.forEach(entry => {
-							updatedEntries.push({
-								"displayName": entry.comment,
-								"text": entry.content,
-								"keys": [...entry.key],
-								"search": entry.scanDepth || ""
-							});
-						});
-
-						return {
-							...prevWorldInfo,
-							entries: updatedEntries
-						};
-					});
+					if (Object.values(worldInfo.entries)?.length) {
+						setSillyTarvernWorldInfoJSON(json);
+						toggleModal("wiImportMode");
+						return;
+					} else {
+						importSillyTavernWorldInfo(json, setWorldInfo, "append");
+					}
 				} catch (e) {
 					alert("The JSON data could not be parsed. Please check that it is valid JSON.");
 					console.error(e);
@@ -2904,22 +2917,24 @@ function WorldInfoModal({ isOpen, closeModal, worldInfo, setWorldInfo, cancel, t
 		</${Modal}>`;
 }
 
-function WorldInfoSelectImportBehaviorModal({ isOpen, closeModal, worldInfo, setWorldInfo, cancel }) {
-	const handleCleanSlateImportSelected = () => {
-
+function WorldInfoSelectImportBehaviorModal({ isOpen, closeModal, worldInfo, setWorldInfo, cancel, sillyTarvernWorldInfoJSON }) {
+	const handleImportReplace = () => {
+		importSillyTavernWorldInfo(sillyTarvernWorldInfoJSON, setWorldInfo, "replace");
+		closeModal();
 	};
 
-	const handleAddImportSelected = () => {
-		
+	const handleImportAppend = () => {
+		importSillyTavernWorldInfo(sillyTarvernWorldInfoJSON, setWorldInfo, "append");
+		closeModal();
 	};
 
 	return html`<${Modal} isOpen=${isOpen} onClose=${closeModal}
 		id="modal-wi-importbehavior"
-		title="Select import behavior"
-		description="There are already world info entries present. Would you like to delete them before importing the new ones? Or would you like to add the imported entries alongside the existing ones?" >
+		title="There are already world info entries present"
+		description="Would you like to delete them before importing the new ones? Or would you like to add the imported entries alongside the existing ones?" >
 		<div id="modal-wi-global">
-			<button id="button-wi-importbehavior-clean" disabled=${!!cancel} onClick=${handleCleanSlateImportSelected}>Clean slate import</button>
-			<button id="button-wi-importbehavior-add" disabled=${!!cancel} onClick=${handleAddImportSelected}>Add to existing</button>
+			<button id="button-wi-importbehavior-replace" disabled=${!!cancel} onClick=${handleImportReplace}>Delete and import</button>
+			<button id="button-wi-importbehavior-append" disabled=${!!cancel} onClick=${handleImportAppend}>Append to existing</button>
 		</div>
 	</${Modal}>`;
 }
@@ -4738,6 +4753,7 @@ export function App({ sessionStorage, templateStorage, useSessionState, useDBTem
 	const [authorNoteTokens, setAuthorNoteTokens] = useSessionState('authorNoteTokens', defaultPresets.authorNoteTokens);
 	const [authorNoteDepth, setAuthorNoteDepth] = useSessionState('authorNoteDepth', defaultPresets.authorNoteDepth);
 	const [worldInfo, setWorldInfo] = useSessionState('worldInfo', defaultPresets.worldInfo);
+	const [sillyTarvernWorldInfoJSON, setSillyTarvernWorldInfoJSON] = useState(null);
 
 
 
@@ -6381,6 +6397,7 @@ export function App({ sessionStorage, templateStorage, useSessionState, useDBTem
 			worldInfo=${worldInfo}
 			setWorldInfo=${setWorldInfo}
 			toggleModal=${toggleModal}
+			setSillyTarvernWorldInfoJSON=${setSillyTarvernWorldInfoJSON}
 			cancel=${cancel}/>
 
 		<${WorldInfoSelectImportBehaviorModal}
@@ -6388,6 +6405,7 @@ export function App({ sessionStorage, templateStorage, useSessionState, useDBTem
 			closeModal=${() => closeModal("wiImportMode")}
 			worldInfo=${worldInfo}
 			setWorldInfo=${setWorldInfo}
+			sillyTarvernWorldInfoJSON=${sillyTarvernWorldInfoJSON}
 			cancel=${cancel}/>
 
 		<!-- TODO: The amount of parameters in this modal is a bit excessive... -->

--- a/mikupad.html
+++ b/mikupad.html
@@ -2787,7 +2787,7 @@ function WorldInfoModal({ isOpen, closeModal, worldInfo, setWorldInfo, cancel })
 		const anchor = document.createElement("a");
 
 		const now = new Date();
-		anchor.download = `mikupad-lorebook-${now.getFullYear()}-${(now.getMonth() + 1).padStart(2, "0")}-${now.getDate().padStart(2, "0")}.json`;
+		anchor.download = `MikuPad-WorldInfo-${now.getFullYear()}-${(""+(now.getMonth() + 1)).padStart(2, "0")}-${(""+now.getDate()).padStart(2, "0")}.json`;
 		anchor.href = (window.webkitURL || window.URL).createObjectURL(blob);
 		anchor.dataset.downloadurl = ["application/json", anchor.download, anchor.href].join(":");
 		anchor.click();


### PR DESCRIPTION
Added buttons for exporting and importing the world info entries using the SillyTavern format to the world info modal.

For any parameters that are present in SillyTavern and not on MikuPad, it uses default values in the exported file, and ignores them when importing.

Exporting is done via a direct file download, while importing is done via a file chooser. When importing, if there are already entries in the session, the user is asked whether they want to replace them or import the new ones alongside the existing ones.

Partially addresses what is discussed in #41 