### PR TITLE
Don't prevent default Ctrl+ArrowRight action without Prediction Preview

### DIFF
--- a/mikupad.html
+++ b/mikupad.html
@@ -7851,6 +7851,7 @@ export function App({ sessionStorage, templateStorage, themeStorage, useSessionS
 				return;
 			if (Object.values(modalState).some((s) => s))
 				return;
+			let preventDefaultAction = true;
 			switch (`${altKey}:${ctrlKey}:${shiftKey}:${key}`) {
 				case 'false:false:true:Enter':
 				case 'false:true:false:Enter':
@@ -7880,7 +7881,11 @@ export function App({ sessionStorage, templateStorage, themeStorage, useSessionS
 					// by pressing Ctrl+ArrowRight.
 
 					if (!showPromptPreview || promptPreviewChunks.length === 0)
+					{
+						// Fall back to default Ctrl+RightArrow behavior (move right by 1 word)
+						preventDefaultAction = false;
 						break;
+					}
 
 					let newPromptChunks = [ ...promptChunks ];
 					let newPromptPreviewChunks = [ ...promptPreviewChunks ];
@@ -7934,7 +7939,9 @@ export function App({ sessionStorage, templateStorage, themeStorage, useSessionS
 					keyState.current = e;
 					return;
 			}
-			e.preventDefault();
+
+			if (preventDefaultAction)
+				e.preventDefault();
 		}
 		function onKeyUp(e) {
 			const { altKey, ctrlKey, shiftKey, key, defaultPrevented } = e;


### PR DESCRIPTION
I use Ctrl+Left/Right (move by 1 word) a lot when editing text but mikupad currently blocks the default action for Ctrl+Right so you can only move backwards but not forwards.

This is a small tweak so that the default action of Ctrl+Right is only prevented if there is no prediction preview.

Initially I just replaced the break with a return, but I thought that obfuscated the control flow a bit too much, so I added a flag instead.