### PR TITLE
Add missing 'marked' dependency to project/package.json

### DIFF
--- a/project/package.json
+++ b/project/package.json
@@ -9,7 +9,8 @@
     "scrollview-resize" : "^1.0.2",
     "htm": "^3.1.1",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "marked": "^16.4.1"
   },
   "devDependencies": {
     "@parcel/transformer-inline-string": "^2.9.3",
@@ -17,6 +18,7 @@
     "htm": "^3.1.1",
     "parcel": "^2.9.3",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "marked": "^16.4.1"
   }
 }


### PR DESCRIPTION
The `marked` package was added to mikupad.html's import map in commit `8fe8b9f`, but was not added to project/package.json, causing the build to fail.