### PR TITLE
Add Docker support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+MIKUPAD_LOGIN="anon"
+MIKUPAD_PASSWORD="SET_YOUR_PASSWORD_HERE"
+MIKUPAD_STORAGE_PATH="/storage/web-session-storage.db"

--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# Docker Compose
+docker-compose.override.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:20.19.3
+
+COPY project /app/project
+COPY server /app/server
+COPY mikupad.html /app/mikupad.html
+COPY compile.sh /app/compile.sh
+
+# Compile HTML
+WORKDIR /app
+RUN /bin/bash compile.sh
+
+# Server expects mikupad.html
+RUN mv /app/mikupad_compiled.html /app/mikupad.html
+
+# Compile server
+WORKDIR /app/server
+RUN npm install --no-audit
+ENTRYPOINT [ "node", "server.js" ]

--- a/README.md
+++ b/README.md
@@ -36,6 +36,26 @@ To use **mikupad** fully offline, run the provided `compile` script or download 
 
 You can also [try it on GitHub Pages](https://lmg-anon.github.io/mikupad/mikupad.html).
 
+## Running with Docker
+
+You can also run **mikupad** using Docker. This automatically compiles the HTML and runs the custom NodeJS server, which serves the HTML, among other functions.
+
+First, copy `.env.example` to `.env`. Then, **change your username and password**; anyone who has access to your hosted **mikupad** can store and load sessions, and proxy network requests through your server!
+
+To run the server:
+
+```shell
+docker compose up --build -d
+```
+
+Then visit http://localhost:3000/.
+
+Note that by default, the server will automatically start when Docker starts (which likely also starts on login). To stop the server, and at the same time also stop it from automatically starting up:
+
+```shell
+docker compose down
+```
+
 ## Contributing
 
 Contributions from the open-source community are welcome. Whether it's fixing a bug, adding a feature, or improving the documentation, your contributions are greatly appreciated. To contribute to **mikupad**, follow these steps:

--- a/README.md
+++ b/README.md
@@ -56,6 +56,27 @@ Note that by default, the server will automatically start when Docker starts (wh
 docker compose down
 ```
 
+### Adding HTTPS support
+
+You can also add HTTPS support, for example, if you wish to use **mikupad** remotely without revealing your generations or password to the entire world.
+
+First, copy and rename `docker-compose.override.example.yml` to `docker-compose.override.yml`. Then, uncomment `services:`, as well as the `ADD HTTPS SUPPORT` section. You may also wish to remove unencrypted HTTP support by uncommenting the `REMOVE HTTP SUPPORT` section.
+
+You will also need to provide a SSL certificate. You can do this in any way you wish, such as obtaining one from a [certificate authority](https://letsencrypt.org/) or creating a self-signed one yourself. Regardless, place the public certificate and the private key files in the `https` folder like so:
+
+```shell
+mikupad/https$ ls
+nginx.conf  private.key  public.crt
+```
+
+If you have already started the server, run this command to start up the HTTPS server as well:
+
+```shell
+docker compose up -d
+```
+
+Then visit https://localhost:3443/.
+
 ## Contributing
 
 Contributions from the open-source community are welcome. Whether it's fixing a bug, adding a feature, or improving the documentation, your contributions are greatly appreciated. To contribute to **mikupad**, follow these steps:

--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ docker compose up -d
 
 Then visit https://localhost:3443/.
 
+### Using AI servers running on localhost when running mikupad in Docker
+
+By default, **mikupad** running in server mode will proxy requests to any endpoints. For example, if you are running Ollama (which is OpenAI compatible), you can set the endpoint to `http://localhost:11434` and it'll work.
+
+However, in Docker, you need to replace `localhost` with `host.docker.internal`. For example, the correct endpoint to use for Ollama is `http://host.docker.internal:11434`.
+
+If you are on Linux, you'd need to copy and rename `docker-compose.override.example.yml` to `docker-compose.override.yml`. Then, uncomment `services:`, as well as the `ADD LOCALHOST AI SERVER SUPPORT FOR LINUX USERS` section.
+
 ## Contributing
 
 Contributions from the open-source community are welcome. Whether it's fixing a bug, adding a feature, or improving the documentation, your contributions are greatly appreciated. To contribute to **mikupad**, follow these steps:

--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -22,3 +22,10 @@
 
 #   mikupad:
 #     ports: !reset []
+
+# ADD LOCALHOST AI SERVER SUPPORT FOR LINUX USERS:
+# (DELETE `mikupad:` IF ALREADY DEFINED ABOVE)
+  
+#   mikupad:
+#     extra_hosts:
+#       - host.docker.internal:host-gateway

--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -1,0 +1,24 @@
+# HOW TO USE THIS FILE
+#
+# 1. Copy into `docker-compose.override.yml`
+# 2. Uncomment the parts you wish to include
+#
+# UNCOMMENT THIS FIRST:
+
+# services:
+  
+# ADD HTTPS SUPPORT:
+  
+#   https:
+#     image: nginx:1.29
+#     ports:
+#       - 3443:3443
+#     volumes:
+#       - ./https/nginx.conf:/etc/nginx/conf.d/default.conf
+#       - ./https/public.crt:/public.crt
+#       - ./https/private.key:/private.key
+
+# REMOVE HTTP SUPPORT:
+
+#   mikupad:
+#     ports: !reset []

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  mikupad:
+    build: .
+    ports:
+      - 3000:3000
+    env_file:
+      - .env
+    restart: unless-stopped
+    volumes:
+      - storage:/storage
+
+volumes:
+  storage:

--- a/https/.gitignore
+++ b/https/.gitignore
@@ -1,0 +1,2 @@
+private.key
+public.crt

--- a/https/nginx.conf
+++ b/https/nginx.conf
@@ -1,0 +1,11 @@
+server {
+    listen 3443 ssl;
+
+    ssl_certificate /public.crt;
+    ssl_certificate_key /private.key;
+
+    location / {
+        proxy_pass http://mikupad:3000;
+        proxy_buffering off; # Required to keep token streaming smooth
+    }
+}

--- a/server/server.js
+++ b/server/server.js
@@ -17,6 +17,7 @@ const host = args.host || process.env.MIKUPAD_HOST || '0.0.0.0';
 const noOpen = (args.open !== undefined && !args.open) || process.env.MIKUPAD_NO_OPEN;
 const login = args.login || process.env.MIKUPAD_LOGIN || 'anon';
 const password = args.password || process.env.MIKUPAD_PASSWORD || undefined;
+const storagePath = args.storagePath || process.env.MIKUPAD_STORAGE_PATH || './web-session-storage.db';
 
 // Headers that shouldn't be forwarded in the proxy endpoint.
 const headersToRemove = [
@@ -54,7 +55,7 @@ app.use((req, res, next) => {
 });
 
 // Open a database connection
-const db = new sqlite3.Database('./web-session-storage.db', (err) => {
+const db = new sqlite3.Database(storagePath, (err) => {
     if (err) {
         console.error(err.message);
         throw err;


### PR DESCRIPTION
Yeah, I know, **mikupad**'s whole selling point is that it's a simple HTML file. But I'm using `server.js` instead, since I wanted to host my own **mikupad**, along with authentication, syncing, and proxying (so I can access my local Ollama without exposing it to the whole world). This makes it simpler, and easier to auto-start on login, by using Docker.

This PR also adds HTTPS support and instructions for using localhost AI in Docker, with a hint that Ollama is OpenAI-compatible. Documentation is added into README.md.

Commits below. For more information about each commit, please see their descriptions.

- **Dockerize server**
- **Add HTTPS support to Docker**
- **Add localhost AI support in Docker**
