### PR TITLE
Optimize onInput performance for long prompts

### DIFF
--- a/mikupad.html
+++ b/mikupad.html
@@ -8120,7 +8120,7 @@ export function App({ sessionStorage, templateStorage, themeStorage, useSessionS
 				setUndoHovered(false);
 
 			// Adjust undo/redo stacks.
-			const chunkDifference = oldPrompt.Length - newPrompt.length;
+			const chunkDifference = oldPrompt.length - newPrompt.length;
 			undoStack.current = undoStack.current.map(pos => {
 				if (pos >= start.length) {
 					return pos - chunkDifference;


### PR DESCRIPTION
When the document becomes very large, I noticed that at some point text inputs at the end of the document become painfully slow, with like 500ms delay per keypress. The profiler showed that most of the time is spent in `onInput` at `oldPrompt.shift()`. This looks like an O(n^2) operation. For me, it started to be a problem at around 32k elements.

This PR changes the logic a bit so that oldPrompt is not mutated, which fixes this issue. No functional changes beyond that.

Maybe there's further room for improvement especially with that `end.unshift(chunk)` which also looks a little suspicious, but I didn't really notice performance issues after that even with much larger documents (and don't understand the code well enough to make that change).