### PR TITLE
Implement accepting partial prompt suggestions.

### DIFF
--- a/mikupad.html
+++ b/mikupad.html
@@ -6905,17 +6905,39 @@ export function App({ sessionStorage, templateStorage, useSessionState, useDBTem
 					setPromptPreviewChunks([]);
 					break;
 				case 'false:true:false:ArrowRight':
-					// Accept prompt preview token-by-token
+					// Accept prompt preview word-by-word
 					// by pressing Ctrl+ArrowRight.
+
 					if (!showPromptPreview || promptPreviewChunks.length === 0)
 						break;
+
+					let newPromptChunks = [ ...promptChunks ];
+					let newPromptPreviewChunks = [ ...promptPreviewChunks ];
+					let newTokens = tokens;
+
+					do {
+						newPromptChunks = newPromptChunks.concat(newPromptPreviewChunks.splice(0, 1));
+					} while (
+						// We still have suggested chunks to go through
+						newPromptPreviewChunks.length > 0 &&
+						// The next suggested chunk does not start with a space
+						newPromptPreviewChunks[0].content[0] != " " &&
+						(
+							// The prompt is empty
+							newPromptChunks.length == 0 ||
+							// Or...
+							(
+								// The prompt is not empty
+								newPromptChunks.length > 0 &&
+								// And the new prompt does not begin with a space 
+								newPromptChunks[newPromptChunks.length - 1].content[newPromptChunks[newPromptChunks.length - 1].content.length - 1] != " "
+							)
+						)
+					)
 					
-					setPromptChunks(p => [
-						...p,
-						promptPreviewChunks[0]
-					]);
-					setTokens(t => t + 1);
-					setPromptPreviewChunks(promptPreviewChunks.slice(1));
+					setPromptChunks(newPromptChunks);
+					setPromptPreviewChunks(newPromptPreviewChunks);
+					setTokens(newTokens);
 					break;
 				case 'false:true:false:r':
 				case 'false:false:true:r':


### PR DESCRIPTION
This implements #114.

In order to preserve the prompt suggestion as the user accepts word by word using Ctrl+ArrowRight, the default behavior had to be changed, where the prompt preview was discarded automatically on any keypress.

Instead, the prompt preview chunks array must now be explicitly set to empty whenever it should be cleared or generated again.

Added a guard on the prompt preview effect to prevent clobbering an existing one, and added explicit clearing of the prompt preview to the predict, undo, redo code paths, as well as when any key is pressed that is not a printable, diacritic, or backspace. This should cover every path and never leave a stray prompt preview where there shouldn't be one.