### PR TITLE
Allow importing multiple files at once and only keep active session in sessions object

### DIFF
--- a/mikupad.html
+++ b/mikupad.html
@@ -4537,6 +4537,30 @@ class IndexedDBAdapter {
 		});
 	}
 
+	async loadSessionInfoFromDatabase(db, storeName) {
+		return new Promise((resolve, reject) => {
+			const tx = db.transaction(storeName, 'readonly');
+			const store = tx.objectStore(storeName);
+			const request = store.openCursor();
+
+			let allTables = {};
+
+			request.onsuccess = async (event) => {
+				const cursor = event.target.result;
+				if (cursor) {
+					if (cursor.key !== 'nextSessionId' && cursor.key !== 'selectedSessionId') {
+						allTables[cursor.key] = cursor.value.name;
+					}
+					cursor.continue();
+				} else {
+					resolve(allTables);
+				}
+			};
+			request.onerror = () => reject(request.error);
+		});
+	}
+	
+
 	async saveToDatabase(db, storeName, key, data) {
 		return new Promise((resolve, reject) => {
 			const tx = db.transaction(storeName, 'readwrite');
@@ -4545,6 +4569,27 @@ class IndexedDBAdapter {
 
 			request.onsuccess = () => resolve();
 			request.onerror = () => reject(request.error);
+		});
+	}
+
+	async renameSessionInDatabase(db, storeName, key, newName) {
+		return new Promise((resolve, reject) => {
+			const tx = db.transaction(storeName, 'readwrite');
+			const store = tx.objectStore(storeName);
+			const getRequest = store.get(key);
+
+			getRequest.onsuccess = async () => {
+				const sessionData = getRequest.result;
+				if (sessionData) {
+					sessionData.name = newName;
+					const putRequest = store.put(sessionData, key);
+					putRequest.onsuccess = () => resolve();
+					putRequest.onerror = () => reject(putRequest.error);
+				} else {
+					reject(new Error(`Session with key '${key}' not found`));
+				}
+			};
+			getRequest.onerror = () => reject(request.error);
 		});
 	}
 

--- a/mikupad.html
+++ b/mikupad.html
@@ -2352,21 +2352,33 @@ function Sessions({ sessionStorage, disabled }) {
 	const importSession = () => {
 		const fileInput = document.createElement("input");
 		fileInput.type = 'file';
+		fileInput.multiple = true;
 		fileInput.style.display = 'none';
-		fileInput.onchange = (e) => {
-			const file = e.target.files[0];
-			if (!file)
+		fileInput.onchange = async (e) => {
+			const files = e.target.files;
+			if (files.length === 0)
 				return;
-			const reader = new FileReader();
-			reader.onload = (e) => {
-				const contents = e.target.result;
-				fileInput.func(contents);
+
+				const sortedFiles = Array.from(files).sort((a, b) => a.lastModified - b.lastModified);
+
+				const reader = new FileReader();
+				let lastNewId = null;
+
+				for (const file of sortedFiles) {
+					await new Promise((resolve, reject) => {
+						reader.onload = async (e) => {
+							lastNewId = await sessionStorage.createSessionFromObject(JSON.parse(e.target.result), false);
+							resolve();
+						};
+						reader.onerror = (e) => {
+							reject(e);
+						};
+						reader.readAsText(file);
+					});
 			}
-			reader.readAsText(file);
-		};
-		fileInput.func = async (text) => {
-			const newId = await sessionStorage.createSessionFromObject(JSON.parse(text), false);
-			await sessionStorage.switchSession(newId);
+			if (lastNewId !== null) {
+				await sessionStorage.switchSession(lastNewId);
+			}
 		};
 		document.body.appendChild(fileInput);
 		fileInput.click();
@@ -4612,9 +4624,33 @@ class ServerDBAdapter {
 		});
 	}
 
+	async loadSessionInfoFromDatabase(db, storeName) {
+		return new Promise(async (resolve, reject) => {
+			const res = await db("/sessions", { storeName });
+			if (!res.ok) {
+				reject(res.status);
+				return;
+			}
+			const { result } = await res.json();
+			resolve(result);
+		});
+	}
+
 	async saveToDatabase(db, storeName, key, data) {
 		return new Promise(async (resolve, reject) => {
 			const res = await db("/save", { storeName, key, data });
+			if (!res.ok) {
+				reject(res.status);
+				return;
+			}
+			const { result } = await res.json();
+			resolve(result);
+		});
+	}
+
+	async renameSessionInDatabase(db, storeName, key, newName) {
+		return new Promise(async (resolve, reject) => {
+			const res = await db("/rename", { storeName, key, newName });
 			if (!res.ok) {
 				reject(res.status);
 				return;
@@ -4700,9 +4736,27 @@ class AbstractStorage extends EventTarget {
 		}
 	}
 
+	async loadSessionInfoFromDatabase(db) {
+		try {
+			return await this.dbAdapter.loadSessionInfoFromDatabase(db, this.storeName);
+		} catch (e) {
+			this.dispatchErrorEvent(e);
+			throw e;
+		}
+	}
+
 	async saveToDatabase(db, key, data) {
 		try {
 			return await this.dbAdapter.saveToDatabase(db, this.storeName, key, data);
+		} catch (e) {
+			this.dispatchErrorEvent(e);
+			throw e;
+		}
+	}
+
+	async renameSessionInDatabase(db, key, newName) {
+		try {
+			return await this.dbAdapter.renameSessionInDatabase(db, this.storeName, key, newName);
 		} catch (e) {
 			this.dispatchErrorEvent(e);
 			throw e;
@@ -4835,11 +4889,9 @@ class SessionStorage extends AbstractStorage {
 	}
 
 	async loadSessions(db) {
-		const sessions = await this.loadAllFromDatabase(db);
-		for (const [key, value] of Object.entries(sessions)) {
-			if (key !== 'nextSessionId' && key !== 'selectedSessionId') {
-				this.sessions[key] = value;
-			}
+		const sessions = await this.loadSessionInfoFromDatabase(db);
+		for (const [key, name] of Object.entries(sessions)) {
+			this.sessions[key] = { name: name };
 		}
 		if (Object.keys(this.sessions).length === 0) {
 			if (!await this.migrateSessions()) {
@@ -4863,11 +4915,16 @@ class SessionStorage extends AbstractStorage {
 	async switchSession(sessionId) {
 		if (!this.sessions[sessionId])
 			return;
-		
+
+		//Clear data of old session in order to minimize memory usage.
+		if (this.sessions[this.selectedSession] && this.sessions[this.selectedSession]['name'])
+			this.sessions[this.selectedSession] = { name: this.sessions[this.selectedSession]['name'] };
+
 		const db = await this.openDatabase();
 		await this.saveToDatabase(db, 'selectedSessionId', +sessionId);
 
 		this.selectedSession = +sessionId;
+		this.sessions[this.selectedSession] = (await this.loadFromDatabase(db, this.selectedSession));
 
 		this.dispatchChangeEvent();
 		this.dispatchSessionChangeEvent();
@@ -4877,7 +4934,7 @@ class SessionStorage extends AbstractStorage {
 		this.sessions[sessionId]['name'] = renameSessionName;
 
 		const db = await this.openDatabase();
-		await this.saveToDatabase(db, sessionId, this.sessions[sessionId]);
+		await this.renameSessionInDatabase(db, sessionId, renameSessionName);
 
 		this.dispatchChangeEvent();
 	}
@@ -4933,6 +4990,10 @@ class SessionStorage extends AbstractStorage {
 
 		const db = await this.openDatabase();
 		await this.saveToDatabase(db, newId, this.sessions[newId]);
+
+		//Clear data of the session in order to minimize memory usage.
+		if (this.sessions[newId] && this.sessions[newId]['name'])
+			this.sessions[this.selectedSession] = { name: this.sessions[this.selectedSession]['name'] };
 
 		onchange?.();
 		return newId;

--- a/mikupad.html
+++ b/mikupad.html
@@ -4993,7 +4993,7 @@ class SessionStorage extends AbstractStorage {
 
 		//Clear data of the session in order to minimize memory usage.
 		if (this.sessions[newId] && this.sessions[newId]['name'])
-			this.sessions[this.selectedSession] = { name: this.sessions[this.selectedSession]['name'] };
+			this.sessions[newId] = { name: this.sessions[newId]['name'] };
 
 		onchange?.();
 		return newId;

--- a/server/server.js
+++ b/server/server.js
@@ -199,6 +199,27 @@ app.post('/save', (req, res) => {
     });
 });
 
+// POST route to update session name
+app.post('/rename', (req, res) => {
+    const { storeName, key, newName } = req.body;
+    const normStoreName = normalizeStoreName(storeName);
+    db.run(
+        `
+        UPDATE ${normStoreName}
+        SET data = json_set(data, '$.name', ?)
+        WHERE key = ?
+        `,
+        [newName, key],
+        (err) => {
+            if (err) {
+                res.status(500).json({ ok: false, message: 'Error updating the database' });
+            } else {
+                res.json({ ok: true, result: 'Session renamed successfully' });
+            }
+        }
+    );
+});
+
 // POST route to get all rows from a table
 app.post('/all', (req, res) => {
     const { storeName } = req.body;
@@ -214,6 +235,31 @@ app.post('/all', (req, res) => {
             res.json({ ok: true, result: all });
         }
     });
+});
+
+// POST route to get session info
+app.post('/sessions', (req, res) => {
+    const { storeName } = req.body;
+    const normStoreName = normalizeStoreName(storeName);
+    db.all(
+        `
+        SELECT key, json_extract(data, '$.name') AS name
+        FROM ${normStoreName}
+        WHERE key NOT IN ('selectedSessionId', 'nextSessionId')
+        `,
+        [],
+        (err, rows) => {
+            if (err) {
+                res.status(500).json({ ok: false, message: 'Error querying the database' });
+            } else {
+                const sessions = {};
+                rows.forEach((row) => {
+                    sessions[row.key] = row.name;
+                });
+                res.json({ ok: true, result: sessions });
+            }
+        }
+    );
 });
 
 // POST route to delete a session


### PR DESCRIPTION
This drastically cuts down on memory usage which matters on mobile devices, and also calling /all with a mikupad server running with a lot of sessions previously would cause node.js to balloon in memory usage, and even if given the RAM the  ```res.json({ ok: true, result: all });``` would cause RangeError: Invalid string length.

This is a draft PR as it does not function with the IndexedDBAdapter, I would appreciate it if you could handle that, or at least verify that you are fine with this approach, and I'll then work on that, but I'm not very familiar with IndexedDB and couldn't see a way to efficiently handle the new operations.