### PR TITLE
remove automatic json parsing and update error check

### DIFF
--- a/mikupad.html
+++ b/mikupad.html
@@ -5835,7 +5835,7 @@ export function App({ sessionStorage, templateStorage, useSessionState, useDBTem
 							dry_base: dryBase,
 							dry_allowed_length: dryAllowedLength,
 							dry_penalty_last_n: dryPenaltyRange,
-							dry_sequence_breakers: JSON.parse(drySequenceBreakers),
+							dry_sequence_breakers: drySequenceBreakers,
 						}: {}),
 						...(enabledSamplers.includes('ban_tokens') ? {
 							banned_tokens: JSON.parse(bannedTokens),
@@ -6005,7 +6005,15 @@ export function App({ sessionStorage, templateStorage, useSessionState, useDBTem
 			JSON.parse(drySequenceBreakers);
 			setDrySequenceBreakersError(undefined);
 		} catch (e) {
-			setDrySequenceBreakersError(e.toString());
+			try {
+				const unescapedString = drySequenceBreakers
+					.replace(/\\\\/g, '\\')
+					.replace(/\\"/g, '"');
+				JSON.parse(unescapedString);
+				setDrySequenceBreakersError(undefined);
+			} catch (e2) {
+				setDrySequenceBreakersError(e2.toString());
+			}
 		}
 	}, [drySequenceBreakers]);
 

--- a/mikupad.html
+++ b/mikupad.html
@@ -5835,7 +5835,9 @@ export function App({ sessionStorage, templateStorage, useSessionState, useDBTem
 							dry_base: dryBase,
 							dry_allowed_length: dryAllowedLength,
 							dry_penalty_last_n: dryPenaltyRange,
-							dry_sequence_breakers: drySequenceBreakers,
+							dry_sequence_breakers: endpointAPI == API_OPENAI_COMPAT ? 
+								drySequenceBreakers : 
+								JSON.parse(drySequenceBreakers),
 						}: {}),
 						...(enabledSamplers.includes('ban_tokens') ? {
 							banned_tokens: JSON.parse(bannedTokens),
@@ -6005,15 +6007,7 @@ export function App({ sessionStorage, templateStorage, useSessionState, useDBTem
 			JSON.parse(drySequenceBreakers);
 			setDrySequenceBreakersError(undefined);
 		} catch (e) {
-			try {
-				const unescapedString = drySequenceBreakers
-					.replace(/\\\\/g, '\\')
-					.replace(/\\"/g, '"');
-				JSON.parse(unescapedString);
-				setDrySequenceBreakersError(undefined);
-			} catch (e2) {
-				setDrySequenceBreakersError(e2.toString());
-			}
+			setDrySequenceBreakersError(e.toString());
 		}
 	}, [drySequenceBreakers]);
 


### PR DESCRIPTION
When using ooba text generation web ui as a backend, I was running into 422 errors when I tried to have my sequence breakers set to the following value: ["\n", ":", "\"", "*"]

When I updated the text value for dry sequence breakers to the default value from the presets, [\"\\n\", \":\", \"\\\"\", \"*\"], I encountered an error saying that it was not a valid json.

I updated the code so where it will not automatically json.parse the drySequenceBreakers value, so my original value can be sent. In the api logs for the ooba server, it shows that the value is received as: 'dry_sequence_breakers': '["\\n", ":", "\\"", "*"]'

This change works for my use case, but it seems like it might disrupt the existing functionality. To ensure compatibility, I also updated the error checking logic to remove escape characters prior to parsing, so that the default value passes validation.

Before:
![image](https://github.com/user-attachments/assets/0d3b3107-1f00-4e11-9ef1-3821b38391bc)
![image](https://github.com/user-attachments/assets/5780b5e3-5370-40a7-ac9d-e1cffe15a67f)

After:
![image](https://github.com/user-attachments/assets/18653385-a540-4530-b744-75587ebfcb22)
![image](https://github.com/user-attachments/assets/4a4ac9b1-d1f0-4d0a-a943-3c6a13204215)
