### PR TITLE
Add whitelist to `normalizeStoreName` to avoid injection

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -206,7 +206,11 @@ app.delete('/proxy/*', async (req, res) => {
 const normalizeStoreName = (storeName) => {
     if (!storeName)
         return "Sessions";
-    return storeName.split(' ')[0].toLowerCase();
+    const normalizedStoreName = storeName.split(' ')[0].toLowerCase();
+    if (["sessions", "templates"].includes(normalizedStoreName)) {
+        return normalizedStoreName;
+    }
+    return "Sessions";
 };
 
 // POST route to load data


### PR DESCRIPTION
This PR introduces a whitelist check to mitigate SQL injection risks when handling user input. Previously, user-controlled input was being used directly in dynamic SQL queries, which could allow an attacker to manipulate database queries. E.g. https://github.com/lmg-anon/mikupad/blob/HEAD/server/server.js#L285